### PR TITLE
Add support for alerts, notifiers and add additional ingest-token support.

### DIFF
--- a/api/alerts.go
+++ b/api/alerts.go
@@ -1,0 +1,207 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+type HumioQuery struct {
+	QueryString string `yaml:"queryString" json:"queryString"`
+	Start       string `yaml:"start"       json:"start"`
+	End         string `yaml:"end"         json:"end"`
+	IsLive      bool   `yaml:"isLive"      json:"isLive"`
+}
+
+type Alert struct {
+	ID                 string     `yaml:"-"                     json:"id"`
+	Name               string     `yaml:"name"                  json:"name"`
+	Query              HumioQuery `yaml:"query"                 json:"query"`
+	Description        string     `yaml:"description,omitempty" json:"description"`
+	ThrottleTimeMillis int        `yaml:"throttleTimeMillis"    json:"throttleTimeMillis"`
+	Silenced           bool       `yaml:"silenced"              json:"silenced"`
+	Notifiers          []string   `yaml:"notifiers"             json:"notifiers"`
+	LinkURL            string     `yaml:"linkURL"               json:"linkURL"`
+	Labels             []string   `yaml:"labels,omitempty"      json:"labels,omitempty"`
+}
+
+type Alerts struct {
+	client *Client
+}
+
+func (c *Client) Alerts() *Alerts { return &Alerts{client: c} }
+
+func (a *Alerts) List(view string) ([]Alert, error) {
+	url := fmt.Sprintf("api/v1/repositories/%s/alerts", view)
+
+	res, err := a.client.HttpGET(url)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	body, readErr := ioutil.ReadAll(res.Body)
+	if readErr != nil {
+		log.Fatal(readErr)
+	}
+
+	alerts := []Alert{}
+	jsonErr := json.Unmarshal(body, &alerts)
+	if jsonErr != nil {
+		log.Fatal(jsonErr)
+	}
+
+	return alerts, nil
+}
+
+func (a *Alerts) Update(viewName string, alert *Alert) (*Alert, error) {
+	existingID, err := a.convertAlertNameToID(viewName, alert.Name)
+	if err != nil {
+		return nil, fmt.Errorf("could not convert alert name to id: %v", err)
+	}
+
+	url := fmt.Sprintf("api/v1/repositories/%s/alerts/%s", viewName, existingID)
+
+	jsonStr, err := json.Marshal(alert)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert alert to json string: %v", err)
+	}
+	// Humio requires notifiers to be specified even if no notifier is desired
+	if alert.Notifiers == nil {
+		alert.Notifiers = []string{}
+	}
+	res, postErr := a.client.HttpPUT(url, bytes.NewBuffer(jsonStr))
+	if postErr != nil {
+		return nil, fmt.Errorf("could not add alert in view %s with name %s, got: %v", viewName, alert.Name, postErr)
+	}
+
+	body, readErr := ioutil.ReadAll(res.Body)
+	if readErr != nil {
+		log.Fatal(readErr)
+	}
+
+	resAlert := Alert{}
+	jsonErr := json.Unmarshal(body, &resAlert)
+	if jsonErr != nil {
+		log.Fatal(jsonErr)
+	}
+	return &resAlert, nil
+}
+
+func (a *Alerts) Add(viewName string, alert *Alert, updateExisting bool) (*Alert, error) {
+	nameAlreadyInUse, err := a.alertNameInUse(viewName, alert.Name)
+	if err != nil {
+		return nil, fmt.Errorf("could not determine if alert name is in use: %v", err)
+	}
+	if nameAlreadyInUse {
+		if updateExisting == false {
+			return nil, fmt.Errorf("alert with name %s already exists", alert.Name)
+		}
+		return a.Update(viewName, alert)
+	}
+
+	url := fmt.Sprintf("api/v1/repositories/%s/alerts/", viewName)
+	jsonStr, err := json.Marshal(alert)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert alert to json string: %v", err)
+	}
+	// Humio requires notifiers to be specified even if no notifier is desired
+	if alert.Notifiers == nil {
+		alert.Notifiers = []string{}
+	}
+	res, postErr := a.client.HttpPOST(url, bytes.NewBuffer(jsonStr))
+	if postErr != nil {
+		return nil, fmt.Errorf("could not add alert in view %s with name %s, got: %v", viewName, alert.Name, postErr)
+	}
+
+	body, readErr := ioutil.ReadAll(res.Body)
+	if readErr != nil {
+		log.Fatal(readErr)
+	}
+
+	resAlert := Alert{}
+	jsonErr := json.Unmarshal(body, &resAlert)
+	if jsonErr != nil {
+		log.Fatal(jsonErr)
+	}
+	return &resAlert, nil
+}
+
+func (a *Alerts) Get(view, name string) (*Alert, error) {
+	alertID, err := a.convertAlertNameToID(view, name)
+	if err != nil {
+		return nil, fmt.Errorf("could not find a notifier in view %s with name: %s", view, name)
+	}
+
+	url := fmt.Sprintf("api/v1/repositories/%s/alerts/%s", view, alertID)
+
+	res, err := a.client.HttpGET(url)
+	if err != nil {
+		return nil, fmt.Errorf("could not get alert with id %s, got: %v", alertID, err)
+	}
+
+	body, readErr := ioutil.ReadAll(res.Body)
+	if readErr != nil {
+		log.Fatal(readErr)
+	}
+
+	resAlert := Alert{}
+	jsonErr := json.Unmarshal(body, &resAlert)
+	if jsonErr != nil {
+		log.Fatal(jsonErr)
+	}
+
+	// Humio requires notifiers to be specified even if no notifier is desired
+	if resAlert.Notifiers == nil {
+		resAlert.Notifiers = []string{}
+	}
+
+	return &resAlert, nil
+}
+
+func (a *Alerts) Delete(viewName, name string) error {
+	alertID, err := a.convertAlertNameToID(viewName, name)
+	if err != nil {
+		return fmt.Errorf("could not find a notifier in view %s with name: %s", viewName, name)
+	}
+
+	url := fmt.Sprintf("api/v1/repositories/%s/alerts/%s", viewName, alertID)
+
+	res, err := a.client.HttpDELETE(url)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err != nil || res.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("could not delete alert in view %s with id %s, got: %v", viewName, alertID, err)
+	}
+	return nil
+}
+
+func (a *Alerts) convertAlertNameToID(viewName, alertName string) (string, error) {
+	listOfAlerts, err := a.List(viewName)
+	if err != nil {
+		return "", fmt.Errorf("could not list all alerts for view %s: %v", viewName, err)
+	}
+	for _, v := range listOfAlerts {
+		if v.Name == alertName {
+			return v.ID, nil
+		}
+	}
+	return "", fmt.Errorf("could not find an alert in view %s with name: %s", viewName, alertName)
+}
+
+func (a *Alerts) alertNameInUse(viewName, alertName string) (bool, error) {
+	listOfAlerts, err := a.List(viewName)
+	if err != nil {
+		return true, fmt.Errorf("could not list all alerts for view %s: %v", viewName, err)
+	}
+	for _, v := range listOfAlerts {
+		if v.Name == alertName {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/api/alerts.go
+++ b/api/alerts.go
@@ -37,7 +37,7 @@ func (c *Client) Alerts() *Alerts { return &Alerts{client: c} }
 func (a *Alerts) List(view string) ([]Alert, error) {
 	url := fmt.Sprintf("api/v1/repositories/%s/alerts", view)
 
-	res, err := a.client.HttpGET(url)
+	res, err := a.client.HTTPRequest(http.MethodGet, url, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func (a *Alerts) Update(viewName string, alert *Alert) (*Alert, error) {
 	if alert.Notifiers == nil {
 		alert.Notifiers = []string{}
 	}
-	res, postErr := a.client.HttpPUT(url, bytes.NewBuffer(jsonStr))
+	res, postErr := a.client.HTTPRequest(http.MethodPut, url, bytes.NewBuffer(jsonStr))
 	if postErr != nil {
 		return nil, fmt.Errorf("could not add alert in view %s with name %s, got: %v", viewName, alert.Name, postErr)
 	}
@@ -111,7 +111,7 @@ func (a *Alerts) Add(viewName string, alert *Alert, updateExisting bool) (*Alert
 	if alert.Notifiers == nil {
 		alert.Notifiers = []string{}
 	}
-	res, postErr := a.client.HttpPOST(url, bytes.NewBuffer(jsonStr))
+	res, postErr := a.client.HTTPRequest(http.MethodPost, url, bytes.NewBuffer(jsonStr))
 	if postErr != nil {
 		return nil, fmt.Errorf("could not add alert in view %s with name %s, got: %v", viewName, alert.Name, postErr)
 	}
@@ -137,7 +137,7 @@ func (a *Alerts) Get(view, name string) (*Alert, error) {
 
 	url := fmt.Sprintf("api/v1/repositories/%s/alerts/%s", view, alertID)
 
-	res, err := a.client.HttpGET(url)
+	res, err := a.client.HTTPRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not get alert with id %s, got: %v", alertID, err)
 	}
@@ -169,7 +169,7 @@ func (a *Alerts) Delete(viewName, name string) error {
 
 	url := fmt.Sprintf("api/v1/repositories/%s/alerts/%s", viewName, alertID)
 
-	res, err := a.client.HttpDELETE(url)
+	res, err := a.client.HTTPRequest(http.MethodDelete, url, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/api/alerts.go
+++ b/api/alerts.go
@@ -34,8 +34,8 @@ type Alerts struct {
 
 func (c *Client) Alerts() *Alerts { return &Alerts{client: c} }
 
-func (a *Alerts) List(view string) ([]Alert, error) {
-	url := fmt.Sprintf("api/v1/repositories/%s/alerts", view)
+func (a *Alerts) List(viewName string) ([]Alert, error) {
+	url := fmt.Sprintf("api/v1/repositories/%s/alerts", viewName)
 
 	res, err := a.client.HTTPRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -93,13 +93,13 @@ func (a *Alerts) Add(viewName string, alert *Alert, updateExisting bool) (*Alert
 	return a.unmarshalToAlert(res)
 }
 
-func (a *Alerts) Get(view, name string) (*Alert, error) {
-	alertID, err := a.convertAlertNameToID(view, name)
+func (a *Alerts) Get(viewName, alertName string) (*Alert, error) {
+	alertID, err := a.convertAlertNameToID(viewName, alertName)
 	if err != nil {
-		return nil, fmt.Errorf("could not find a notifier in view %s with name: %s", view, name)
+		return nil, fmt.Errorf("could not find a notifier in view %s with name: %s", viewName, alertName)
 	}
 
-	url := fmt.Sprintf("api/v1/repositories/%s/alerts/%s", view, alertID)
+	url := fmt.Sprintf("api/v1/repositories/%s/alerts/%s", viewName, alertID)
 
 	res, err := a.client.HTTPRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -109,10 +109,10 @@ func (a *Alerts) Get(view, name string) (*Alert, error) {
 	return a.unmarshalToAlert(res)
 }
 
-func (a *Alerts) Delete(viewName, name string) error {
-	alertID, err := a.convertAlertNameToID(viewName, name)
+func (a *Alerts) Delete(viewName, alertName string) error {
+	alertID, err := a.convertAlertNameToID(viewName, alertName)
 	if err != nil {
-		return fmt.Errorf("could not find a notifier in view %s with name: %s", viewName, name)
+		return fmt.Errorf("could not find a notifier in view %s with name: %s", viewName, alertName)
 	}
 
 	url := fmt.Sprintf("api/v1/repositories/%s/alerts/%s", viewName, alertID)

--- a/api/client.go
+++ b/api/client.go
@@ -62,50 +62,17 @@ func (c *Client) Mutate(mutation interface{}, variables map[string]interface{}) 
 	return graphqlErr
 }
 
-func (c *Client) HttpGET(path string) (*http.Response, error) {
-	url := c.Address() + path
-	req, reqErr := http.NewRequest(http.MethodGet, url, bytes.NewBuffer([]byte("")))
-	req.Header.Set("Authorization", "Bearer "+c.Token())
-	req.Header.Set("Accept", "application/json")
-	var client = &http.Client{}
-
-	if reqErr != nil {
-		return nil, reqErr
+func (c *Client) HTTPRequest(httpMethod string, path string, body *bytes.Buffer) (*http.Response, error) {
+	if body == nil {
+		body = bytes.NewBuffer([]byte(""))
 	}
-	return client.Do(req)
-}
 
-func (c *Client) HttpPOST(path string, jsonStr *bytes.Buffer) (*http.Response, error) {
 	url := c.Address() + path
-	req, reqErr := http.NewRequest(http.MethodPost, url, jsonStr)
+
+	req, reqErr := http.NewRequest(httpMethod, url, body)
 	req.Header.Set("Authorization", "Bearer "+c.Token())
 	req.Header.Set("Content-Type", "application/json")
-	var client = &http.Client{}
 
-	if reqErr != nil {
-		return nil, reqErr
-	}
-	return client.Do(req)
-}
-
-func (c *Client) HttpPUT(path string, jsonStr *bytes.Buffer) (*http.Response, error) {
-	url := c.Address() + path
-	req, reqErr := http.NewRequest(http.MethodPut, url, jsonStr)
-	req.Header.Set("Authorization", "Bearer "+c.Token())
-	req.Header.Set("Content-Type", "application/json")
-	var client = &http.Client{}
-
-	if reqErr != nil {
-		return nil, reqErr
-	}
-	return client.Do(req)
-}
-
-func (c *Client) HttpDELETE(path string) (*http.Response, error) {
-	url := c.Address() + path
-	req, reqErr := http.NewRequest(http.MethodDelete, url, bytes.NewBuffer([]byte("")))
-	req.Header.Set("Authorization", "Bearer "+c.Token())
-	req.Header.Set("Content-Type", "application/json")
 	var client = &http.Client{}
 
 	if reqErr != nil {

--- a/api/client.go
+++ b/api/client.go
@@ -62,9 +62,9 @@ func (c *Client) Mutate(mutation interface{}, variables map[string]interface{}) 
 	return graphqlErr
 }
 
-func (c *Client) httpGET(path string) (*http.Response, error) {
+func (c *Client) HttpGET(path string) (*http.Response, error) {
 	url := c.Address() + path
-	req, reqErr := http.NewRequest("GET", url, bytes.NewBuffer([]byte("")))
+	req, reqErr := http.NewRequest(http.MethodGet, url, bytes.NewBuffer([]byte("")))
 	req.Header.Set("Authorization", "Bearer "+c.Token())
 	req.Header.Set("Accept", "application/json")
 	var client = &http.Client{}
@@ -77,8 +77,34 @@ func (c *Client) httpGET(path string) (*http.Response, error) {
 
 func (c *Client) HttpPOST(path string, jsonStr *bytes.Buffer) (*http.Response, error) {
 	url := c.Address() + path
-	req, reqErr := http.NewRequest("POST", url, jsonStr)
-	req.Header.Set("Authorization", "Bearer "+c.config.Token)
+	req, reqErr := http.NewRequest(http.MethodPost, url, jsonStr)
+	req.Header.Set("Authorization", "Bearer "+c.Token())
+	req.Header.Set("Content-Type", "application/json")
+	var client = &http.Client{}
+
+	if reqErr != nil {
+		return nil, reqErr
+	}
+	return client.Do(req)
+}
+
+func (c *Client) HttpPUT(path string, jsonStr *bytes.Buffer) (*http.Response, error) {
+	url := c.Address() + path
+	req, reqErr := http.NewRequest(http.MethodPut, url, jsonStr)
+	req.Header.Set("Authorization", "Bearer "+c.Token())
+	req.Header.Set("Content-Type", "application/json")
+	var client = &http.Client{}
+
+	if reqErr != nil {
+		return nil, reqErr
+	}
+	return client.Do(req)
+}
+
+func (c *Client) HttpDELETE(path string) (*http.Response, error) {
+	url := c.Address() + path
+	req, reqErr := http.NewRequest(http.MethodDelete, url, bytes.NewBuffer([]byte("")))
+	req.Header.Set("Authorization", "Bearer "+c.Token())
 	req.Header.Set("Content-Type", "application/json")
 	var client = &http.Client{}
 

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -167,7 +167,7 @@ type ClusterNodes struct {
 	client *Client
 }
 
-func (n *Client) ClusterNodes() *ClusterNodes { return &ClusterNodes{client: n} }
+func (c *Client) ClusterNodes() *ClusterNodes { return &ClusterNodes{client: c} }
 
 func (n *ClusterNodes) List() ([]ClusterNode, error) {
 	var q struct {

--- a/api/license.go
+++ b/api/license.go
@@ -53,7 +53,7 @@ func (l OnPremLicense) LicenseType() string {
 
 func (c *Client) Licenses() *Licenses { return &Licenses{client: c} }
 
-func (p *Licenses) Install(license string) error {
+func (l *Licenses) Install(license string) error {
 
 	var mutation struct {
 		UpdateLicenseKey struct {
@@ -64,10 +64,10 @@ func (p *Licenses) Install(license string) error {
 		"license": graphql.String(license),
 	}
 
-	return p.client.Mutate(&mutation, variables)
+	return l.client.Mutate(&mutation, variables)
 }
 
-func (c *Licenses) Get() (License, error) {
+func (l *Licenses) Get() (License, error) {
 	var query struct {
 		License struct {
 			ExpiresAt string
@@ -80,7 +80,7 @@ func (c *Licenses) Get() (License, error) {
 		}
 	}
 
-	err := c.client.Query(&query, nil)
+	err := l.client.Query(&query, nil)
 
 	if err != nil {
 		return nil, err

--- a/api/notifiers.go
+++ b/api/notifiers.go
@@ -1,0 +1,217 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+const NotifierTypeEmail = "EmailNotifier"
+const NotifierTypeOpsGenie = "OpsGenieNotifier"
+const NotifierTypePagerDuty = "PagerDutyNotifier"
+const NotifierTypeSlack = "SlackNotifier"
+const NotifierTypeVictorOps = "VictorOpsNotifier"
+const NotifierTypeWebHook = "WebHookNotifier"
+
+type Notifiers struct {
+	client *Client
+}
+
+type Notifier struct {
+	Entity     string                 `json:"entity"`
+	ID         string                 `json:"id,omitempty"`
+	Name       string                 `json:"name"`
+	Properties map[string]interface{} `json:"properties"`
+}
+
+func (c *Client) Notifiers() *Notifiers { return &Notifiers{client: c} }
+
+func (n *Notifiers) List(view string) ([]Notifier, error) {
+	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers", view)
+
+	res, err := n.client.HttpGET(url)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	body, readErr := ioutil.ReadAll(res.Body)
+	if readErr != nil {
+		log.Fatal(readErr)
+	}
+
+	notifiers := []Notifier{}
+	jsonErr := json.Unmarshal(body, &notifiers)
+	if jsonErr != nil {
+		log.Fatal(jsonErr)
+	}
+
+	return notifiers, nil
+}
+
+func (n *Notifiers) Update(viewName string, notifier *Notifier) (*Notifier, error) {
+	existingID, err := n.convertNotifierNameToID(viewName, notifier.Name)
+	if err != nil {
+		return nil, fmt.Errorf("could not convert notifier name to id: %v", err)
+	}
+	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers/%s", viewName, existingID)
+
+	jsonStr, err := json.Marshal(notifier)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert notifier to json string: %v", err)
+	}
+
+	res, err := n.client.HttpPUT(url, bytes.NewBuffer(jsonStr))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	body, readErr := ioutil.ReadAll(res.Body)
+	fmt.Println(res.Body)
+	if readErr != nil {
+		log.Fatal(readErr)
+	}
+
+	resNotifier := Notifier{}
+	jsonErr := json.Unmarshal(body, &resNotifier)
+	if jsonErr != nil {
+		log.Fatal(jsonErr)
+	}
+
+	return &resNotifier, nil
+}
+
+func (n *Notifiers) Add(viewName string, notifier *Notifier, force bool) (*Notifier, error) {
+	url := fmt.Sprintf("%sapi/v1/repositories/%s/alertnotifiers/", n.client.Address(), viewName)
+
+	nameAlreadyInUse, err := n.notifierNameInUse(viewName, notifier.Name)
+	if err != nil {
+		return nil, fmt.Errorf("could not determine if notifier name is in use: %v", err)
+	}
+	if nameAlreadyInUse {
+		if force == false {
+			return nil, fmt.Errorf("notifier with name %s already exists", notifier.Name)
+		}
+		return n.Update(viewName, notifier)
+	}
+
+	jsonStr, err := json.Marshal(notifier)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert notifier to json string: %v", err)
+	}
+
+	res, err := n.client.HttpPOST(url, bytes.NewBuffer(jsonStr))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	body, readErr := ioutil.ReadAll(res.Body)
+	fmt.Println(res.Body)
+	if readErr != nil {
+		log.Fatal(readErr)
+	}
+
+	resNotifier := Notifier{}
+	jsonErr := json.Unmarshal(body, &resNotifier)
+	if jsonErr != nil {
+		log.Fatal(jsonErr)
+	}
+
+	return &resNotifier, nil
+}
+
+func (n *Notifiers) Get(view, name string) (*Notifier, error) {
+	notifierID, err := n.convertNotifierNameToID(view, name)
+	if err != nil {
+		return nil, fmt.Errorf("could not find a notifier in view %s with name: %s", view, name)
+	}
+
+	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers/%s", view, notifierID)
+
+	res, err := n.client.HttpGET(url)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	body, readErr := ioutil.ReadAll(res.Body)
+	if readErr != nil {
+		log.Fatal(readErr)
+	}
+
+	resNotifier := Notifier{}
+	jsonErr := json.Unmarshal(body, &resNotifier)
+	if jsonErr != nil {
+		log.Fatal(jsonErr)
+	}
+
+	return &resNotifier, nil
+}
+
+func (n *Notifiers) GetByID(view, notifierID string) (*Notifier, error) {
+	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers/%s", view, notifierID)
+
+	res, err := n.client.HttpGET(url)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	body, readErr := ioutil.ReadAll(res.Body)
+	if readErr != nil {
+		log.Fatal(readErr)
+	}
+
+	resNotifier := Notifier{}
+	jsonErr := json.Unmarshal(body, &resNotifier)
+	if jsonErr != nil {
+		log.Fatal(jsonErr)
+	}
+
+	return &resNotifier, nil
+}
+
+func (n *Notifiers) Delete(viewName, name string) error {
+	notifierID, err := n.convertNotifierNameToID(viewName, name)
+	if err != nil {
+		return fmt.Errorf("could not find a notifier in view %s with name: %s", viewName, name)
+	}
+
+	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers/%s", viewName, notifierID)
+
+	res, err := n.client.HttpDELETE(url)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err != nil || res.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("could not delete notifier in view %s with id %s, got: %v", viewName, notifierID, err)
+	}
+	return nil
+}
+
+func (n *Notifiers) convertNotifierNameToID(viewName, notifierName string) (string, error) {
+	listOfNotifiers, err := n.List(viewName)
+	if err != nil {
+		return "", fmt.Errorf("could not list all notifiers for view %s: %v", viewName, err)
+	}
+	for _, v := range listOfNotifiers {
+		if v.Name == notifierName {
+			return v.ID, nil
+		}
+	}
+	return "", fmt.Errorf("could not find a notifier in view %s with name: %s", viewName, notifierName)
+}
+
+func (n *Notifiers) notifierNameInUse(viewName, notifierName string) (bool, error) {
+	listOfNotifiers, err := n.List(viewName)
+	if err != nil {
+		return true, fmt.Errorf("could not list all notifiers for view %s: %v", viewName, err)
+	}
+	for _, v := range listOfNotifiers {
+		if v.Name == notifierName {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/api/notifiers.go
+++ b/api/notifiers.go
@@ -29,8 +29,8 @@ type Notifier struct {
 
 func (c *Client) Notifiers() *Notifiers { return &Notifiers{client: c} }
 
-func (n *Notifiers) List(view string) ([]Notifier, error) {
-	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers", view)
+func (n *Notifiers) List(viewName string) ([]Notifier, error) {
+	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers", viewName)
 
 	res, err := n.client.HTTPRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -88,13 +88,13 @@ func (n *Notifiers) Add(viewName string, notifier *Notifier, force bool) (*Notif
 	return n.unmarshalToNotifier(res)
 }
 
-func (n *Notifiers) Get(view, name string) (*Notifier, error) {
-	notifierID, err := n.convertNotifierNameToID(view, name)
+func (n *Notifiers) Get(viewName, notifierName string) (*Notifier, error) {
+	notifierID, err := n.convertNotifierNameToID(viewName, notifierName)
 	if err != nil {
-		return nil, fmt.Errorf("could not find a notifier in view %s with name: %s", view, name)
+		return nil, fmt.Errorf("could not find a notifier in view %s with name: %s", viewName, notifierName)
 	}
 
-	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers/%s", view, notifierID)
+	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers/%s", viewName, notifierID)
 
 	res, err := n.client.HTTPRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -104,8 +104,8 @@ func (n *Notifiers) Get(view, name string) (*Notifier, error) {
 	return n.unmarshalToNotifier(res)
 }
 
-func (n *Notifiers) GetByID(view, notifierID string) (*Notifier, error) {
-	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers/%s", view, notifierID)
+func (n *Notifiers) GetByID(viewName, notifierID string) (*Notifier, error) {
+	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers/%s", viewName, notifierID)
 
 	res, err := n.client.HTTPRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -115,10 +115,10 @@ func (n *Notifiers) GetByID(view, notifierID string) (*Notifier, error) {
 	return n.unmarshalToNotifier(res)
 }
 
-func (n *Notifiers) Delete(viewName, name string) error {
-	notifierID, err := n.convertNotifierNameToID(viewName, name)
+func (n *Notifiers) Delete(viewName, notifierName string) error {
+	notifierID, err := n.convertNotifierNameToID(viewName, notifierName)
 	if err != nil {
-		return fmt.Errorf("could not find a notifier in view %s with name: %s", viewName, name)
+		return fmt.Errorf("could not find a notifier in view %s with name: %s", viewName, notifierName)
 	}
 
 	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers/%s", viewName, notifierID)

--- a/api/notifiers.go
+++ b/api/notifiers.go
@@ -32,7 +32,7 @@ func (c *Client) Notifiers() *Notifiers { return &Notifiers{client: c} }
 func (n *Notifiers) List(view string) ([]Notifier, error) {
 	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers", view)
 
-	res, err := n.client.HttpGET(url)
+	res, err := n.client.HTTPRequest(http.MethodGet, url, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func (n *Notifiers) Update(viewName string, notifier *Notifier) (*Notifier, erro
 		return nil, fmt.Errorf("unable to convert notifier to json string: %v", err)
 	}
 
-	res, err := n.client.HttpPUT(url, bytes.NewBuffer(jsonStr))
+	res, err := n.client.HTTPRequest(http.MethodPut, url, bytes.NewBuffer(jsonStr))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func (n *Notifiers) Update(viewName string, notifier *Notifier) (*Notifier, erro
 }
 
 func (n *Notifiers) Add(viewName string, notifier *Notifier, force bool) (*Notifier, error) {
-	url := fmt.Sprintf("%sapi/v1/repositories/%s/alertnotifiers/", n.client.Address(), viewName)
+	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers/", viewName)
 
 	nameAlreadyInUse, err := n.notifierNameInUse(viewName, notifier.Name)
 	if err != nil {
@@ -102,7 +102,7 @@ func (n *Notifiers) Add(viewName string, notifier *Notifier, force bool) (*Notif
 		return nil, fmt.Errorf("unable to convert notifier to json string: %v", err)
 	}
 
-	res, err := n.client.HttpPOST(url, bytes.NewBuffer(jsonStr))
+	res, err := n.client.HTTPRequest(http.MethodPost, url, bytes.NewBuffer(jsonStr))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -130,7 +130,7 @@ func (n *Notifiers) Get(view, name string) (*Notifier, error) {
 
 	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers/%s", view, notifierID)
 
-	res, err := n.client.HttpGET(url)
+	res, err := n.client.HTTPRequest(http.MethodGet, url, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func (n *Notifiers) Get(view, name string) (*Notifier, error) {
 func (n *Notifiers) GetByID(view, notifierID string) (*Notifier, error) {
 	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers/%s", view, notifierID)
 
-	res, err := n.client.HttpGET(url)
+	res, err := n.client.HTTPRequest(http.MethodGet, url, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func (n *Notifiers) Delete(viewName, name string) error {
 
 	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers/%s", viewName, notifierID)
 
-	res, err := n.client.HttpDELETE(url)
+	res, err := n.client.HTTPRequest(http.MethodDelete, url, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/api/parsers.go
+++ b/api/parsers.go
@@ -12,12 +12,11 @@ type ParserTestCase struct {
 }
 
 type Parser struct {
-	Name        string
-	Description string           `yaml:",omitempty"`
-	Tests       []ParserTestCase `yaml:",omitempty"`
-	Example     string           `yaml:",omitempty"`
-	Script      string           `yaml:",flow"`
-	TagFields   []string         `yaml:",omitempty"`
+	Name      string
+	Tests     []ParserTestCase `yaml:",omitempty"`
+	Example   string           `yaml:",omitempty"`
+	Script    string           `yaml:",flow"`
+	TagFields []string         `yaml:",omitempty"`
 }
 
 type Parsers struct {
@@ -119,6 +118,7 @@ func (p *Parsers) Get(reposistoryName string, parserName string) (*Parser, error
 				Name       string
 				SourceCode string
 				TestData   []string
+				TagFields  []string
 			} `graphql:"parser(name: $parserName)"`
 		} `graphql:"repository(name: $repositoryName)"`
 	}
@@ -133,9 +133,10 @@ func (p *Parsers) Get(reposistoryName string, parserName string) (*Parser, error
 	var parser Parser
 	if graphqlErr == nil {
 		parser = Parser{
-			Name:   query.Repository.Parser.Name,
-			Tests:  mapTests(query.Repository.Parser.TestData, toTestCase),
-			Script: query.Repository.Parser.SourceCode,
+			Name:      query.Repository.Parser.Name,
+			Tests:     mapTests(query.Repository.Parser.TestData, toTestCase),
+			Script:    query.Repository.Parser.SourceCode,
+			TagFields: query.Repository.Parser.TagFields,
 		}
 	}
 

--- a/api/repositories.go
+++ b/api/repositories.go
@@ -12,14 +12,14 @@ type Repositories struct {
 
 type Repository struct {
 	Name            string
-	RetentionDays   int64 `graphql:"timeBasedRetention"`
-	RetentionSizeGB int64 `graphql:"storageSizeBasedRetention"`
-	SpaceUsed       int64 `graphql:"compressedByteSize"`
+	RetentionDays   float64 `graphql:"timeBasedRetention"`
+	RetentionSizeGB float64 `graphql:"storageSizeBasedRetention"`
+	SpaceUsed       int64   `graphql:"compressedByteSize"`
 }
 
 func (c *Client) Repositories() *Repositories { return &Repositories{client: c} }
 
-func (c *Repositories) Get(name string) (Repository, error) {
+func (r *Repositories) Get(name string) (Repository, error) {
 	var q struct {
 		Repository Repository `graphql:"repository(name: $name)"`
 	}
@@ -28,7 +28,7 @@ func (c *Repositories) Get(name string) (Repository, error) {
 		"name": graphql.String(name),
 	}
 
-	graphqlErr := c.client.Query(&q, variables)
+	graphqlErr := r.client.Query(&q, variables)
 
 	return q.Repository, graphqlErr
 }
@@ -38,17 +38,17 @@ type RepoListItem struct {
 	SpaceUsed int64 `graphql:"compressedByteSize"`
 }
 
-func (c *Repositories) List() ([]RepoListItem, error) {
+func (r *Repositories) List() ([]RepoListItem, error) {
 	var q struct {
 		Repositories []RepoListItem `graphql:"repositories"`
 	}
 
-	graphqlErr := c.client.Query(&q, nil)
+	graphqlErr := r.client.Query(&q, nil)
 
 	return q.Repositories, graphqlErr
 }
 
-func (c *Repositories) Create(name string) error {
+func (r *Repositories) Create(name string) error {
 	var m struct {
 		CreateRepository struct {
 			Repository Repository
@@ -59,7 +59,7 @@ func (c *Repositories) Create(name string) error {
 		"name": graphql.String(name),
 	}
 
-	graphqlErr := c.client.Mutate(&m, variables)
+	graphqlErr := r.client.Mutate(&m, variables)
 
 	if graphqlErr != nil {
 		// The graphql error message is vague if the repo already exists, so add a hint.

--- a/api/status.go
+++ b/api/status.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 )
@@ -13,7 +12,7 @@ type StatusResponse struct {
 }
 
 func (c *Client) Status() (*StatusResponse, error) {
-	resp, err := c.httpGET("api/v1/status")
+	resp, err := c.HttpGET("api/v1/status")
 
 	if err != nil {
 		return nil, err
@@ -22,7 +21,7 @@ func (c *Client) Status() (*StatusResponse, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return nil, errors.New(fmt.Sprintf("error getting server status: %s", resp.Status))
+		return nil, fmt.Errorf("error getting server status: %s", resp.Status)
 	}
 
 	jsonData, err := ioutil.ReadAll(resp.Body)

--- a/api/status.go
+++ b/api/status.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 )
 
 type StatusResponse struct {
@@ -12,7 +13,7 @@ type StatusResponse struct {
 }
 
 func (c *Client) Status() (*StatusResponse, error) {
-	resp, err := c.HttpGET("api/v1/status")
+	resp, err := c.HTTPRequest(http.MethodGet, "api/v1/status", nil)
 
 	if err != nil {
 		return nil, err

--- a/api/users.go
+++ b/api/users.go
@@ -33,17 +33,17 @@ type UserChangeSet struct {
 
 func (c *Client) Users() *Users { return &Users{client: c} }
 
-func (c *Users) List() ([]User, error) {
+func (u *Users) List() ([]User, error) {
 	var q struct {
 		Users []User `graphql:"accounts"`
 	}
 
-	graphqlErr := c.client.Query(&q, nil)
+	graphqlErr := u.client.Query(&q, nil)
 
 	return q.Users, graphqlErr
 }
 
-func (c *Users) Get(username string) (User, error) {
+func (u *Users) Get(username string) (User, error) {
 	var q struct {
 		User User `graphql:"account(username: $username)"`
 	}
@@ -52,32 +52,32 @@ func (c *Users) Get(username string) (User, error) {
 		"username": graphql.String(username),
 	}
 
-	graphqlErr := c.client.Query(&q, variables)
+	graphqlErr := u.client.Query(&q, variables)
 
 	return q.User, graphqlErr
 }
 
-func (c *Users) Update(username string, changeset UserChangeSet) (User, error) {
+func (u *Users) Update(username string, changeset UserChangeSet) (User, error) {
 	var mutation struct {
 		Result struct{ User User } `graphql:"updateUser(input: {username: $username, isRoot: $isRoot, fullName: $fullName, company: $company, countryCode: $countryCode, email: $email, picture: $picture})"`
 	}
 
-	graphqlErr := c.client.Mutate(&mutation, userChangesetToVars(username, changeset))
+	graphqlErr := u.client.Mutate(&mutation, userChangesetToVars(username, changeset))
 
 	return mutation.Result.User, graphqlErr
 }
 
-func (c *Users) Add(username string, changeset UserChangeSet) (User, error) {
+func (u *Users) Add(username string, changeset UserChangeSet) (User, error) {
 	var mutation struct {
 		Result struct{ User User } `graphql:"addUser(input: {username: $username, isRoot: $isRoot, fullName: $fullName, company: $company, countryCode: $countryCode, email: $email, picture: $picture})"`
 	}
 
-	graphqlErr := c.client.Mutate(&mutation, userChangesetToVars(username, changeset))
+	graphqlErr := u.client.Mutate(&mutation, userChangesetToVars(username, changeset))
 
 	return mutation.Result.User, graphqlErr
 }
 
-func (c *Users) Remove(username string) (User, error) {
+func (u *Users) Remove(username string) (User, error) {
 	var mutation struct {
 		Result struct {
 			// We have to make a selection, so just take __typename
@@ -89,7 +89,7 @@ func (c *Users) Remove(username string) (User, error) {
 		"username": graphql.String(username),
 	}
 
-	graphqlErr := c.client.Mutate(&mutation, variables)
+	graphqlErr := u.client.Mutate(&mutation, variables)
 
 	return mutation.Result.User, graphqlErr
 }

--- a/cmd/alerts.go
+++ b/cmd/alerts.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Humio Ltd.
+// Copyright © 2020 Humio Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,20 +18,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newIngestTokensCmd() *cobra.Command {
+func newAlertsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ingest-tokens [flags]",
-		Short: "Manage ingest tokens",
-		Long: `Ingest tokens, unlike the more general API tokens, can only be used for ingestion of data.
-
-You can also assign a parser to an ingest token, allowing you to configure how Humio parses incoming data
-without having to change anything on sender/client.`,
+		Use:   "alerts",
+		Short: "Manage alerts",
 	}
 
-	cmd.AddCommand(newIngestTokensAddCmd())
-	cmd.AddCommand(newIngestTokensRemoveCmd())
-	cmd.AddCommand(newIngestTokensListCmd())
-	cmd.AddCommand(newIngestTokensShowCmd())
+	cmd.AddCommand(newAlertsListCmd())
+	cmd.AddCommand(newAlertsInstallCmd())
+	cmd.AddCommand(newAlertsExportCmd())
+	cmd.AddCommand(newAlertsRemoveCmd())
 
 	return cmd
 }

--- a/cmd/alerts_export.go
+++ b/cmd/alerts_export.go
@@ -1,0 +1,68 @@
+// Copyright © 2020 Humio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func newAlertsExportCmd() *cobra.Command {
+	var outputName string
+
+	cmd := cobra.Command{
+		Use:   "export [flags] <view> <alert>",
+		Short: "Export an alert <alert> in <view> to a file.",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			view := args[0]
+			alertName := args[1]
+
+			if outputName == "" {
+				outputName = alertName
+			}
+
+			// Get the HTTP client
+			client := NewApiClient(cmd)
+
+			alert, apiErr := client.Alerts().Get(view, alertName)
+			if apiErr != nil {
+				cmd.Println(fmt.Errorf("Error fetching alert: %s", apiErr))
+				os.Exit(1)
+			}
+
+			yamlData, yamlErr := yaml.Marshal(&alert)
+			if yamlErr != nil {
+				cmd.Println(fmt.Errorf("Failed to serialize the alert: %s", yamlErr))
+				os.Exit(1)
+			}
+			outFilePath := outputName + ".yaml"
+
+			writeErr := ioutil.WriteFile(outFilePath, yamlData, 0644)
+			if writeErr != nil {
+				cmd.Println(fmt.Errorf("Error saving the alert file: %s", writeErr))
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&outputName, "output", "o", "", "The file path where the alert should be written. Defaults to ./<alert-name>.yaml")
+
+	return &cmd
+}

--- a/cmd/alerts_install.go
+++ b/cmd/alerts_install.go
@@ -1,0 +1,105 @@
+// Copyright © 2020 Humio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/humio/cli/api"
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func newAlertsInstallCmd() *cobra.Command {
+	var content []byte
+	var readErr error
+	var force bool
+	var filePath, url, name string
+
+	cmd := cobra.Command{
+		Use:   "install [flags] <view>",
+		Short: "Installs an alert in a view",
+		Long: `Install an alert from a URL or from a local file.
+
+The install command allows you to install alerts from a URL or from a local file, e.g.
+
+  $ humioctl alerts install viewName alertName --url=https://example.com/acme/alert.yaml
+
+  $ humioctl alerts install viewName alertName --file=./parser.yaml
+
+  $ humioctl alerts install viewName --file=./alert.yaml
+
+By default 'install' will not override existing alerts with the same name.
+Use the --force flag to update existing alerts with conflicting names.
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			// Check that we got the right number of argument
+			// if we only got <view> you must supply --file or --url.
+			if l := len(args); l == 1 {
+				if filePath != "" {
+					content, readErr = getAlertFromFile(filePath)
+				} else if url != "" {
+					content, readErr = getURLAlert(url)
+				} else {
+					cmd.Println(fmt.Errorf("you must specify a path using --file or --url"))
+					os.Exit(1)
+				}
+			} else if l := len(args); l != 2 {
+				cmd.Println(fmt.Errorf("This command takes one argument: <view>"))
+				os.Exit(1)
+			}
+			exitOnError(cmd, readErr, "Failed to load the alert")
+
+			viewName := args[0]
+			alert := api.Alert{}
+			alert.Name = name
+			yamlErr := yaml.Unmarshal(content, &alert)
+			exitOnError(cmd, yamlErr, "The alert's format was invalid")
+
+			// Get the HTTP client
+			client := NewApiClient(cmd)
+
+			_, installErr := client.Alerts().Add(viewName, &alert, force)
+			exitOnError(cmd, installErr, "error installing alert")
+
+			cmd.Println("Alert installed")
+		},
+	}
+
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Overrides any alert with the same name. This can be used for updating alert that are already installed. (See --name)")
+	cmd.Flags().StringVar(&filePath, "file", "", "The local file path to the alert to install.")
+	cmd.Flags().StringVar(&url, "url", "", "A URL to fetch the alert file from.")
+	cmd.Flags().StringVarP(&name, "name", "n", "", "Install the alert under a specific name, ignoreing the `name` attribute in the alert file.")
+
+	return &cmd
+}
+
+func getAlertFromFile(filePath string) ([]byte, error) {
+	return ioutil.ReadFile(filePath)
+}
+
+func getURLAlert(url string) ([]byte, error) {
+	response, err := http.Get(url)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer response.Body.Close()
+	return ioutil.ReadAll(response.Body)
+}

--- a/cmd/alerts_list.go
+++ b/cmd/alerts_list.go
@@ -1,0 +1,63 @@
+// Copyright © 2020 Humio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newAlertsListCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "list [flags] <view>",
+		Short: "List all alerts in a view.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			view := args[0]
+
+			// Get the HTTP client
+			client := NewApiClient(cmd)
+			alerts, err := client.Alerts().List(view)
+
+			if err != nil {
+				return fmt.Errorf("Error fetching alerts: %s", err)
+			}
+
+			var output []string
+			output = append(output, "Name | Enabled | Description | Notifiers")
+			for i := 0; i < len(alerts); i++ {
+				alert := alerts[i]
+				var notifierNames []string
+				for _, notifierID := range alert.Notifiers {
+					notifier, err := client.Notifiers().GetByID(view, notifierID)
+					if err != nil {
+						return fmt.Errorf("could not get details for notifier with id %s: %v", notifierID, err)
+					}
+					notifierNames = append(notifierNames, notifier.Name)
+				}
+				output = append(output, fmt.Sprintf("%v | %v | %v | %v", alert.Name, !alert.Silenced, alert.Description, strings.Join(notifierNames, ", ")))
+			}
+
+			printTable(cmd, output)
+
+			return nil
+		},
+	}
+
+	return &cmd
+}

--- a/cmd/alerts_remove.go
+++ b/cmd/alerts_remove.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Humio Ltd.
+// Copyright © 2020 Humio Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,23 +15,34 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
-func newIngestTokensCmd() *cobra.Command {
+func newAlertsRemoveCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ingest-tokens [flags]",
-		Short: "Manage ingest tokens",
-		Long: `Ingest tokens, unlike the more general API tokens, can only be used for ingestion of data.
+		Use:   "remove [flags] <view> <name>",
+		Short: "Removes an alert.",
+		Long:  `Removes the alert with name '<name>' in the view with name '<view>'.`,
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			view := args[0]
+			name := args[1]
 
-You can also assign a parser to an ingest token, allowing you to configure how Humio parses incoming data
-without having to change anything on sender/client.`,
+			// Get the HTTP client
+			client := NewApiClient(cmd)
+
+			err := client.Alerts().Delete(view, name)
+			if err != nil {
+				cmd.Println(fmt.Errorf("error removing ingest token: %s", err))
+				os.Exit(1)
+			}
+
+			cmd.Println("Alert removed")
+		},
 	}
-
-	cmd.AddCommand(newIngestTokensAddCmd())
-	cmd.AddCommand(newIngestTokensRemoveCmd())
-	cmd.AddCommand(newIngestTokensListCmd())
-	cmd.AddCommand(newIngestTokensShowCmd())
 
 	return cmd
 }

--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -27,10 +27,6 @@ type eventList struct {
 	Messages []string          `json:"messages"`
 }
 
-type event struct {
-	RawString string `json:"rawstring"`
-}
-
 func tailFile(client *api.Client, repo string, filepath string, quiet bool) {
 
 	// Join Tail
@@ -218,7 +214,10 @@ has the same effect.`,
 
 			// Open the browser (First so it has a chance to load)
 			if openBrowser {
-				open.Start(client.Address() + repo + "/search?live=true&start=1d&query=" + key)
+				err := open.Start(client.Address() + repo + "/search?live=true&start=1d&query=" + key)
+				if err != nil {
+					fmt.Println(fmt.Errorf("could not open browser: %v", err))
+				}
 			}
 
 			startSending(client, repo, fields, parserName)
@@ -235,7 +234,7 @@ has the same effect.`,
 
 	cmd.Flags().StringVarP(&parserName, "parser", "p", "default", "Use a specific parser for ingestion.")
 	cmd.Flags().StringVarP(&filepath, "tail", "f", "", "A file to tail instead of listening to stdin.")
-	cmd.Flags().StringP("ingest-token", "i", "", "The ingest token to use. Fefaults to your Account API token.")
+	cmd.Flags().StringP("ingest-token", "i", "", "The ingest token to use. Defaults to your Account API token.")
 	cmd.Flags().BoolVarP(&openBrowser, "open", "o", false, "Open the browser with live tail of the stream.")
 	cmd.Flags().StringVarP(&label, "label", "l", "", "Adds a @label=<lavel> field to each event. This can help you find specific data send by the CLI when searching in the UI.")
 	cmd.Flags().BoolVarP(&noSession, "no-session", "n", false, "No @session field will be added to each event. @session assigns a new UUID to each executing of the Humio CLI.")

--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -140,7 +141,7 @@ func sendBatch(client *api.Client, repo string, messages []string, fields map[st
 	}
 
 	url := "api/v1/repositories/" + repo + "/ingest-messages"
-	resp, err := client.HttpPOST(url, bytes.NewBuffer(lineJSON))
+	resp, err := client.HTTPRequest(http.MethodPost, url, bytes.NewBuffer(lineJSON))
 
 	if err != nil {
 		fmt.Println((fmt.Errorf("error while sending data: %v", err)))

--- a/cmd/ingest_tokens_show.go
+++ b/cmd/ingest_tokens_show.go
@@ -1,0 +1,52 @@
+// Copyright © 2020 Humio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newIngestTokensShowCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "show [flags] <repo> <token-name>",
+		Short: "Show details about an ingest-token in a repository.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			repo := args[0]
+			name := args[1]
+
+			// Get the HTTP client
+			client := NewApiClient(cmd)
+			ingestToken, err := client.IngestTokens().Get(repo, name)
+
+			if err != nil {
+				return fmt.Errorf("Error fetching ingest-token: %s", err)
+			}
+
+			var output []string
+			output = append(output, "Name | Token | Assigned parser")
+			output = append(output, fmt.Sprintf("%v | %v | %v", ingestToken.Name, ingestToken.Token, ingestToken.AssignedParser))
+
+			printTable(cmd, output)
+
+			return nil
+		},
+	}
+
+	return &cmd
+}

--- a/cmd/notifiers.go
+++ b/cmd/notifiers.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Humio Ltd.
+// Copyright © 2020 Humio Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,20 +18,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newIngestTokensCmd() *cobra.Command {
+func newNotifiersCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ingest-tokens [flags]",
-		Short: "Manage ingest tokens",
-		Long: `Ingest tokens, unlike the more general API tokens, can only be used for ingestion of data.
-
-You can also assign a parser to an ingest token, allowing you to configure how Humio parses incoming data
-without having to change anything on sender/client.`,
+		Use:   "notifiers",
+		Short: "Manage notifiers",
 	}
 
-	cmd.AddCommand(newIngestTokensAddCmd())
-	cmd.AddCommand(newIngestTokensRemoveCmd())
-	cmd.AddCommand(newIngestTokensListCmd())
-	cmd.AddCommand(newIngestTokensShowCmd())
+	cmd.AddCommand(newNotifiersListCmd())
+	cmd.AddCommand(newNotifiersShowCmd())
+	cmd.AddCommand(newNotifiersRemoveCmd())
+	cmd.AddCommand(newNotifiersInstallCmd())
+	cmd.AddCommand(newNotifiersExportCmd())
 
 	return cmd
 }

--- a/cmd/notifiers_export.go
+++ b/cmd/notifiers_export.go
@@ -1,0 +1,68 @@
+// Copyright © 2020 Humio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func newNotifiersExportCmd() *cobra.Command {
+	var outputName string
+
+	cmd := cobra.Command{
+		Use:   "export [flags] <view> <notifier>",
+		Short: "Export a notifier <notifier> in <view> to a file.",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			view := args[0]
+			notifierName := args[1]
+
+			if outputName == "" {
+				outputName = notifierName
+			}
+
+			// Get the HTTP client
+			client := NewApiClient(cmd)
+
+			notifier, apiErr := client.Notifiers().Get(view, notifierName)
+			if apiErr != nil {
+				cmd.Println(fmt.Errorf("Error fetching notifier: %s", apiErr))
+				os.Exit(1)
+			}
+
+			yamlData, yamlErr := yaml.Marshal(&notifier)
+			if yamlErr != nil {
+				cmd.Println(fmt.Errorf("Failed to serialize the notifier: %s", yamlErr))
+				os.Exit(1)
+			}
+			outFilePath := outputName + ".yaml"
+
+			writeErr := ioutil.WriteFile(outFilePath, yamlData, 0644)
+			if writeErr != nil {
+				cmd.Println(fmt.Errorf("Error saving the notifier file: %s", writeErr))
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&outputName, "output", "o", "", "The file path where the notifier should be written. Defaults to ./<notifier-name>.yaml")
+
+	return &cmd
+}

--- a/cmd/notifiers_install.go
+++ b/cmd/notifiers_install.go
@@ -1,0 +1,103 @@
+// Copyright © 2020 Humio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/humio/cli/api"
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func newNotifiersInstallCmd() *cobra.Command {
+	var content []byte
+	var readErr error
+	var force bool
+	var filePath, url, name string
+
+	cmd := cobra.Command{
+		Use:   "install [flags] <view>",
+		Short: "Installs a notifier in a view",
+		Long: `Install a notifier from a URL or from a local file.
+
+The install command allows you to install notifiers from a URL or from a local file, e.g.
+
+  $ humioctl notifiers install viewName notifierName --url=https://example.com/acme/notifier.yaml
+
+  $ humioctl notifiers install viewName notifierName --file=./notifier.yaml
+
+  $ humioctl notifiers install viewName --file=./notifier.yaml
+
+By default 'install' will not override existing parsers with the same name.
+Use the --force flag to update existing parsers with conflicting names.
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			// Check that we got the right number of argument
+			// if we only got <view> you must supply --file or --url.
+			if l := len(args); l == 1 {
+				if filePath != "" {
+					content, readErr = getNotifierFromFile(filePath)
+				} else if url != "" {
+					content, readErr = getURLNotifier(url)
+				} else {
+					cmd.Println(fmt.Errorf("you must specify a path using --file or --url"))
+					os.Exit(1)
+				}
+			} else if l := len(args); l != 2 {
+				cmd.Println(fmt.Errorf("This command takes one argument: <view>"))
+				os.Exit(1)
+			}
+			exitOnError(cmd, readErr, "Failed to load the notifier")
+
+			viewName := args[0]
+			notifier := api.Notifier{}
+			notifier.Name = name
+			yamlErr := yaml.Unmarshal(content, &notifier)
+			exitOnError(cmd, yamlErr, "The notifier's format was invalid")
+
+			// Get the HTTP client
+			client := NewApiClient(cmd)
+
+			_, installErr := client.Notifiers().Add(viewName, &notifier, force)
+			exitOnError(cmd, installErr, "error installing parser")
+		},
+	}
+
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Overrides any notifier with the same name. This can be used for updating notifier that are already installed. (See --name)")
+	cmd.Flags().StringVar(&filePath, "file", "", "The local file path to the notifier to install.")
+	cmd.Flags().StringVar(&url, "url", "", "A URL to fetch the notifier file from.")
+	cmd.Flags().StringVarP(&name, "name", "n", "", "Install the notifer under a specific name, ignoreing the `name` attribute in the notifier file.")
+
+	return &cmd
+}
+
+func getNotifierFromFile(filePath string) ([]byte, error) {
+	return ioutil.ReadFile(filePath)
+}
+
+func getURLNotifier(url string) ([]byte, error) {
+	response, err := http.Get(url)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer response.Body.Close()
+	return ioutil.ReadAll(response.Body)
+}

--- a/cmd/notifiers_list.go
+++ b/cmd/notifiers_list.go
@@ -1,0 +1,54 @@
+// Copyright © 2020 Humio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newNotifiersListCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "list [flags] <view>",
+		Short: "List all notifiers in a view.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			view := args[0]
+
+			// Get the HTTP client
+			client := NewApiClient(cmd)
+			notifiers, err := client.Notifiers().List(view)
+
+			if err != nil {
+				return fmt.Errorf("Error fetching notifiers: %s", err)
+			}
+
+			var output []string
+			output = append(output, "Name | Type")
+			for i := 0; i < len(notifiers); i++ {
+				notifier := notifiers[i]
+				output = append(output, fmt.Sprintf("%v | %v", notifier.Name, notifier.Entity))
+			}
+
+			printTable(cmd, output)
+
+			return nil
+		},
+	}
+
+	return &cmd
+}

--- a/cmd/notifiers_remove.go
+++ b/cmd/notifiers_remove.go
@@ -1,4 +1,4 @@
-// Copyright © 2018 Humio Ltd.
+// Copyright © 2020 Humio Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,23 +15,34 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
-func newIngestTokensCmd() *cobra.Command {
+func newNotifiersRemoveCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ingest-tokens [flags]",
-		Short: "Manage ingest tokens",
-		Long: `Ingest tokens, unlike the more general API tokens, can only be used for ingestion of data.
+		Use:   "remove [flags] <view> <name>",
+		Short: "Removes an alert notifier.",
+		Long:  `Removes the alert notifier with name '<name>' in the view with name '<view>'.`,
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			view := args[0]
+			name := args[1]
 
-You can also assign a parser to an ingest token, allowing you to configure how Humio parses incoming data
-without having to change anything on sender/client.`,
+			// Get the HTTP client
+			client := NewApiClient(cmd)
+
+			err := client.Notifiers().Delete(view, name)
+			if err != nil {
+				cmd.Println(fmt.Errorf("error removing ingest token: %s", err))
+				os.Exit(1)
+			}
+
+			cmd.Println("Notifier removed")
+		},
 	}
-
-	cmd.AddCommand(newIngestTokensAddCmd())
-	cmd.AddCommand(newIngestTokensRemoveCmd())
-	cmd.AddCommand(newIngestTokensListCmd())
-	cmd.AddCommand(newIngestTokensShowCmd())
 
 	return cmd
 }

--- a/cmd/notifiers_show.go
+++ b/cmd/notifiers_show.go
@@ -1,0 +1,52 @@
+// Copyright © 2020 Humio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newNotifiersShowCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "show [flags] <view> <name>",
+		Short: "Show details about a notifier in a view.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			view := args[0]
+			name := args[1]
+
+			// Get the HTTP client
+			client := NewApiClient(cmd)
+			notifier, err := client.Notifiers().Get(view, name)
+
+			if err != nil {
+				return fmt.Errorf("Error fetching notifier: %s", err)
+			}
+
+			var output []string
+			output = append(output, "Name | EntityType")
+			output = append(output, fmt.Sprintf("%v | %v", notifier.Name, notifier.Entity))
+
+			printTable(cmd, output)
+
+			return nil
+		},
+	}
+
+	return &cmd
+}

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -37,6 +37,7 @@ func valueOrEmpty(v string) string {
 	return v
 }
 
+// ByteCountDecimal returns a human-readable size of a byte count
 func ByteCountDecimal(b int64) string {
 	const unit = 1000
 	if b < unit {

--- a/cmd/parsers_install.go
+++ b/cmd/parsers_install.go
@@ -67,9 +67,9 @@ Use the --force flag to update existing parsers with conflicting names.
 				if filePath != "" {
 					content, readErr = getParserFromFile(filePath)
 				} else if url != "" {
-					content, readErr = getUrlParser(url)
+					content, readErr = getURLParser(url)
 				} else {
-					cmd.Println(fmt.Errorf("if you only provide repo you must specify --file or --url."))
+					cmd.Println(fmt.Errorf("if you only provide repo you must specify --file or --url"))
 					os.Exit(1)
 				}
 			} else if l := len(args); l != 2 {
@@ -114,10 +114,10 @@ func getParserFromFile(filePath string) ([]byte, error) {
 
 func getGithubParser(parserName string) ([]byte, error) {
 	url := "https://raw.githubusercontent.com/humio/community/master/parsers/" + parserName + ".yaml"
-	return getUrlParser(url)
+	return getURLParser(url)
 }
 
-func getUrlParser(url string) ([]byte, error) {
+func getURLParser(url string) ([]byte, error) {
 	response, err := http.Get(url)
 
 	if err != nil {

--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-type Login struct {
+type login struct {
 	address  string
 	token    string
 	username string

--- a/cmd/profiles_add.go
+++ b/cmd/profiles_add.go
@@ -56,7 +56,7 @@ func saveConfig() error {
 	return nil
 }
 
-func addAccount(out *prompt.Prompt, newName string, profile *Login) {
+func addAccount(out *prompt.Prompt, newName string, profile *login) {
 	profiles := viper.GetStringMap("profiles")
 
 	profiles[newName] = map[string]string{
@@ -68,8 +68,8 @@ func addAccount(out *prompt.Prompt, newName string, profile *Login) {
 	viper.Set("profiles", profiles)
 }
 
-func mapToLogin(data interface{}) *Login {
-	return &Login{
+func mapToLogin(data interface{}) *login {
+	return &login{
 		address:  getMapKey(data, "address"),
 		username: getMapKey(data, "username"),
 		token:    getMapKey(data, "token"),
@@ -90,7 +90,7 @@ func getMapKey(data interface{}, key string) string {
 	return ""
 }
 
-func collectProfileInfo(cmd *cobra.Command) (*Login, error) {
+func collectProfileInfo(cmd *cobra.Command) (*login, error) {
 	var addr, token, username string
 
 	out := prompt.NewPrompt(cmd.OutOrStdout())
@@ -99,7 +99,7 @@ func collectProfileInfo(cmd *cobra.Command) (*Login, error) {
 	out.Description("If you are not using Humio Cloud enter the address of your Humio installation,")
 	out.Description("e.g. http://localhost:8080/ or https://humio.example.com/")
 
-	for true {
+	for {
 		var err error
 		out.Output("")
 		addr, err = out.Ask("Address (default: https://cloud.humio.com/ [Hit Enter])")
@@ -169,7 +169,7 @@ func collectProfileInfo(cmd *cobra.Command) (*Login, error) {
 
 	out.Output()
 
-	for true {
+	for {
 		var err error
 		token, err = out.AskSecret("API Token")
 		exitOnError(cmd, err, "error reading token")
@@ -203,7 +203,7 @@ func collectProfileInfo(cmd *cobra.Command) (*Login, error) {
 		break
 	}
 
-	return &Login{address: addr, token: token, username: username}, nil
+	return &login{address: addr, token: token, username: username}, nil
 }
 
 func isCurrentAccount(addr string, token string) bool {

--- a/cmd/profiles_set_default.go
+++ b/cmd/profiles_set_default.go
@@ -36,7 +36,7 @@ func newProfilesSetDefaultCmd() *cobra.Command {
 	return cmd
 }
 
-func loadProfile(profileName string) (*Login, error) {
+func loadProfile(profileName string) (*login, error) {
 	profiles := viper.GetStringMap("profiles")
 	profileData := profiles[profileName]
 
@@ -44,7 +44,7 @@ func loadProfile(profileName string) (*Login, error) {
 		return nil, fmt.Errorf("unknown profile %s", profileName)
 	}
 
-	profile := Login{address: getMapKey(profileData, "address"), token: getMapKey(profileData, "token")}
+	profile := login{address: getMapKey(profileData, "address"), token: getMapKey(profileData, "token")}
 
 	return &profile, nil
 }

--- a/cmd/repos.go
+++ b/cmd/repos.go
@@ -40,8 +40,8 @@ func printRepoTable(cmd *cobra.Command, repo api.Repository) {
 	data := [][]string{
 		[]string{"Name", repo.Name},
 		[]string{"Space Used", ByteCountDecimal(repo.SpaceUsed)},
-		[]string{"Retention (Size)", ByteCountDecimal(repo.RetentionSizeGB / 1000000000)},
-		[]string{"Retention (Days)", fmt.Sprintf("%d", repo.RetentionDays)},
+		[]string{"Retention (Size)", ByteCountDecimal(int64(repo.RetentionSizeGB * 1e9))},
+		[]string{"Retention (Days)", fmt.Sprintf("%d", int64(repo.RetentionDays))},
 	}
 
 	w := tablewriter.NewWriter(cmd.OutOrStdout())

--- a/cmd/repos_list.go
+++ b/cmd/repos_list.go
@@ -42,14 +42,13 @@ func newReposListCmd() *cobra.Command {
 					b = repos[j]
 				} else {
 					a = repos[j]
-					b = repos[j]
+					b = repos[i]
 				}
 
-				if !orderBySize {
-					return a.Name < b.Name
-				} else {
+				if orderBySize {
 					return a.SpaceUsed > b.SpaceUsed
 				}
+				return a.Name < b.Name
 			})
 
 			rows := make([][]string, len(repos))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,11 +77,13 @@ Common Management Commands:
 			// If no token or address flags are passed
 			// and no configuration file exists, run login.
 			if viper.GetString("token") == "" && viper.GetString("address") == "" {
-				newWelcomeCmd().Execute()
+				if err := newWelcomeCmd().Execute(); err != nil {
+					fmt.Println(fmt.Errorf("error printing welcome message: %v", err))
+				}
+
 			} else {
-				err := cmd.Help()
-				if err != nil {
-					fmt.Println(fmt.Errorf("error printing help: %s", err))
+				if err := cmd.Help(); err != nil {
+					fmt.Println(fmt.Errorf("error printing help: %v", err))
 				}
 			}
 		},
@@ -95,8 +97,8 @@ Common Management Commands:
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
-	rootCmd.PersistentFlags().StringVarP(&profileFlag, "profile", "u", "", "name of the config profile to use")
-	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.humio/config.yaml)")
+	rootCmd.PersistentFlags().StringVarP(&profileFlag, "profile", "u", "", "Name of the config profile to use")
+	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "Config file (default is $HOME/.humio/config.yaml)")
 	rootCmd.PersistentFlags().StringVarP(&token, "token", "t", "", "The API token to user when talking to Humio. Overrides the value in your config file.")
 	rootCmd.PersistentFlags().StringVar(&tokenFile, "token-file", "", "File path to a file containing the API token. Overrides the value in your config file and the value of --token.")
 	rootCmd.PersistentFlags().StringVarP(&address, "address", "a", "", "The HTTP address of the Humio cluster. Overrides the value in your config file.")
@@ -118,6 +120,8 @@ Common Management Commands:
 	rootCmd.AddCommand(newReposCmd())
 	rootCmd.AddCommand(newStatusCmd())
 	rootCmd.AddCommand(newClusterCmd())
+	rootCmd.AddCommand(newNotifiersCmd())
+	rootCmd.AddCommand(newAlertsCmd())
 
 	// Hidden Commands
 	rootCmd.AddCommand(newWelcomeCmd())

--- a/cmd/views.go
+++ b/cmd/views.go
@@ -94,11 +94,3 @@ func printViewConnectionsTable(view *api.View) {
 	w.Render()
 	fmt.Println()
 }
-
-func viewRoleNames(user api.User) []string {
-	names := make([]string, len(user.Roles))
-	for i, r := range user.Roles {
-		names[i] = r.Name
-	}
-	return names
-}

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -68,9 +68,9 @@ func (p *Prompt) AskSecret(question string) (string, error) {
 	return string(bytes), nil
 }
 
-func (c *Prompt) Print(i ...interface{}) {
-	fmt.Fprint(c.Out, "  ")
-	fmt.Fprint(c.Out, i...)
+func (p *Prompt) Print(i ...interface{}) {
+	fmt.Fprint(p.Out, "  ")
+	fmt.Fprint(p.Out, i...)
 }
 
 func (p *Prompt) Output(i ...interface{}) {


### PR DESCRIPTION
Changes:
- API: Return tag fields when creating a parser.
- API: Fix types for repo retention settings.
- CLI: Fix repo list ordering.
- CLI: Fix repo retention size output.
- Tidy up based on different linters. Some day we should enable these things on CI :-)
  - Receiver reference are typically named based on the type.
  - Remove unused functions and structs.
  - Acronyms are typically upper case (updated most of them).
  - Errors being returned should be checked, though we may have places we don't care as much about it.
- Adds these to the `api` package:
```
func (c *Client) Alerts() *Alerts
func (c *Client) Notifiers() *Notifiers

func (i *IngestTokens) Get(repoName, tokenName string) (*IngestToken, error)

func (a *Alerts) Add(viewName string, alert *Alert, updateExisting bool) (*Alert, error)
func (a *Alerts) Delete(viewName, alertName string) error
func (a *Alerts) Get(viewName, alertName string) (*Alert, error)
func (a *Alerts) List(viewName string) ([]Alert, error)
func (a *Alerts) Update(viewName string, alert *Alert) (*Alert, error)

func (n *Notifiers) Add(viewName string, notifier *Notifier, force bool) (*Notifier, error)
func (n *Notifiers) Delete(viewName, notifierName string) error
func (n *Notifiers) Get(viewName, notifierName string) (*Notifier, error)
func (n *Notifiers) GetByID(viewName, notifierID string) (*Notifier, error)
func (n *Notifiers) List(viewName string) ([]Notifier, error)
func (n *Notifiers) Update(viewName string, notifier *Notifier) (*Notifier, error)
```
- Adds these new commands to the CLI:
```
humioctl ingest-tokens show [flags] <repo> <token-name>

humioctl alerts list [flags] <view>
humioctl alerts export [flags] <view> <alert>
humioctl alerts remove [flags] <view> <name>
humioctl alerts install [flags] <view>

humioctl notifiers remove [flags] <view> <name>
humioctl notifiers export [flags] <view> <notifier>
humioctl notifiers show [flags] <view> <name>
humioctl notifiers list [flags] <view>
humioctl notifiers install [flags] <view>
```

I'm still a bit unsure what to do about a few things, and would love to get some input on these things:
1. The naming could probably be streamlined a bit, such as:
    1. Parameters to methods in `api` package: view vs viewName vs repo vs repoName vs repositoryName vs searchDomain. For now I've used viewName for alerts and notifiers, even though it may be a tad confusing that it can also be used on a repository.
    2. Notifier vs alert notifier. Going with the first option.
    3. Actions/methods: delete vs remove.
2. Multiple places can only be done using our REST API. Do we want to move that to GraphQL, and is that a blocker before merging this? Thinking alerts and notifiers for this PR, but I know saved queries is also missing from the GraphQL API right now (see this [WIP](https://github.com/humio/cli/compare/master...grant/exporter-importer) that implements functionality to set up saved queries and dashboards).