### PR TITLE
Add method to get the token for the user who is authenticated

### DIFF
--- a/api/viewer.go
+++ b/api/viewer.go
@@ -17,3 +17,15 @@ func (c *Viewer) Username() (string, error) {
 	graphqlErr := c.client.Query(&query, nil)
 	return query.Viewer.Username, graphqlErr
 }
+
+// ApiToken fetches the api token for the user who is currently authenticated.
+func (c *Viewer) ApiToken() (string, error) {
+	var query struct {
+		Viewer struct {
+			ApiToken string
+		}
+	}
+
+	graphqlErr := c.client.Query(&query, nil)
+	return query.Viewer.ApiToken, graphqlErr
+}


### PR DESCRIPTION
In the context of running the humio-operator, we need the ability to extract the api token for the developer user. Since we don't have a way to access the token, we cannot configure the humio api with this token. Therefore, we must login using the username/password, get the jwt token and then we can use the jwt token to authenticate and then call this method to get the persistent api token which will be used as a sort of service account. 