### PR TITLE
Error running humioctl packages list-installed <my-viewname>

### DIFF
--- a/api/packages.go
+++ b/api/packages.go
@@ -115,7 +115,7 @@ func (p *Packages) ListInstalled(viewName string) ([]InstalledPackage, error) {
 	var q struct {
 		Repository struct {
 			InstalledPackages []InstalledPackage
-		} `graphql:"repository(name: $repositoryName)"`
+		} `graphql:"searchDomain(name: $repositoryName)"`
 	}
 
 	variables := map[string]interface{}{


### PR DESCRIPTION
There was an error in the graphql which results in the following command always failing:
```bash
humioctl packages list-installed <my-view-name>
Error: Error fetching packages: There were errors in the input.
```