### PR TITLE
Get current partition layouts

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -245,3 +245,27 @@ func (c *Clusters) SuggestedStoragePartitions() ([]StoragePartitionInput, error)
 
 	return q.Cluster.SuggestedStoragePartitions, err
 }
+
+func (c *Clusters) CurrentIngestPartitions() ([]IngestPartition, error) {
+	var q struct {
+		Cluster struct {
+			IngestPartitions []IngestPartition `graphql:"ingestPartitions"`
+		} `graphql:"cluster"`
+	}
+
+	err := c.client.Query(&q, nil)
+
+	return q.Cluster.IngestPartitions, err
+}
+
+func (c *Clusters) CurrentStoragePartitions() ([]StoragePartition, error) {
+	var q struct {
+		Cluster struct {
+			StoragePartitions []StoragePartition `graphql:"storagePartitions"`
+		} `graphql:"cluster"`
+	}
+
+	err := c.client.Query(&q, nil)
+
+	return q.Cluster.StoragePartitions, err
+}


### PR DESCRIPTION
Not sure if we want to name these method's `IngestPartitions()`, `CurrentIngestPartitions()`, or something completely different.

Let me know what you think.