### PR TITLE
Fixed an issue when adding a new profile

### DIFF
--- a/cmd/profiles_add.go
+++ b/cmd/profiles_add.go
@@ -139,7 +139,7 @@ func collectProfileInfo(cmd *cobra.Command) (*login, error) {
 			continue
 		}
 
-		if status.Status != "ok" {
+		if status.Status != "OK" {
 			cmd.Println(prompt.Colorize("[[red]Failed[reset]]"))
 			cmd.Println(fmt.Errorf("The server reported that is is malfunctioning, status: %s", status.Status))
 			os.Exit(1)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -61,8 +61,8 @@ func newStatusCmd() *cobra.Command {
 }
 
 func formatStatusText(statusText string) string {
-	if statusText == "ok" {
-		return prompt.Colorize("[green]ok[reset]")
+	if statusText == "OK" {
+		return prompt.Colorize("[green]OK[reset]")
 	}
 	return prompt.Colorize(fmt.Sprintf("[red]%s[reset]", statusText))
 }


### PR DESCRIPTION
The Humio server responds with "OK" (uppercase) not "ok", which the cli project interprets wrong.

```
$ humioctl profiles add cloud
  Which Humio instance should we talk to?

  If you are not using Humio Cloud enter the address of your Humio installation,
  e.g. http://localhost:8080/ or https://humio.example.com/

  Address (default: https://cloud.humio.com/ [Hit Enter]):

==> Testing Connection...[Failed]
The server reported that is is malfunctioning, status: WARN
exit status 1
```