### PR TITLE
Add path prefix to client http requests

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -71,7 +71,7 @@ func (c *Client) headers() map[string]string {
 
 func (c *Client) newGraphQLClient() (*graphql.Client, error) {
 	httpClient := c.newHTTPClientWithHeaders(c.headers())
-	graphqlURL, err := c.Address().Parse("/graphql")
+	graphqlURL, err := c.Address().Parse(c.Address().EscapedPath()+"/graphql")
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (c *Client) HTTPRequestContext(ctx context.Context, httpMethod string, path
 		body = bytes.NewReader(nil)
 	}
 
-	url, err := c.Address().Parse(path)
+	url, err := c.Address().Parse(c.Address().EscapedPath()+path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Multiple Humio's might share the same domain using a path prefix.
One example is: https://test01.humio.com/humio/

This commit is a very quick fix, but should ve revised by someone with
more Go experience than mine (almost zero).