### PR TITLE
Improve the search command

### DIFF
--- a/api/search.go
+++ b/api/search.go
@@ -16,12 +16,13 @@ type QueryJobs struct {
 func (c *Client) QueryJobs() *QueryJobs { return &QueryJobs{client: c} }
 
 type Query struct {
-	QueryString    string            `json:"queryString"`
-	Start          string            `json:"start,omitempty"`
-	End            string            `json:"end,omitempty"`
-	Live           bool              `json:"isLive,omitempty"`
-	TimezoneOffset *int              `json:"timeZoneOffsetMinutes,omitempty"`
-	Arguments      map[string]string `json:"arguments,omitempty"`
+	QueryString                string            `json:"queryString"`
+	Start                      string            `json:"start,omitempty"`
+	End                        string            `json:"end,omitempty"`
+	Live                       bool              `json:"isLive,omitempty"`
+	TimezoneOffset             *int              `json:"timeZoneOffsetMinutes,omitempty"`
+	Arguments                  map[string]string `json:"arguments,omitempty"`
+	ShowQueryEventDistribution bool              `json:"showQueryEventDistribution,omitempty"`
 }
 
 type QueryResultMetadata struct {
@@ -96,7 +97,6 @@ func (q *QueryJobs) PollContext(ctx context.Context, repository string, id strin
 	var result QueryResult
 
 	err = json.NewDecoder(resp.Body).Decode(&result)
-	//err = json.NewDecoder(io.TeeReader(resp.Body, os.Stderr)).Decode(&result)
 
 	return result, err
 }

--- a/api/search.go
+++ b/api/search.go
@@ -25,11 +25,19 @@ type Query struct {
 }
 
 type QueryResultMetadata struct {
-	EventCount  uint64 `json:"eventCount"`
-	IsAggregate bool   `json:"isAggregate"`
-	PollAfter   int    `json:"pollAfter"`
-	QueryStart  uint64 `json:"queryStart"`
-	QueryEnd    uint64 `json:"queryEnd"`
+	EventCount       uint64                 `json:"eventCount"`
+	ExtraData        map[string]interface{} `json:"extraData"`
+	FieldOrder       []string               `json:"fieldOrder"`
+	IsAggregate      bool                   `json:"isAggregate"`
+	PollAfter        int                    `json:"pollAfter"`
+	ProcessedBytes   uint64                 `json:"processedBytes"`
+	ProcessedEvents  uint64                 `json:"processedEvents"`
+	QueryStart       uint64                 `json:"queryStart"`
+	QueryEnd         uint64                 `json:"queryEnd"`
+	ResultBufferSize uint64                 `json:"resultBufferSize"`
+	TimeMillis       uint64                 `json:"timeMillis"`
+	TotalWork        uint64                 `json:"totalWork"`
+	WorkDone         uint64                 `json:"workDone"`
 }
 
 type QueryResult struct {
@@ -88,6 +96,7 @@ func (q *QueryJobs) PollContext(ctx context.Context, repository string, id strin
 	var result QueryResult
 
 	err = json.NewDecoder(resp.Body).Decode(&result)
+	//err = json.NewDecoder(io.TeeReader(resp.Body, os.Stderr)).Decode(&result)
 
 	return result, err
 }

--- a/api/status.go
+++ b/api/status.go
@@ -12,6 +12,10 @@ type StatusResponse struct {
 	Version string
 }
 
+func (s StatusResponse) IsDown() bool {
+	return s.Status != "OK" && s.Status != "WARN"
+}
+
 func (c *Client) Status() (*StatusResponse, error) {
 	resp, err := c.HTTPRequest(http.MethodGet, "api/v1/status", nil)
 

--- a/cmd/profiles_add.go
+++ b/cmd/profiles_add.go
@@ -139,7 +139,7 @@ func collectProfileInfo(cmd *cobra.Command) (*login, error) {
 			continue
 		}
 
-		if status.Status != "OK" {
+		if status.IsDown() {
 			cmd.Println(prompt.Colorize("[[red]Failed[reset]]"))
 			cmd.Println(fmt.Errorf("The server reported that is is malfunctioning, status: %s", status.Status))
 			os.Exit(1)

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -184,7 +184,7 @@ func (b *queryResultProgressBar) Update(result api.QueryResult) {
 func (b *queryResultProgressBar) additionalInfoEps() string {
 	if !math.IsNaN(b.epsValue) {
 		v, suffix := prompt.AddSISuffix(b.epsValue, false)
-		return fmt.Sprintf("%.1f %sEPS", v, suffix)
+		return fmt.Sprintf("%.1f %s events/s", v, suffix)
 	}
 	return ""
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -40,11 +40,6 @@ func newSearchCmd() *cobra.Command {
 
 			// run in lambda func to be able to defer and delete the query job
 			err := func() error {
-				var progress *queryResultProgressBar
-				if !noProgress {
-					progress = newQueryResultProgressBar()
-				}
-
 				id, err := client.QueryJobs().Create(repository, api.Query{
 					QueryString: queryString,
 					Start:       start,
@@ -55,6 +50,11 @@ func newSearchCmd() *cobra.Command {
 
 				if err != nil {
 					return err
+				}
+
+				var progress *queryResultProgressBar
+				if !noProgress {
+					progress = newQueryResultProgressBar()
 				}
 
 				defer func(id string) {
@@ -117,6 +117,11 @@ func newSearchCmd() *cobra.Command {
 
 			if err == context.Canceled {
 				err = nil
+			}
+
+			if queryError, ok := err.(api.QueryError); ok {
+				fmt.Printf("There was an error in your query string:\n\n%s\n", queryError.Error())
+				os.Exit(1)
 			}
 
 			exitOnError(cmd, err, "error running search")

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -61,8 +61,12 @@ func newStatusCmd() *cobra.Command {
 }
 
 func formatStatusText(statusText string) string {
-	if statusText == "OK" {
+	switch statusText {
+	case "OK":
 		return prompt.Colorize("[green]OK[reset]")
+	case "WARN":
+		return prompt.Colorize("[yellow]WARN[reset]")
+	default:
+		return prompt.Colorize(fmt.Sprintf("[red]%s[reset]",statusText))
 	}
-	return prompt.Colorize(fmt.Sprintf("[red]%s[reset]", statusText))
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/ryanuber/columnize v2.1.0+incompatible
+	github.com/schollz/progressbar/v2 v2.15.0
 	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f
 	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e
 	github.com/spf13/cobra v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/ryanuber/columnize v2.1.0+incompatible
-	github.com/schollz/progressbar/v2 v2.15.0
 	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f
 	github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e
 	github.com/spf13/cobra v0.0.5

--- a/prompt/progress.go
+++ b/prompt/progress.go
@@ -1,0 +1,156 @@
+package prompt
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+type ProgressBar struct {
+	w              io.Writer
+	description    string
+	cur            uint64
+	max            uint64
+	barSegments    int
+	tickInterval   time.Duration
+	close          chan struct{}
+	update         chan struct{}
+	running        chan struct{}
+	additionalInfo []func() string
+}
+
+type ProgressOption func(*ProgressBar)
+
+func ProgressOptionDescription(description string) ProgressOption {
+	return func(bar *ProgressBar) {
+		bar.description = description
+	}
+}
+
+func ProgressOptionBarSegments(segments int) ProgressOption {
+	return func(bar *ProgressBar) {
+		bar.barSegments = segments
+	}
+}
+
+func ProgressOptionTickInterval(interval time.Duration) ProgressOption {
+	return func(bar *ProgressBar) {
+		bar.tickInterval = interval
+	}
+}
+
+func ProgressOptionAppendAdditionalInfo(f func() string) ProgressOption {
+	return func(bar *ProgressBar) {
+		bar.additionalInfo = append(bar.additionalInfo, f)
+	}
+}
+
+func NewProgressBar(opts ...ProgressOption) *ProgressBar {
+	bar := &ProgressBar{
+		max:         100,
+		barSegments: 30,
+		close:       make(chan struct{}),
+		update:      make(chan struct{}),
+		running:     make(chan struct{}),
+	}
+
+	for _, o := range opts {
+		o(bar)
+	}
+
+	return bar
+}
+
+func (p *ProgressBar) percentage() float64 {
+	if p.max == 0 {
+		return 0
+	}
+
+	return float64(p.cur) / float64(p.max)
+}
+
+func (p *ProgressBar) bar() string {
+	segments := int(float64(p.barSegments) * p.percentage())
+
+	if p.percentage() > 0 && segments == 0 {
+		segments = 1
+	}
+
+	bar := make([]byte, p.barSegments+2)
+	bar[0] = '['
+	bar[p.barSegments+1] = ']'
+	b := bar[1 : len(bar)-1]
+	for i := range b {
+		switch {
+		case i == segments-1:
+			b[i] = '>'
+		case i < segments:
+			b[i] = '='
+		default:
+			b[i] = ' '
+		}
+	}
+
+	return string(bar)
+}
+
+func (ProgressBar) clearLine() {
+	fmt.Fprint(os.Stderr, "\r")
+}
+
+func (p *ProgressBar) print() {
+	d := p.description
+	if len(d) > 0 {
+		d = "  " + d
+	}
+	fmt.Fprintf(os.Stderr, "%s  %.1f %% %s", d, p.percentage()*100, p.bar())
+	for _, f := range p.additionalInfo {
+		fmt.Fprintf(os.Stderr, "  %s", f())
+	}
+}
+
+func (p *ProgressBar) run() {
+	defer close(p.running)
+	for {
+		p.clearLine()
+		p.print()
+		var tick <-chan time.Time
+		if p.tickInterval > 0 {
+			tick = time.After(p.tickInterval)
+		}
+		select {
+		case <-p.close:
+			return
+		case <-tick:
+		case <-p.update:
+		}
+	}
+}
+
+func (p *ProgressBar) Update(cur uint64) {
+	p.Set(cur, p.max)
+}
+
+func (p *ProgressBar) Set(cur, max uint64) {
+	p.cur, p.max = cur, max
+	select {
+	case p.update <- struct{}{}:
+	default:
+	}
+}
+
+func (p *ProgressBar) Finish() {
+	p.Set(p.max, p.max)
+	p.Stop()
+	<-p.running
+	fmt.Fprintln(os.Stderr)
+}
+
+func (p *ProgressBar) Start() {
+	go p.run()
+}
+
+func (p *ProgressBar) Stop() {
+	close(p.close)
+}

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -104,6 +104,7 @@ func Colorize(text string) string {
 		"[purple]", "\x1b[38;5;129m",
 		"[bold]", "\x1b[1m",
 		"[red]", "\x1b[38;5;1m",
+		"[yellow]", "\x1b[33m",
 		"[green]", "\x1b[38;5;2m",
 		"[underline]", "\x1b[4m",
 	)

--- a/prompt/units.go
+++ b/prompt/units.go
@@ -1,0 +1,18 @@
+package prompt
+
+func AddSISuffix(v float64, binary bool) (val float64, suffix string) {
+	var unit float64
+	if binary {
+		unit = 1024
+	} else {
+		unit = 1000
+	}
+
+	div, exp := unit, 0
+	for n := v / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+
+	return v / div, string("kMGTPE"[exp])
+}


### PR DESCRIPTION
- Show progress bar while querying historical data (use `--no-progress` to omit progress bar)
- Show EPS,  B/s when searching
- Only output historical data when query has finished, sorted by `@timestamp`
- Added additional fields to the `QueryResultMetadata` struct
- Added a helper function that determines if a Humio status is down or not
- Print all fields of an aggregate result. Some events have nil values for a column, which led to the column been excluded if event[0] didn't have the column.