### PR TITLE
Add color support for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,13 @@ all: build
 
 $(BIN_PATH): FORCE
 	@echo "--> Building Humio CLI"
-	go build -o $(BIN_PATH) cmd/humioctl/*.go
+	go build -o $(BIN_PATH) ./cmd/humioctl
 
 build: $(BIN_PATH)
+
+build-windows:
+	@echo "--> Building Humio CLI (Windows)"
+	GOOS=windows GOARCH=amd64 go build -o $(BIN_PATH).exe ./cmd/humioctl
 
 clean:
 	@echo "--> Cleaning"
@@ -33,6 +37,6 @@ e2e: $(BIN_PATH)
 e2e-upcoming: $(BIN_PATH)
 	./e2e/run-upcoming-features.bash
 
-.PHONY: build clean snapshot run e2e e2e-upcoming FORCE
+.PHONY: build clean snapshot run e2e e2e-upcoming build-windows FORCE
 
 FORCE:

--- a/cmd/humioctl/init_windows.go
+++ b/cmd/humioctl/init_windows.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// init in init_windows.go ensures that PowerShell and CMD emulate colors and handle
+// other escape codes properly.
+func init() {
+	stdout := windows.Handle(os.Stdout.Fd())
+	var originalMode uint32
+
+	windows.GetConsoleMode(stdout, &originalMode)
+	windows.SetConsoleMode(stdout, originalMode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4
+	golang.org/x/sys v0.0.0-20190412213103-97732733099d
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.2.4


### PR DESCRIPTION
This PR adds escape and color handling for windows terminals.

The additional make target is to allow cross-compiling to windows while testing on linux.