### PR TITLE
update gets to parser asset, to use id rather than name as input

### DIFF
--- a/api/parsers.go
+++ b/api/parsers.go
@@ -119,7 +119,7 @@ func (p *Parsers) Get(reposistoryName string, parserName string) (*Parser, error
 				SourceCode string
 				TestData   []string
 				TagFields  []string
-			} `graphql:"parser(name: $parserName)"`
+			} `graphql:"parser(id: $parserName)"`
 		} `graphql:"repository(name: $repositoryName)"`
 	}
 
@@ -164,7 +164,7 @@ func (p *Parsers) Export(reposistoryName string, parserName string) (string, err
 		Repository struct {
 			Parser struct {
 				YamlTemplate string
-			} `graphql:"parser(name: $parserName)"`
+			} `graphql:"parser(id: $parserName)"`
 		} `graphql:"repository(name: $repositoryName)"`
 	}
 


### PR DESCRIPTION
Aligns CLI with changes made to parser endpoint in Humio.
Have only updated endpoint calls, not variable naming and the like, as I'm not sure of the impact of this. I.e changing parserName to parserId. 