### PR TITLE
Add client with transport option and default http timeout

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -57,6 +57,11 @@ func (c *Client) Config() Config {
 }
 
 func NewClient(config Config) *Client {
+	httpTransport := NewHttpTransport(config)
+	return NewClientWithTransport(config, httpTransport)
+}
+
+func NewClientWithTransport(config Config, httpTransport *http.Transport) *Client {
 	if config.Address != nil && !strings.HasSuffix(config.Address.Path, "/") {
 		config.Address.Path = config.Address.Path + "/"
 	}
@@ -64,8 +69,6 @@ func NewClient(config Config) *Client {
 	if config.UserAgent == "" {
 		config.UserAgent = defaultUserAgent
 	}
-
-	httpTransport := newHttpTransport(config)
 
 	return &Client{
 		config:        config,

--- a/api/httpclient.go
+++ b/api/httpclient.go
@@ -16,7 +16,7 @@ type headerTransport struct {
 	headers map[string]string
 }
 
-func newHttpTransport(config Config) *http.Transport {
+func NewHttpTransport(config Config) *http.Transport {
 	dialContext := config.DialContext
 	if dialContext == nil {
 		dialContext = (&net.Dialer{

--- a/api/httpclient.go
+++ b/api/httpclient.go
@@ -82,6 +82,7 @@ func (c *Client) newHTTPClientWithHeaders(headers map[string]string) *http.Clien
 			base:    c.httpTransport,
 			headers: headers,
 		},
+		Timeout: 30 * time.Second,
 	}
 }
 


### PR DESCRIPTION
Adds ability to pass in a transport when setting up the HTTP connection. Also adds a default HTTP timeout.

This allows clients using the API to reuse transports. This is intended as per https://pkg.go.dev/net/http#Transport:
>By default, Transport caches connections for future re-use. This may leave many open connections when accessing many hosts. This behavior can be managed using Transport's CloseIdleConnections method and the MaxIdleConnsPerHost and DisableKeepAlives fields.
>
>Transports should be reused instead of created as needed. Transports are safe for concurrent use by multiple goroutines.
