### PR TITLE
Add README instructions for installing via Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ $ brew install humioctl
 $ sudo snap install humioctl
 ```
 
+### Nix
+
+```bash
+$ nix-env -i humioctl
+```
 
 ## Usage
 


### PR DESCRIPTION
I've added a Nix package for humioctl in [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/logging/humioctl/default.nix) for version 0.25.0. This PR adds installation instructions for Nix to the README.