### PR TITLE
Accounting for changes to Parser API queries and mutations

### DIFF
--- a/api/parsers.go
+++ b/api/parsers.go
@@ -60,7 +60,7 @@ func (p *Parsers) Remove(reposistoryName string, parserId string) error {
 
 	variables := map[string]interface{}{
 		"repositoryName": graphql.String(reposistoryName),
-		"id":           graphql.String(parserId),
+		"id":             graphql.String(parserId),
 	}
 
 	return p.client.Mutate(&mutation, variables)
@@ -124,7 +124,7 @@ func (p *Parsers) Get(reposistoryName string, parserId string) (*Parser, error) 
 	}
 
 	variables := map[string]interface{}{
-		"parserId":     graphql.String(parserId),
+		"parserId":       graphql.String(parserId),
 		"repositoryName": graphql.String(reposistoryName),
 	}
 
@@ -169,7 +169,7 @@ func (p *Parsers) Export(reposistoryName string, parserId string) (string, error
 	}
 
 	variables := map[string]interface{}{
-		"parserId":     graphql.String(parserId),
+		"parserId":       graphql.String(parserId),
 		"repositoryName": graphql.String(reposistoryName),
 	}
 

--- a/api/parsers.go
+++ b/api/parsers.go
@@ -51,16 +51,16 @@ func (p *Parsers) List(reposistoryName string) ([]ParserListItem, error) {
 	return parsers, graphqlErr
 }
 
-func (p *Parsers) Remove(reposistoryName string, parserName string) error {
+func (p *Parsers) Remove(reposistoryName string, parserId string) error {
 	var mutation struct {
 		RemoveParser struct {
 			Type string `graphql:"__typename"`
-		} `graphql:"removeParser(input: { name: $name, repositoryName: $repositoryName })"`
+		} `graphql:"removeParser(input: { id: $id, repositoryName: $repositoryName })"`
 	}
 
 	variables := map[string]interface{}{
 		"repositoryName": graphql.String(reposistoryName),
-		"name":           graphql.String(parserName),
+		"id":           graphql.String(parserId),
 	}
 
 	return p.client.Mutate(&mutation, variables)
@@ -110,7 +110,7 @@ func testCasesToStrings(parser *Parser) []graphql.String {
 	return result
 }
 
-func (p *Parsers) Get(reposistoryName string, parserName string) (*Parser, error) {
+func (p *Parsers) Get(reposistoryName string, parserId string) (*Parser, error) {
 
 	var query struct {
 		Repository struct {
@@ -119,12 +119,12 @@ func (p *Parsers) Get(reposistoryName string, parserName string) (*Parser, error
 				SourceCode string
 				TestData   []string
 				TagFields  []string
-			} `graphql:"parser(id: $parserName)"`
+			} `graphql:"parser(id: $parserId)"`
 		} `graphql:"repository(name: $repositoryName)"`
 	}
 
 	variables := map[string]interface{}{
-		"parserName":     graphql.String(parserName),
+		"parserId":     graphql.String(parserId),
 		"repositoryName": graphql.String(reposistoryName),
 	}
 
@@ -158,18 +158,18 @@ func toTestCase(line string) ParserTestCase {
 	}
 }
 
-func (p *Parsers) Export(reposistoryName string, parserName string) (string, error) {
+func (p *Parsers) Export(reposistoryName string, parserId string) (string, error) {
 
 	var query struct {
 		Repository struct {
 			Parser struct {
 				YamlTemplate string
-			} `graphql:"parser(id: $parserName)"`
+			} `graphql:"parser(id: $parserId)"`
 		} `graphql:"repository(name: $repositoryName)"`
 	}
 
 	variables := map[string]interface{}{
-		"parserName":     graphql.String(parserName),
+		"parserId":     graphql.String(parserId),
 		"repositoryName": graphql.String(reposistoryName),
 	}
 

--- a/cmd/humioctl/parsers_export.go
+++ b/cmd/humioctl/parsers_export.go
@@ -31,16 +31,16 @@ func newParsersExportCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			repo := args[0]
-			parserName := args[1]
+			parserId := args[1]
 
 			if outputName == "" {
-				outputName = parserName
+				outputName = parserId
 			}
 
 			// Get the HTTP client
 			client := NewApiClient(cmd)
 
-			yamlData, apiErr := client.Parsers().Export(repo, parserName)
+			yamlData, apiErr := client.Parsers().Export(repo, parserId)
 			if apiErr != nil {
 				cmd.Println(fmt.Errorf("Error fetching parsers: %s", apiErr))
 				os.Exit(1)

--- a/cmd/humioctl/parsers_remove.go
+++ b/cmd/humioctl/parsers_remove.go
@@ -25,11 +25,11 @@ func newParsersRemoveCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			repo := args[0]
-			parser := args[1]
+			parserId := args[1]
 
 			client := NewApiClient(cmd)
 
-			apiError := client.Parsers().Remove(repo, parser)
+			apiError := client.Parsers().Remove(repo, parserId)
 			exitOnError(cmd, apiError, "Error removing parser")
 		},
 	}


### PR DESCRIPTION
Not ready for merge, API changes have to get into Humio first.
* Updates parser code to fit with future changes in Humio API. Using parser Id rather than parser name on queries and mutations.