### PR TITLE
Client api improvements for notifiers and alerts

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -53,7 +53,7 @@ func (c *Client) Config() Config {
 }
 
 func NewClient(config Config) *Client {
-	if !strings.HasSuffix(config.Address.Path, "/") {
+	if config.Address != nil && !strings.HasSuffix(config.Address.Path, "/") {
 		config.Address.Path = config.Address.Path + "/"
 	}
 


### PR DESCRIPTION
* Removed fatal exits from the notifier and alerts code. Since the client api is used by other projects, we should not do `log.Fatal` since it crashes the code which depends on this api.
* Changed where we check if the config address is set first before trying to load the config. Otherwise it panics.
* Only try to get a notifier's ID when the ID is not set
* Updated so we return the error string in the case the humio api calls fail. This is important when a request is rejected for validation reasons (like a missing or invalid field) but the error returned by the humio api is not a json response.