### PR TITLE
Stop querying deprecated clientMutationId

### DIFF
--- a/api/files.go
+++ b/api/files.go
@@ -43,7 +43,8 @@ func (f *Files) List(viewName string) ([]File, error) {
 func (f *Files) Delete(viewName string, fileName string) error {
 	var q struct {
 		RemoveFile struct {
-			TypeName string `graphql:"__typename"`
+			// We have to make a selection, so just take __typename
+			Typename graphql.String `graphql:"__typename"`
 		} `graphql:"removeFile(name:$viewName, fileName: $fileName)"`
 	}
 

--- a/api/ingest-tokens.go
+++ b/api/ingest-tokens.go
@@ -109,7 +109,8 @@ func (i *IngestTokens) Add(repositoryName string, tokenName string, parserName s
 func (i *IngestTokens) Update(repositoryName string, tokenName string, parserName string) (*IngestToken, error) {
 	var mutation struct {
 		Result struct {
-			Type string `graphql:"__typename"`
+			// We have to make a selection, so just take __typename
+			Typename graphql.String `graphql:"__typename"`
 		} `graphql:"assignIngestToken(repositoryName: $repositoryName, tokenName: $tokenName, parserName: $parserName)"`
 	}
 
@@ -130,7 +131,8 @@ func (i *IngestTokens) Update(repositoryName string, tokenName string, parserNam
 func (i *IngestTokens) Remove(repositoryName string, tokenName string) error {
 	var mutation struct {
 		Result struct {
-			Type string `graphql:"__typename"`
+			// We have to make a selection, so just take __typename
+			Typename graphql.String `graphql:"__typename"`
 		} `graphql:"removeIngestToken(repositoryName: $repositoryName, name: $tokenName)"`
 	}
 

--- a/api/license.go
+++ b/api/license.go
@@ -35,7 +35,8 @@ func (l *Licenses) Install(license string) error {
 
 	var mutation struct {
 		UpdateLicenseKey struct {
-			Type string `graphql:"__typename"`
+			// We have to make a selection, so just take __typename
+			Typename graphql.String `graphql:"__typename"`
 		} `graphql:"updateLicenseKey(license: $license)"`
 	}
 	variables := map[string]interface{}{

--- a/api/parsers.go
+++ b/api/parsers.go
@@ -52,7 +52,8 @@ func (p *Parsers) List(reposistoryName string) ([]ParserListItem, error) {
 func (p *Parsers) Remove(reposistoryName string, parserName string) error {
 	var mutation struct {
 		RemoveParser struct {
-			Type string `graphql:"__typename"`
+			// We have to make a selection, so just take __typename
+			Typename graphql.String `graphql:"__typename"`
 		} `graphql:"removeParser(input: { name: $name, repositoryName: $repositoryName })"`
 	}
 
@@ -68,7 +69,8 @@ func (p *Parsers) Add(reposistoryName string, parser *Parser, force bool) error 
 
 	var mutation struct {
 		CreateParser struct {
-			Type string `graphql:"__typename"`
+			// We have to make a selection, so just take __typename
+			Typename graphql.String `graphql:"__typename"`
 		} `graphql:"createParser(input: { name: $name, repositoryName: $repositoryName, testData: $testData, tagFields: $tagFields, sourceCode: $sourceCode, force: $force})"`
 	}
 

--- a/api/repositories.go
+++ b/api/repositories.go
@@ -91,7 +91,8 @@ func (r *Repositories) Delete(name, reason string, allowDataDeletion bool) error
 
 	var m struct {
 		DeleteSearchDomain struct {
-			ClientMutationId string
+			// We have to make a selection, so just take __typename
+			Typename graphql.String `graphql:"__typename"`
 		} `graphql:"deleteSearchDomain(name: $name, deleteMessage: $reason)"`
 	}
 	variables := map[string]interface{}{
@@ -143,7 +144,8 @@ func (r *Repositories) UpdateUserGroup(name, username string, groups ...DefaultG
 
 	var mutation struct {
 		UpdateDefaultGroupMembershipsMutation struct {
-			ClientMutationId string
+			// We have to make a selection, so just take __typename
+			Typename graphql.String `graphql:"__typename"`
 		} `graphql:"updateDefaultGroupMemberships(input: {viewName: $name, userName: $username, groups: $groups})"`
 	}
 	variables := map[string]interface{}{
@@ -164,7 +166,8 @@ func (r *Repositories) UpdateTimeBasedRetention(name string, retentionInDays flo
 
 	var m struct {
 		UpdateRetention struct {
-			Type string `graphql:"__typename"`
+			// We have to make a selection, so just take __typename
+			Typename graphql.String `graphql:"__typename"`
 		} `graphql:"updateRetention(repositoryName: $name, timeBasedRetention: $retentionInDays)"`
 	}
 	variables := map[string]interface{}{
@@ -197,7 +200,8 @@ func (r *Repositories) UpdateStorageBasedRetention(name string, storageInGB floa
 
 	var m struct {
 		UpdateRetention struct {
-			Type string `graphql:"__typename"`
+			// We have to make a selection, so just take __typename
+			Typename graphql.String `graphql:"__typename"`
 		} `graphql:"updateRetention(repositoryName: $name, storageSizeBasedRetention: $storageInGB)"`
 	}
 	variables := map[string]interface{}{
@@ -230,7 +234,8 @@ func (r *Repositories) UpdateIngestBasedRetention(name string, ingestInGB float6
 
 	var m struct {
 		UpdateRetention struct {
-			Type string `graphql:"__typename"`
+			// We have to make a selection, so just take __typename
+			Typename graphql.String `graphql:"__typename"`
 		} `graphql:"updateRetention(repositoryName: $name, ingestSizeBasedRetention: $ingestInGB)"`
 	}
 	variables := map[string]interface{}{
@@ -257,7 +262,8 @@ func (r *Repositories) UpdateIngestBasedRetention(name string, ingestInGB float6
 func (r *Repositories) UpdateDescription(name, description string) error {
 	var m struct {
 		UpdateDescription struct {
-			Type string `graphql:"__typename"`
+			// We have to make a selection, so just take __typename
+			Typename graphql.String `graphql:"__typename"`
 		} `graphql:"updateDescriptionForSearchDomain(name: $name, newDescription: $description)"`
 	}
 

--- a/api/users.go
+++ b/api/users.go
@@ -95,7 +95,6 @@ func (u *Users) Add(username string, changeset UserChangeSet) (User, error) {
 func (u *Users) Remove(username string) (User, error) {
 	var mutation struct {
 		Result struct {
-			// We have to make a selection, so just take __typename
 			User User
 		} `graphql:"removeUser(input: {username: $username})"`
 	}

--- a/api/views.go
+++ b/api/views.go
@@ -124,7 +124,8 @@ func (c *Views) Create(name, description string, connections map[string]string) 
 func (c *Views) Delete(name, reason string) error {
 	var m struct {
 		DeleteSearchDomain struct {
-			ClientMutationId string
+			// We have to make a selection, so just take __typename
+			Typename graphql.String `graphql:"__typename"`
 		} `graphql:"deleteSearchDomain(name: $name, deleteMessage: $reason)"`
 	}
 	variables := map[string]interface{}{
@@ -175,7 +176,8 @@ func (c *Views) UpdateConnections(name string, connections map[string]string) er
 func (c *Views) UpdateDescription(name string, description string) error {
 	var m struct {
 		UpdateDescriptionMutation struct {
-			ClientMutationId string
+			// We have to make a selection, so just take __typename
+			Typename graphql.String `graphql:"__typename"`
 		} `graphql:"updateDescriptionForSearchDomain(name: $name, newDescription: $description)"`
 	}
 


### PR DESCRIPTION
I also updated the many, slightly different, ways of fetching `__typename` to be more consistent.