### PR TITLE
Adjust to new syntax due to goreleaser deprecations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,80 +16,81 @@ release:
     owner: humio
     name: cli
 
+brews:
+  -
+    github:
+      owner: humio
+      name: homebrew-humio
+    folder: Formula
+    homepage:  https://humio.com/
+    description: Manage and Stream Logs to Humio
+    test: |
+      system "echo DONE"
 
-brew:
-  github:
-    owner: humio
-    name: homebrew-humio
-  folder: Formula
-  homepage:  https://humio.com/
-  description: Manage and Stream Logs to Humio
-  test: |
-    system "echo DONE"
+archives:
+  -
+    format: tar.gz
+    replacements:
+      amd64: 64-bit
+      darwin: macOS
+      linux: Linux
+    format_overrides:
+      - goos: windows
+        format: zip
 
+snapcrafts:
+  -
+    # The name of the snap. This is optional.
+    # Default is project name.
+    name: humioctl
 
-archive:
-  format: tar.gz
-  replacements:
-    amd64: 64-bit
-    darwin: macOS
-    linux: Linux
-  format_overrides:
-    - goos: windows
-      format: zip
+    # Wether to publish the snap to the snapcraft store.
+    # Remember you need to `snapcraft login` first.
+    # Defaults to false.
+    publish: true
 
-snapcraft:
-  # The name of the snap. This is optional.
-  # Default is project name.
-  name: humioctl
+    # Single-line elevator pitch for your amazing snap.
+    # 79 char long at most.
+    summary: CLI for managing and streaming data to Humio.
 
-  # Wether to publish the snap to the snapcraft store.
-  # Remember you need to `snapcraft login` first.
-  # Defaults to false.
-  publish: true
+    # This the description of your snap. You have a paragraph or two to tell the
+    # most important story about your snap. Keep it under 100 words though,
+    # we live in tweetspace and your description wants to look good in the snap
+    # store.
+    description: |
+      The Humio CLI is an easy way to manage your Humio cluster. You can also
+      use it to tail files and stream them to Humio, but this is no replacement
+      for a full-featured data shipper like filebeat.
 
-  # Single-line elevator pitch for your amazing snap.
-  # 79 char long at most.
-  summary: CLI for managing and streaming data to Humio.
+    # A guardrail to prevent you from releasing a snap to all your users before
+    # it is ready.
+    # `devel` will let you release only to the `edge` and `beta` channels in the
+    # store. `stable` will let you release also to the `candidate` and `stable`
+    # channels. More info about channels here:
+    # https://snapcraft.io/docs/reference/channels
+    grade: stable
 
-  # This the description of your snap. You have a paragraph or two to tell the
-  # most important story about your snap. Keep it under 100 words though,
-  # we live in tweetspace and your description wants to look good in the snap
-  # store.
-  description: |
-    The Humio CLI is an easy way to manage your Humio cluster. You can also
-    use it to tail files and stream them to Humio, but this is no replacement
-    for a full-featured data shipper like filebeat.
+    # Snaps can be setup to follow three different confinement policies:
+    # `strict`, `devmode` and `classic`. A strict confinement where the snap
+    # can only read and write in its own namespace is recommended. Extra
+    # permissions for strict snaps can be declared as `plugs` for the app, which
+    # are explained later. More info about confinement here:
+    # https://snapcraft.io/docs/reference/confinement
+    confinement: strict
 
-  # A guardrail to prevent you from releasing a snap to all your users before
-  # it is ready.
-  # `devel` will let you release only to the `edge` and `beta` channels in the
-  # store. `stable` will let you release also to the `candidate` and `stable`
-  # channels. More info about channels here:
-  # https://snapcraft.io/docs/reference/channels
-  grade: stable
+    # Each binary built by GoReleaser is an app inside the snap. In this section
+    # you can declare extra details for those binaries. It is optional.
+    apps:
 
-  # Snaps can be setup to follow three different confinement policies:
-  # `strict`, `devmode` and `classic`. A strict confinement where the snap
-  # can only read and write in its own namespace is recommended. Extra
-  # permissions for strict snaps can be declared as `plugs` for the app, which
-  # are explained later. More info about confinement here:
-  # https://snapcraft.io/docs/reference/confinement
-  confinement: strict
+      # The name of the app must be the same name as the binary built or the snapcraft name.
+      humioctl:
 
-  # Each binary built by GoReleaser is an app inside the snap. In this section
-  # you can declare extra details for those binaries. It is optional.
-  apps:
-
-    # The name of the app must be the same name as the binary built or the snapcraft name.
-    humioctl:
-
-      # If your app requires extra permissions to work outside of its default
-      # confined space, declare them here.
-      # You can read the documentation about the available plugs and the
-      # things they allow:
-      # https://snapcraft.io/docs/reference/interfaces.
-      plugs: ["home", "network"]
+        # If your app requires extra permissions to work outside of its default
+        # confined space, declare them here.
+        # You can read the documentation about the available plugs and the
+        # things they allow:
+        # https://snapcraft.io/docs/reference/interfaces.
+        plugs: ["home", "network"]
 
 dockers:
   - image_templates:


### PR DESCRIPTION
Just spotted that running `goreleaser check` gives me:
```
• loading config file       file=.goreleaser.yaml
   • DEPRECATED: `archive` should not be used anymore, check https://goreleaser.com/deprecations#archive for more info.
   • DEPRECATED: `snapcraft` should not be used anymore, check https://goreleaser.com/deprecations#snapcraft for more info.
   • DEPRECATED: `brew` should not be used anymore, check https://goreleaser.com/deprecations#brew for more info.
• optimistically guessing `brew[0].installs`, double check
• config is valid
```

Given the changes in this PR, it only returns:
```
• loading config file       file=.goreleaser.yaml
• optimistically guessing `brew[0].installs`, double check
• config is valid
```