### PR TITLE
Removed user roles

### DIFF
--- a/api/users.go
+++ b/api/users.go
@@ -6,10 +6,6 @@ type Users struct {
 	client *Client
 }
 
-type Role struct {
-	Name string
-}
-
 type User struct {
 	Username    string
 	FullName    string
@@ -19,7 +15,6 @@ type User struct {
 	Picture     string
 	IsRoot      bool
 	CreatedAt   string
-	Roles       []Role
 }
 
 type UserChangeSet struct {

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -49,7 +49,6 @@ func printUserTable(cmd *cobra.Command, user api.User) {
 		[]string{"Username", user.Username},
 		[]string{"Name", user.FullName},
 		[]string{"Is Root", yesNo(user.IsRoot)},
-		[]string{"Roles", strings.Join(userRoleNames(user), ", ")},
 		[]string{"Email", user.Email},
 		[]string{"Created At", user.CreatedAt},
 		[]string{"Country Code", user.CountryCode},
@@ -65,12 +64,4 @@ func printUserTable(cmd *cobra.Command, user api.User) {
 	fmt.Println()
 	w.Render()
 	fmt.Println()
-}
-
-func userRoleNames(user api.User) []string {
-	names := make([]string, len(user.Roles))
-	for i, r := range user.Roles {
-		names[i] = r.Name
-	}
-	return names
 }


### PR DESCRIPTION
The UserRole object does not seem to be used anymore.
Without this change the `users add` command fails with: 
```
err non-200 OK status code: 400 Bad Request body: "{\"data\":null,\"errors\":[{\"message\":\"Cannot query field 'roles' on type 'User'. Did you mean 'groups'?
```