### PR TITLE
Parsers.Get should return an error for non-existant parser.

### DIFF
--- a/api/error.go
+++ b/api/error.go
@@ -1,0 +1,37 @@
+package api
+
+import "fmt"
+
+type EntityType string
+
+const (
+	EntityTypeParser EntityType = "parser"
+)
+
+func (e EntityType) String() string {
+	return string(e)
+}
+
+type EntityNotFound struct {
+	entityType EntityType
+	key        string
+}
+
+func (e EntityNotFound) EntityType() EntityType {
+	return e.entityType
+}
+
+func (e EntityNotFound) Key() string {
+	return e.key
+}
+
+func (e EntityNotFound) Error() string {
+	return fmt.Sprintf("%s %q not found", e.entityType.String(), e.key)
+}
+
+func ParserNotFound(name string) error {
+	return EntityNotFound{
+		entityType: EntityTypeParser,
+		key:        name,
+	}
+}

--- a/api/parsers.go
+++ b/api/parsers.go
@@ -98,7 +98,7 @@ func (p *Parsers) Add(reposistoryName string, parser *Parser, force bool) error 
 	return p.client.Mutate(&mutation, variables)
 }
 
-func (p *Parsers) Get(reposistoryName string, parserName string) (*Parser, error) {
+func (p *Parsers) Get(repositoryName string, parserName string) (*Parser, error) {
 
 	var query struct {
 		Repository struct {
@@ -113,7 +113,7 @@ func (p *Parsers) Get(reposistoryName string, parserName string) (*Parser, error
 
 	variables := map[string]interface{}{
 		"parserName":     graphql.String(parserName),
-		"repositoryName": graphql.String(reposistoryName),
+		"repositoryName": graphql.String(repositoryName),
 	}
 
 	graphqlErr := p.client.Query(&query, variables)


### PR DESCRIPTION
- Fixed typo
- Make Parsers Get/Export return a not found error
