### PR TITLE
Always run `go build` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ $(BIN_PATH): $(GOFILES)
 
 all: build
 
-$(BIN_PATH): $(GOFILES)
+$(BIN_PATH): FORCE
 	@echo "--> Building Humio CLI"
 	go build -o $(BIN_PATH) main.go
 
@@ -34,4 +34,6 @@ dist: clean
 run: $(BIN_PATH)
 	$(BIN_PATH) $(CLI_COMMAND)
 
-.PHONY: build get clean dist run
+.PHONY: build get clean dist run FORCE
+
+FORCE:


### PR DESCRIPTION
The go build system is very smart and fast, and generally takes <1s if nothing has changed.
Unless every .go file is listed as a dependency, make might skip rebuilding.