### PR TITLE
Various cleanup/streamlining

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,22 +9,15 @@ $(BIN_PATH): $(GOFILES)
 all: build
 
 $(BIN_PATH): FORCE
-	@echo "--> Building Humio CLI"
 	go build -o $(BIN_PATH) ./cmd/humioctl
 
 build: $(BIN_PATH)
 
-build-windows:
-	@echo "--> Building Humio CLI (Windows)"
-	GOOS=windows GOARCH=amd64 go build -o $(BIN_PATH).exe ./cmd/humioctl
-
 clean:
-	@echo "--> Cleaning"
 	go clean
 	@rm -rf bin/
 
 snapshot:
-	@echo "--> Building snapshot"
 	goreleaser build --rm-dist --snapshot
 	@rm -rf bin/
 
@@ -37,6 +30,6 @@ e2e: $(BIN_PATH)
 e2e-upcoming: $(BIN_PATH)
 	./e2e/run-upcoming-features.bash
 
-.PHONY: build clean snapshot run e2e e2e-upcoming build-windows FORCE
+.PHONY: build clean snapshot run e2e e2e-upcoming FORCE
 
 FORCE:

--- a/api/alerts.go
+++ b/api/alerts.go
@@ -46,19 +46,19 @@ func (a *Alerts) List(viewName string) ([]Alert, error) {
 func (a *Alerts) Update(viewName string, alert *Alert) (*Alert, error) {
 	existingID, err := a.convertAlertNameToID(viewName, alert.Name)
 	if err != nil {
-		return nil, fmt.Errorf("could not convert alert name to id: %v", err)
+		return nil, fmt.Errorf("could not convert alert name to id: %w", err)
 	}
 
 	jsonStr, err := a.marshalToJSON(alert)
 	if err != nil {
-		return nil, fmt.Errorf("unable to convert alert to json string: %v", err)
+		return nil, fmt.Errorf("unable to convert alert to json string: %w", err)
 	}
 
 	url := fmt.Sprintf("api/v1/repositories/%s/alerts/%s", viewName, existingID)
 
 	res, err := a.client.HTTPRequest(http.MethodPut, url, bytes.NewBuffer(jsonStr))
 	if err != nil {
-		return nil, fmt.Errorf("could not add alert in view %s with name %s, got: %v", viewName, alert.Name, err)
+		return nil, fmt.Errorf("could not add alert in view %s with name %s, got: %w", viewName, alert.Name, err)
 	}
 	return a.unmarshalToAlert(res)
 }
@@ -66,7 +66,7 @@ func (a *Alerts) Update(viewName string, alert *Alert) (*Alert, error) {
 func (a *Alerts) Add(viewName string, alert *Alert, updateExisting bool) (*Alert, error) {
 	nameAlreadyInUse, err := a.alertNameInUse(viewName, alert.Name)
 	if err != nil {
-		return nil, fmt.Errorf("could not determine if alert name is in use: %v", err)
+		return nil, fmt.Errorf("could not determine if alert name is in use: %w", err)
 	}
 
 	if nameAlreadyInUse {
@@ -78,14 +78,14 @@ func (a *Alerts) Add(viewName string, alert *Alert, updateExisting bool) (*Alert
 
 	jsonStr, err := a.marshalToJSON(alert)
 	if err != nil {
-		return nil, fmt.Errorf("unable to convert alert to json string: %v", err)
+		return nil, fmt.Errorf("unable to convert alert to json string: %w", err)
 	}
 
 	url := fmt.Sprintf("api/v1/repositories/%s/alerts/", viewName)
 
 	res, err := a.client.HTTPRequest(http.MethodPost, url, bytes.NewBuffer(jsonStr))
 	if err != nil {
-		return nil, fmt.Errorf("could not add alert in view %s with name %s, got: %v", viewName, alert.Name, err)
+		return nil, fmt.Errorf("could not add alert in view %s with name %s, got: %w", viewName, alert.Name, err)
 	}
 
 	return a.unmarshalToAlert(res)
@@ -101,7 +101,7 @@ func (a *Alerts) Get(viewName, alertName string) (*Alert, error) {
 
 	res, err := a.client.HTTPRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("could not get alert with id %s, got: %v", alertID, err)
+		return nil, fmt.Errorf("could not get alert with id %s, got: %w", alertID, err)
 	}
 
 	return a.unmarshalToAlert(res)
@@ -121,8 +121,9 @@ func (a *Alerts) Delete(viewName, alertName string) error {
 	}
 
 	if err != nil || res.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("could not delete alert in view %s with id %s, got: %v", viewName, alertID, err)
+		return fmt.Errorf("could not delete alert in view %s with id %s, got: %w", viewName, alertID, err)
 	}
+
 	return nil
 }
 
@@ -134,7 +135,7 @@ func (a *Alerts) marshalToJSON(alert *Alert) ([]byte, error) {
 
 	jsonStr, err := json.Marshal(alert)
 	if err != nil {
-		return nil, fmt.Errorf("unable to convert alert to json string: %v", err)
+		return nil, fmt.Errorf("unable to convert alert to json string: %w", err)
 	}
 	return jsonStr, nil
 }
@@ -149,7 +150,7 @@ func (a *Alerts) unmarshalToAlertList(res *http.Response) ([]Alert, error) {
 
 	err = json.Unmarshal(body, &alertList)
 	if err != nil {
-		return alertList, fmt.Errorf("error in json response: %v. response: %v", err, string(body))
+		return alertList, fmt.Errorf("error in json response: %w. response: %v", err, string(body))
 	}
 
 	return alertList, nil
@@ -165,7 +166,7 @@ func (a *Alerts) unmarshalToAlert(res *http.Response) (*Alert, error) {
 
 	err = json.Unmarshal(body, &alert)
 	if err != nil {
-		return &alert, fmt.Errorf("error in json response: %v. response: %v", err, string(body))
+		return &alert, fmt.Errorf("error in json response: %w. response: %v", err, string(body))
 	}
 	return &alert, nil
 }
@@ -173,7 +174,7 @@ func (a *Alerts) unmarshalToAlert(res *http.Response) (*Alert, error) {
 func (a *Alerts) convertAlertNameToID(viewName, alertName string) (string, error) {
 	listOfAlerts, err := a.List(viewName)
 	if err != nil {
-		return "", fmt.Errorf("could not list all alerts for view %s: %v", viewName, err)
+		return "", fmt.Errorf("could not list all alerts for view %s: %w", viewName, err)
 	}
 	for _, v := range listOfAlerts {
 		if v.Name == alertName {
@@ -186,7 +187,7 @@ func (a *Alerts) convertAlertNameToID(viewName, alertName string) (string, error
 func (a *Alerts) alertNameInUse(viewName, alertName string) (bool, error) {
 	listOfAlerts, err := a.List(viewName)
 	if err != nil {
-		return true, fmt.Errorf("could not list all alerts for view %s: %v", viewName, err)
+		return true, fmt.Errorf("could not list all alerts for view %s: %w", viewName, err)
 	}
 	for _, v := range listOfAlerts {
 		if v.Name == alertName {

--- a/api/client.go
+++ b/api/client.go
@@ -108,8 +108,7 @@ func (c *Client) Query(query interface{}, variables map[string]interface{}) erro
 	if err != nil {
 		return err
 	}
-	graphqlErr := client.Query(context.Background(), query, variables)
-	return graphqlErr
+	return client.Query(context.Background(), query, variables)
 }
 
 func (c *Client) Mutate(mutation interface{}, variables map[string]interface{}) error {
@@ -117,8 +116,7 @@ func (c *Client) Mutate(mutation interface{}, variables map[string]interface{}) 
 	if err != nil {
 		return err
 	}
-	graphqlErr := client.Mutate(context.Background(), mutation, variables)
-	return graphqlErr
+	return client.Mutate(context.Background(), mutation, variables)
 }
 
 // JSONContentType is "application/json"
@@ -145,7 +143,6 @@ func (c *Client) HTTPRequestContext(ctx context.Context, httpMethod string, path
 	}
 
 	headers := c.headers()
-
 	headers["Content-Type"] = contentType
 
 	var client = c.newHTTPClientWithHeaders(headers)

--- a/api/files.go
+++ b/api/files.go
@@ -25,7 +25,7 @@ type File struct {
 func (c *Client) Files() *Files { return &Files{client: c} }
 
 func (f *Files) List(viewName string) ([]File, error) {
-	var q struct {
+	var query struct {
 		Repository struct {
 			Files []File
 		} `graphql:"repository(name:$viewName)"`
@@ -35,13 +35,12 @@ func (f *Files) List(viewName string) ([]File, error) {
 		"viewName": graphql.String(viewName),
 	}
 
-	err := f.client.Query(&q, variables)
-
-	return q.Repository.Files, err
+	err := f.client.Query(&query, variables)
+	return query.Repository.Files, err
 }
 
 func (f *Files) Delete(viewName string, fileName string) error {
-	var q struct {
+	var query struct {
 		RemoveFile struct {
 			// We have to make a selection, so just take __typename
 			Typename graphql.String `graphql:"__typename"`
@@ -53,9 +52,7 @@ func (f *Files) Delete(viewName string, fileName string) error {
 		"fileName": graphql.String(fileName),
 	}
 
-	err := f.client.Mutate(&q, variables)
-
-	return err
+	return f.client.Mutate(&query, variables)
 }
 
 func (f *Files) Upload(viewName string, fileName string, reader io.Reader) error {

--- a/api/groups.go
+++ b/api/groups.go
@@ -10,7 +10,7 @@ type Groups struct {
 }
 
 type Group struct {
-	ID   string
+	ID          string
 	DisplayName string
 }
 
@@ -19,18 +19,18 @@ func (c *Client) Groups() *Groups { return &Groups{client: c} }
 var ErrUserNotFound = errors.New("user not found")
 
 func (g *Groups) List() ([]Group, error) {
-	var q struct {
+	var query struct {
 		Page struct {
 			Groups []Group `graphql:"page"`
 		} `graphql:"groupsPage(pageNumber:1,pageSize:2147483647)"`
 	}
 
-	err := g.client.Query(&q, nil)
+	err := g.client.Query(&query, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return q.Page.Groups, nil
+	return query.Page.Groups, nil
 }
 
 func (g *Groups) AddUserToGroup(groupID string, userID string) error {

--- a/api/ingest-tokens.go
+++ b/api/ingest-tokens.go
@@ -38,7 +38,6 @@ func (i *IngestTokens) List(repo string) ([]IngestToken, error) {
 	}
 
 	err := i.client.Query(&query, variables)
-
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +97,6 @@ func (i *IngestTokens) Add(repositoryName string, tokenName string, parserName s
 	}
 
 	err := i.client.Mutate(&mutation, variables)
-
 	if err != nil {
 		return nil, err
 	}
@@ -107,22 +105,41 @@ func (i *IngestTokens) Add(repositoryName string, tokenName string, parserName s
 }
 
 func (i *IngestTokens) Update(repositoryName string, tokenName string, parserName string) (*IngestToken, error) {
-	var mutation struct {
-		Result struct {
-			// We have to make a selection, so just take __typename
-			Typename graphql.String `graphql:"__typename"`
-		} `graphql:"assignIngestToken(repositoryName: $repositoryName, tokenName: $tokenName, parserName: $parserName)"`
-	}
+	if parserName == "" {
+		var mutation struct {
+			Result struct {
+				// We have to make a selection, so just take __typename
+				Typename graphql.String `graphql:"__typename"`
+			} `graphql:"unassignIngestToken(repositoryName: $repositoryName, tokenName: $tokenName)"`
+		}
 
-	variables := map[string]interface{}{
-		"tokenName":      graphql.String(tokenName),
-		"repositoryName": graphql.String(repositoryName),
-		"parserName":     graphql.String(parserName),
-	}
+		variables := map[string]interface{}{
+			"tokenName":      graphql.String(tokenName),
+			"repositoryName": graphql.String(repositoryName),
+		}
 
-	err := i.client.Mutate(&mutation, variables)
-	if err != nil {
-		return nil, err
+		err := i.client.Mutate(&mutation, variables)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		var mutation struct {
+			Result struct {
+				// We have to make a selection, so just take __typename
+				Typename graphql.String `graphql:"__typename"`
+			} `graphql:"assignIngestToken(repositoryName: $repositoryName, tokenName: $tokenName, parserName: $parserName)"`
+		}
+
+		variables := map[string]interface{}{
+			"tokenName":      graphql.String(tokenName),
+			"repositoryName": graphql.String(repositoryName),
+			"parserName":     graphql.String(parserName),
+		}
+
+		err := i.client.Mutate(&mutation, variables)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return i.Get(repositoryName, tokenName)

--- a/api/license.go
+++ b/api/license.go
@@ -60,7 +60,6 @@ func (l *Licenses) Get() (License, error) {
 	}
 
 	err := l.client.Query(&query, nil)
-
 	if err != nil {
 		return nil, err
 	}

--- a/api/notifiers.go
+++ b/api/notifiers.go
@@ -45,14 +45,14 @@ func (n *Notifiers) Update(viewName string, notifier *Notifier) (*Notifier, erro
 	if notifier.ID == "" {
 		existingID, err := n.convertNotifierNameToID(viewName, notifier.Name)
 		if err != nil {
-			return nil, fmt.Errorf("could not convert notifier name to id: %v", err)
+			return nil, fmt.Errorf("could not convert notifier name to id: %w", err)
 		}
 		notifier.ID = existingID
 	}
 
 	jsonStr, err := n.marshalToJSON(notifier)
 	if err != nil {
-		return nil, fmt.Errorf("unable to convert notifier to json string: %v", err)
+		return nil, fmt.Errorf("unable to convert notifier to json string: %w", err)
 	}
 
 	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers/%s", viewName, notifier.ID)
@@ -68,7 +68,7 @@ func (n *Notifiers) Update(viewName string, notifier *Notifier) (*Notifier, erro
 func (n *Notifiers) Add(viewName string, notifier *Notifier, force bool) (*Notifier, error) {
 	nameAlreadyInUse, err := n.notifierNameInUse(viewName, notifier.Name)
 	if err != nil {
-		return nil, fmt.Errorf("could not determine if notifier name is in use: %v", err)
+		return nil, fmt.Errorf("could not determine if notifier name is in use: %w", err)
 	}
 	if nameAlreadyInUse {
 		if !force {
@@ -79,7 +79,7 @@ func (n *Notifiers) Add(viewName string, notifier *Notifier, force bool) (*Notif
 
 	jsonStr, err := n.marshalToJSON(notifier)
 	if err != nil {
-		return nil, fmt.Errorf("unable to convert notifier to json string: %v", err)
+		return nil, fmt.Errorf("unable to convert notifier to json string: %w", err)
 	}
 
 	url := fmt.Sprintf("api/v1/repositories/%s/alertnotifiers/", viewName)
@@ -133,15 +133,16 @@ func (n *Notifiers) Delete(viewName, notifierName string) error {
 	}
 
 	if err != nil || res.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("could not delete notifier in view %s with id %s, got: %v", viewName, notifierID, err)
+		return fmt.Errorf("could not delete notifier in view %s with id %s, got: %w", viewName, notifierID, err)
 	}
+
 	return nil
 }
 
 func (n *Notifiers) marshalToJSON(notifier *Notifier) ([]byte, error) {
 	jsonStr, err := json.Marshal(notifier)
 	if err != nil {
-		return nil, fmt.Errorf("unable to convert notifier to json string: %v", err)
+		return nil, fmt.Errorf("unable to convert notifier to json string: %w", err)
 	}
 	return jsonStr, nil
 }
@@ -168,7 +169,7 @@ func (n *Notifiers) unmarshalToNotifier(res *http.Response) (*Notifier, error) {
 	}
 
 	if err = json.Unmarshal(body, &notifier); err != nil {
-		return &notifier, fmt.Errorf("error in json response: %v. response: %v", err, string(body))
+		return &notifier, fmt.Errorf("error in json response: %w. response: %v", err, string(body))
 	}
 
 	return &notifier, nil
@@ -177,7 +178,7 @@ func (n *Notifiers) unmarshalToNotifier(res *http.Response) (*Notifier, error) {
 func (n *Notifiers) convertNotifierNameToID(viewName, notifierName string) (string, error) {
 	listOfNotifiers, err := n.List(viewName)
 	if err != nil {
-		return "", fmt.Errorf("could not list all notifiers for view %s: %v", viewName, err)
+		return "", fmt.Errorf("could not list all notifiers for view %s: %w", viewName, err)
 	}
 	for _, v := range listOfNotifiers {
 		if v.Name == notifierName {
@@ -190,7 +191,7 @@ func (n *Notifiers) convertNotifierNameToID(viewName, notifierName string) (stri
 func (n *Notifiers) notifierNameInUse(viewName, notifierName string) (bool, error) {
 	listOfNotifiers, err := n.List(viewName)
 	if err != nil {
-		return true, fmt.Errorf("could not list all notifiers for view %s: %v", viewName, err)
+		return true, fmt.Errorf("could not list all notifiers for view %s: %w", viewName, err)
 	}
 	for _, v := range listOfNotifiers {
 		if v.Name == notifierName {

--- a/api/organizations.go
+++ b/api/organizations.go
@@ -15,7 +15,7 @@ type Organization struct {
 func (c *Client) Organizations() *Organizations { return &Organizations{client: c} }
 
 func (o *Organizations) CreateOrganization(name string) (Organization, error) {
-	var m struct {
+	var mutation struct {
 		CreateOrganization Organization `graphql:"createEmptyOrganization(name: $name)"`
 	}
 
@@ -23,7 +23,7 @@ func (o *Organizations) CreateOrganization(name string) (Organization, error) {
 		"name": graphql.String(name),
 	}
 
-	err := o.client.Mutate(&m, variables)
+	err := o.client.Mutate(&mutation, variables)
 
-	return m.CreateOrganization, err
+	return mutation.CreateOrganization, err
 }

--- a/api/parsers.go
+++ b/api/parsers.go
@@ -30,7 +30,7 @@ type ParserListItem struct {
 }
 
 func (p *Parsers) List(repositoryName string) ([]ParserListItem, error) {
-	var q struct {
+	var query struct {
 		Repository struct {
 			Parsers []ParserListItem
 		} `graphql:"repository(name: $repositoryName)"`
@@ -40,14 +40,12 @@ func (p *Parsers) List(repositoryName string) ([]ParserListItem, error) {
 		"repositoryName": graphql.String(repositoryName),
 	}
 
-	graphqlErr := p.client.Query(&q, variables)
-
 	var parsers []ParserListItem
-	if graphqlErr == nil {
-		parsers = q.Repository.Parsers
+	err := p.client.Query(&query, variables)
+	if err == nil {
+		parsers = query.Repository.Parsers
 	}
-
-	return parsers, graphqlErr
+	return parsers, err
 }
 
 func (p *Parsers) Remove(repositoryName string, parserName string) error {
@@ -117,9 +115,9 @@ func (p *Parsers) Get(repositoryName string, parserName string) (*Parser, error)
 		"repositoryName": graphql.String(repositoryName),
 	}
 
-	graphqlErr := p.client.Query(&query, variables)
-	if graphqlErr != nil {
-		return nil, graphqlErr
+	err := p.client.Query(&query, variables)
+	if err != nil {
+		return nil, err
 	}
 
 	if query.Repository.Parser == nil {
@@ -152,10 +150,10 @@ func (p *Parsers) Export(repositoryName string, parserName string) (string, erro
 		"repositoryName": graphql.String(repositoryName),
 	}
 
-	graphqlErr := p.client.Query(&query, variables)
+	err := p.client.Query(&query, variables)
 
-	if graphqlErr != nil {
-		return "", graphqlErr
+	if err != nil {
+		return "", err
 	}
 
 	if query.Repository.Parser == nil {

--- a/api/transfer.go
+++ b/api/transfer.go
@@ -15,23 +15,22 @@ func (c *Client) Transfer() *Transfer { return &Transfer{client: c} }
 var ErrManagedGroupDoesNotExist = errors.New("managed export group does not exist")
 
 func (t *Transfer) GetManagedExportGroup() (string, error) {
-	var q struct {
+	var query struct {
 		ManagedRolesAndGroupsForExport *struct {
 			GroupID string
 		} `graphql:"managedRolesAndGroupsForExport"`
 	}
 
-	err := t.client.Query(&q, nil)
-
+	err := t.client.Query(&query, nil)
 	if err != nil {
 		return "", err
 	}
 
-	if q.ManagedRolesAndGroupsForExport == nil {
+	if query.ManagedRolesAndGroupsForExport == nil {
 		return "", ErrManagedGroupDoesNotExist
 	}
 
-	return q.ManagedRolesAndGroupsForExport.GroupID, nil
+	return query.ManagedRolesAndGroupsForExport.GroupID, nil
 }
 
 func (t *Transfer) CreateManagedExportGroup() (string, error) {
@@ -68,16 +67,16 @@ type TransferJob struct {
 }
 
 func (t *Transfer) ListTransferJobs() ([]TransferJob, error) {
-	var q struct {
+	var query struct {
 		TransferJobs []TransferJob `graphql:"transferJobs"`
 	}
 
-	err := t.client.Query(&q, nil)
+	err := t.client.Query(&query, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return q.TransferJobs, nil
+	return query.TransferJobs, nil
 }
 
 type AddTransferJobResponse struct {
@@ -138,7 +137,7 @@ type TransferJobStatus struct {
 }
 
 func (t *Transfer) GetTransferJobStatus(transferJobID string) (TransferJobStatus, error) {
-	var q struct {
+	var query struct {
 		TransferJobStatus TransferJobStatus `graphql:"transferJobStatus(transferJobId: $transferJobId)"`
 	}
 
@@ -146,7 +145,7 @@ func (t *Transfer) GetTransferJobStatus(transferJobID string) (TransferJobStatus
 		"transferJobId": graphql.String(transferJobID),
 	}
 
-	err := t.client.Query(&q, variables)
+	err := t.client.Query(&query, variables)
 
-	return q.TransferJobStatus, err
+	return query.TransferJobStatus, err
 }

--- a/api/users.go
+++ b/api/users.go
@@ -33,17 +33,16 @@ type UserChangeSet struct {
 func (c *Client) Users() *Users { return &Users{client: c} }
 
 func (u *Users) List() ([]User, error) {
-	var q struct {
+	var query struct {
 		Users []User `graphql:"users"`
 	}
 
-	graphqlErr := u.client.Query(&q, nil)
-
-	return q.Users, graphqlErr
+	err := u.client.Query(&query, nil)
+	return query.Users, err
 }
 
 func (u *Users) Get(username string) (User, error) {
-	var q struct {
+	var query struct {
 		Users []User `graphql:"users(search: $username)"`
 	}
 
@@ -51,13 +50,12 @@ func (u *Users) Get(username string) (User, error) {
 		"username": graphql.String(username),
 	}
 
-	graphqlErr := u.client.Query(&q, variables)
-
-	if graphqlErr != nil {
-		return User{}, graphqlErr
+	err := u.client.Query(&query, variables)
+	if err != nil {
+		return User{}, err
 	}
 
-	for _, user := range q.Users {
+	for _, user := range query.Users {
 		if user.Username == username {
 			return user, nil
 		}
@@ -71,9 +69,8 @@ func (u *Users) Update(username string, changeset UserChangeSet) (User, error) {
 		Result struct{ User User } `graphql:"updateUser(input: {username: $username, company: $company, isRoot: $isRoot, fullName: $fullName, picture: $picture, email: $email, countryCode: $countryCode})"`
 	}
 
-	graphqlErr := u.client.Mutate(&mutation, userChangesetToVars(username, changeset))
-
-	return mutation.Result.User, graphqlErr
+	err := u.client.Mutate(&mutation, userChangesetToVars(username, changeset))
+	return mutation.Result.User, err
 }
 
 func (u *Users) Add(username string, changeset UserChangeSet) (User, error) {
@@ -84,9 +81,9 @@ func (u *Users) Add(username string, changeset UserChangeSet) (User, error) {
 		} `graphql:"addUserV2(input: {username: $username, company: $company, isRoot: $isRoot, fullName: $fullName, picture: $picture, email: $email, countryCode: $countryCode})"`
 	}
 
-	graphqlErr := u.client.Mutate(&mutation, userChangesetToVars(username, changeset))
-	if graphqlErr != nil {
-		return User{}, graphqlErr
+	err := u.client.Mutate(&mutation, userChangesetToVars(username, changeset))
+	if err != nil {
+		return User{}, err
 	}
 
 	return u.Get(username)
@@ -103,9 +100,8 @@ func (u *Users) Remove(username string) (User, error) {
 		"username": graphql.String(username),
 	}
 
-	graphqlErr := u.client.Mutate(&mutation, variables)
-
-	return mutation.Result.User, graphqlErr
+	err := u.client.Mutate(&mutation, variables)
+	return mutation.Result.User, err
 }
 
 func (u *Users) RotateUserApiTokenAndGet(userID string) (string, error) {
@@ -122,7 +118,6 @@ func (u *Users) RotateUserApiTokenAndGet(userID string) (string, error) {
 	}
 
 	err := u.client.Mutate(&mutation, variables)
-
 	if err != nil {
 		return "", err
 	}

--- a/api/viewer.go
+++ b/api/viewer.go
@@ -14,8 +14,8 @@ func (c *Viewer) Username() (string, error) {
 		}
 	}
 
-	graphqlErr := c.client.Query(&query, nil)
-	return query.Viewer.Username, graphqlErr
+	err := c.client.Query(&query, nil)
+	return query.Viewer.Username, err
 }
 
 // ApiToken fetches the api token for the user who is currently authenticated.
@@ -26,6 +26,6 @@ func (c *Viewer) ApiToken() (string, error) {
 		}
 	}
 
-	graphqlErr := c.client.Query(&query, nil)
-	return query.Viewer.ApiToken, graphqlErr
+	err := c.client.Query(&query, nil)
+	return query.Viewer.ApiToken, err
 }

--- a/cmd/humioctl/alerts_remove.go
+++ b/cmd/humioctl/alerts_remove.go
@@ -15,8 +15,7 @@
 package main
 
 import (
-	"os"
-
+	"fmt"
 	"github.com/spf13/cobra"
 )
 
@@ -27,19 +26,14 @@ func newAlertsRemoveCmd() *cobra.Command {
 		Long:  `Removes the alert with name '<name>' in the view with name '<view>'.`,
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			view := args[0]
-			name := args[1]
-
-			// Get the HTTP client
+			viewName := args[0]
+			alertName := args[1]
 			client := NewApiClient(cmd)
 
-			err := client.Alerts().Delete(view, name)
-			if err != nil {
-				cmd.Printf("Error removing ingest token: %s\n", err)
-				os.Exit(1)
-			}
+			err := client.Alerts().Delete(viewName, alertName)
+			exitOnError(cmd, err, "Error removing alert")
 
-			cmd.Println("Alert removed")
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully removed alert %q from view %q\n", alertName, viewName)
 		},
 	}
 

--- a/cmd/humioctl/cluster_nodes.go
+++ b/cmd/humioctl/cluster_nodes.go
@@ -15,7 +15,10 @@
 package main
 
 import (
+	"fmt"
+	"github.com/humio/cli/api"
 	"github.com/spf13/cobra"
+	"strconv"
 )
 
 func newClusterNodesCmd() *cobra.Command {
@@ -29,4 +32,34 @@ func newClusterNodesCmd() *cobra.Command {
 	cmd.AddCommand(newClusterNodesUnregisterCmd())
 
 	return cmd
+}
+
+func printClusterNodeDetailsTable(cmd *cobra.Command, node api.ClusterNode) {
+	details := [][]string{
+		{"ID", strconv.Itoa(node.Id)},
+		{"Name", node.Name},
+		{"URI", node.Uri},
+		{"UUID", node.Uuid},
+		{"Cluster info age (Seconds)", fmt.Sprintf("%.3f", node.ClusterInfoAgeSeconds)},
+		{"Inbound segment (Size)", ByteCountDecimal(int64(node.InboundSegmentSize))},
+		{"Outbound segment (Size)", ByteCountDecimal(int64(node.OutboundSegmentSize))},
+		{"Storage Divergence (Size)", ByteCountDecimal(int64(node.StorageDivergence))},
+		{"Can be safely unregistered", strconv.FormatBool(node.CanBeSafelyUnregistered)},
+		{"Current size", ByteCountDecimal(int64(node.CurrentSize))},
+		{"Primary size", ByteCountDecimal(int64(node.PrimarySize))},
+		{"Secondary size", ByteCountDecimal(int64(node.SecondarySize))},
+		{"Total size of primary", ByteCountDecimal(int64(node.TotalSizeOfPrimary))},
+		{"Total size of secondary", ByteCountDecimal(int64(node.TotalSizeOfSecondary))},
+		{"Free on primary", ByteCountDecimal(int64(node.FreeOnPrimary))},
+		{"Free on secondary", ByteCountDecimal(int64(node.FreeOnSecondary))},
+		{"WIP size", ByteCountDecimal(int64(node.WipSize))},
+		{"Target size", ByteCountDecimal(int64(node.TargetSize))},
+		{"Reapply target size", ByteCountDecimal(int64(node.Reapply_targetSize))},
+		{"Solitary segment size", ByteCountDecimal(int64(node.SolitarySegmentSize))},
+		{"Is available", strconv.FormatBool(node.IsAvailable)},
+		{"Last heartbeat", node.LastHeartbeat},
+		{"Availability Zone", node.Zone},
+	}
+
+	printDetailsTable(cmd, details)
 }

--- a/cmd/humioctl/cluster_nodes_list.go
+++ b/cmd/humioctl/cluster_nodes_list.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 
 	"github.com/humio/cli/api"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
@@ -32,8 +31,8 @@ func newClusterNodesListCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			client := NewApiClient(cmd)
 
-			nodes, apiErr := client.ClusterNodes().List()
-			exitOnError(cmd, apiErr, "error fetching cluster nodes")
+			nodes, err := client.ClusterNodes().List()
+			exitOnError(cmd, err, "Error fetching cluster nodes")
 
 			sort.Slice(nodes, func(i, j int) bool {
 				var a, b api.ClusterNode
@@ -47,13 +46,7 @@ func newClusterNodesListCmd() *cobra.Command {
 				rows[i] = []string{strconv.Itoa(node.Id), node.Name, strconv.FormatBool(node.CanBeSafelyUnregistered), node.Zone}
 			}
 
-			w := tablewriter.NewWriter(cmd.OutOrStdout())
-			w.SetHeader([]string{"ID", "Name", "Can be safely unregistered", "Availability Zone"})
-			w.AppendBulk(rows)
-			w.SetBorder(false)
-
-			w.Render()
-			cmd.Println()
+			printOverviewTable(cmd, []string{"ID", "Name", "Can be safely unregistered", "Availability Zone"}, rows)
 		},
 	}
 

--- a/cmd/humioctl/cluster_nodes_show.go
+++ b/cmd/humioctl/cluster_nodes_show.go
@@ -15,11 +15,8 @@
 package main
 
 import (
-	"fmt"
 	"strconv"
 
-	"github.com/humio/cli/api"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
@@ -30,49 +27,17 @@ func newClusterNodesShowCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			nodeID := args[0]
-			id, parseErr := strconv.Atoi(nodeID)
-			exitOnError(cmd, parseErr, "could not parse node id")
-
 			client := NewApiClient(cmd)
-			node, apiErr := client.ClusterNodes().Get(id)
-			exitOnError(cmd, apiErr, "error fetching node information")
-			printClusterNodeInfo(cmd, node)
-			cmd.Println()
+
+			id, err := strconv.Atoi(nodeID)
+			exitOnError(cmd, err, "Could not parse node id")
+
+			node, err := client.ClusterNodes().Get(id)
+			exitOnError(cmd, err, "Error fetching node information")
+
+			printClusterNodeDetailsTable(cmd, node)
 		},
 	}
 
 	return cmd
-}
-
-func printClusterNodeInfo(cmd *cobra.Command, node api.ClusterNode) {
-	data := [][]string{
-		{"ID", strconv.Itoa(node.Id)},
-		{"Name", node.Name},
-		{"URI", node.Uri},
-		{"UUID", node.Uuid},
-		{"Cluster info age (Seconds)", fmt.Sprintf("%.3f", node.ClusterInfoAgeSeconds)},
-		{"Inbound segment (Size)", ByteCountDecimal(int64(node.InboundSegmentSize))},
-		{"Outbound segment (Size)", ByteCountDecimal(int64(node.OutboundSegmentSize))},
-		{"Storage Divergence (Size)", ByteCountDecimal(int64(node.StorageDivergence))},
-		{"Can be safely unregistered", strconv.FormatBool(node.CanBeSafelyUnregistered)},
-		{"Current size", ByteCountDecimal(int64(node.CurrentSize))},
-		{"Primary size", ByteCountDecimal(int64(node.PrimarySize))},
-		{"Secondary size", ByteCountDecimal(int64(node.SecondarySize))},
-		{"Total size of primary", ByteCountDecimal(int64(node.TotalSizeOfPrimary))},
-		{"Total size of secondary", ByteCountDecimal(int64(node.TotalSizeOfSecondary))},
-		{"Free on primary", ByteCountDecimal(int64(node.FreeOnPrimary))},
-		{"Free on secondary", ByteCountDecimal(int64(node.FreeOnSecondary))},
-		{"WIP size", ByteCountDecimal(int64(node.WipSize))},
-		{"Target size", ByteCountDecimal(int64(node.TargetSize))},
-		{"Reapply target size", ByteCountDecimal(int64(node.Reapply_targetSize))},
-		{"Solitary segment size", ByteCountDecimal(int64(node.SolitarySegmentSize))},
-		{"Is available", strconv.FormatBool(node.IsAvailable)},
-		{"Last heartbeat", node.LastHeartbeat},
-		{"Availability Zone", node.Zone},
-	}
-
-	w := tablewriter.NewWriter(cmd.OutOrStdout())
-	w.AppendBulk(data)
-	w.SetColumnAlignment([]int{tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_LEFT})
-	w.Render()
 }

--- a/cmd/humioctl/cluster_nodes_unregister.go
+++ b/cmd/humioctl/cluster_nodes_unregister.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -26,13 +27,15 @@ func newClusterNodesUnregisterCmd() *cobra.Command {
 		Short: "Unregister (remove) a node from the cluster [Root Only]",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			node, parseErr := strconv.ParseInt(args[0], 10, 64)
-			exitOnError(cmd, parseErr, "Not valid node id")
-
 			client := NewApiClient(cmd)
 
-			apiError := client.ClusterNodes().Unregister(node, false)
-			exitOnError(cmd, apiError, "Error removing parser")
+			node, err := strconv.Atoi(args[0])
+			exitOnError(cmd, err, "Not valid node id")
+
+			err = client.ClusterNodes().Unregister(node, false)
+			exitOnError(cmd, err, "Error removing cluster node")
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully unregistered node %q\n", node)
 		},
 	}
 

--- a/cmd/humioctl/completion.go
+++ b/cmd/humioctl/completion.go
@@ -50,9 +50,7 @@ var (
 )
 
 func newCompletionCmd() *cobra.Command {
-	out := os.Stdout
-
-	shells := []string{}
+	var shells []string
 	for s := range completionShells {
 		shells = append(shells, s)
 	}
@@ -62,7 +60,7 @@ func newCompletionCmd() *cobra.Command {
 		Short: "Generate autocompletions script for the specified shell (bash or zsh)",
 		Long:  completionDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCompletion(out, cmd, args)
+			return runCompletion(os.Stdout, cmd, args)
 		},
 		ValidArgs: shells,
 	}

--- a/cmd/humioctl/files_delete.go
+++ b/cmd/humioctl/files_delete.go
@@ -1,20 +1,26 @@
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
 
 func newFilesDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete <view name> <file name>",
+		Use:   "delete <view-name> <file-name>",
 		Short: "Delete an uploaded file.",
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
+			viewName := args[0]
+			fileName := args[1]
 			client := NewApiClient(cmd)
 
-			err := client.Files().Delete(args[0], args[1])
-			exitOnError(cmd, err, "error deleting file")
+			err := client.Files().Delete(viewName, fileName)
+			exitOnError(cmd, err, "Error deleting file")
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully deleted file %q in repo %q\n", fileName, viewName)
 		},
 	}
 
 	return cmd
 }
-

--- a/cmd/humioctl/files_download.go
+++ b/cmd/humioctl/files_download.go
@@ -12,14 +12,16 @@ func newFilesDownloadCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:  "download <view name> <file name>",
+		Use:  "download <view-name> <file-name>",
 		Long: `Download a file.`,
 		Args: cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
+			viewName := args[0]
+			fileName := args[1]
 			client := NewApiClient(cmd)
 
-			reader, err := client.Files().Download(args[0], args[1])
-			exitOnError(cmd, err, "error downloading file")
+			reader, err := client.Files().Download(viewName, fileName)
+			exitOnError(cmd, err, "Error downloading file")
 
 			var writer io.Writer
 			if saveAs == "-" || saveAs == "" {
@@ -27,11 +29,11 @@ func newFilesDownloadCmd() *cobra.Command {
 			} else {
 				var err error
 				writer, err = os.Create(saveAs)
-				exitOnError(cmd, err, "error opening output file")
+				exitOnError(cmd, err, "Error opening output file")
 			}
 
 			_, err = io.Copy(writer, reader)
-			exitOnError(cmd, err, "error writing output")
+			exitOnError(cmd, err, "Error writing output")
 		},
 	}
 
@@ -39,4 +41,3 @@ func newFilesDownloadCmd() *cobra.Command {
 
 	return cmd
 }
-

--- a/cmd/humioctl/files_list.go
+++ b/cmd/humioctl/files_list.go
@@ -1,31 +1,29 @@
 package main
 
 import (
-	"fmt"
 	"github.com/spf13/cobra"
 )
 
 func newFilesListCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list <view name>",
+		Use:   "list <view-name>",
 		Short: "List uploaded files in a view.",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			client := NewApiClient(cmd)
 
 			files, err := client.Files().List(args[0])
-			exitOnError(cmd, err, "error listing files")
+			exitOnError(cmd, err, "Error listing files")
 
-			table := []string{"ID | Name | Content Hash"}
+			var rows [][]string
 
 			for _, file := range files {
-				table = append(table, fmt.Sprintf("%s | %s | %s", file.ID, file.Name, file.ContentHash))
+				rows = append(rows, []string{file.Name, file.ContentHash, file.ID})
 			}
 
-			printTable(cmd, table)
+			printOverviewTable(cmd, []string{"Name", "Content Hash", "ID"}, rows)
 		},
 	}
 
 	return cmd
 }
-

--- a/cmd/humioctl/files_upload.go
+++ b/cmd/humioctl/files_upload.go
@@ -13,7 +13,7 @@ func newFilesUploadCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use: "upload <view name> <input file>",
+		Use: "upload <view-name> <input-file>",
 		Long: `Upload a file to a view.
 
 Specify '-' as the input file to read from stdin.`,
@@ -37,13 +37,13 @@ Specify '-' as the input file to read from stdin.`,
 			} else {
 				var err error
 				reader, err = os.Open(args[1])
-				exitOnError(cmd, err, "error opening input file")
+				exitOnError(cmd, err, "Error opening input file")
 			}
 
 			client := NewApiClient(cmd)
 
 			err := client.Files().Upload(args[0], fileName, reader)
-			exitOnError(cmd, err, "error uploading file")
+			exitOnError(cmd, err, "Error uploading file")
 		},
 	}
 
@@ -51,4 +51,3 @@ Specify '-' as the input file to read from stdin.`,
 
 	return cmd
 }
-

--- a/cmd/humioctl/groups_add_user.go
+++ b/cmd/humioctl/groups_add_user.go
@@ -1,6 +1,9 @@
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
 
 func newGroupsAddUserCmd() *cobra.Command {
 	return &cobra.Command{
@@ -8,10 +11,14 @@ func newGroupsAddUserCmd() *cobra.Command {
 		Short: "Add user to group.",
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
+			groupID := args[0]
+			userID := args[1]
 			client := NewApiClient(cmd)
 
-			err := client.Groups().AddUserToGroup(args[0], args[1])
-			exitOnError(cmd, err, "error adding user to group")
+			err := client.Groups().AddUserToGroup(groupID, userID)
+			exitOnError(cmd, err, "Error adding user to group")
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully added user %q to group %q\n", userID, groupID)
 		},
 	}
 }

--- a/cmd/humioctl/groups_list.go
+++ b/cmd/humioctl/groups_list.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"github.com/spf13/cobra"
 )
 
@@ -13,17 +12,14 @@ func newGroupsList() *cobra.Command {
 			client := NewApiClient(cmd)
 
 			groups, err := client.Groups().List()
-			exitOnError(cmd, err, "error listing groups")
+			exitOnError(cmd, err, "Error listing groups")
 
-			rows := make([]string, len(groups))
+			rows := make([][]string, len(groups))
 			for i, group := range groups {
-				rows[i] = fmt.Sprintf("%s | %s", group.ID, group.DisplayName)
+				rows[i] = []string{group.DisplayName, group.ID}
 			}
 
-			printTable(cmd, append([]string{
-				"ID | Display name"},
-				rows...,
-			))
+			printOverviewTable(cmd, []string{"Display Name", "ID"}, rows)
 		},
 	}
 }

--- a/cmd/humioctl/groups_remove_user.go
+++ b/cmd/humioctl/groups_remove_user.go
@@ -1,6 +1,9 @@
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
 
 func newGroupsRemoveUserCmd() *cobra.Command {
 	return &cobra.Command{
@@ -8,10 +11,14 @@ func newGroupsRemoveUserCmd() *cobra.Command {
 		Short: "Remove user from group.",
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
+			groupID := args[0]
+			userID := args[1]
 			client := NewApiClient(cmd)
 
-			err := client.Groups().RemoveUserFromGroup(args[0], args[1])
-			exitOnError(cmd, err, "error removing user from group")
+			err := client.Groups().RemoveUserFromGroup(groupID, userID)
+			exitOnError(cmd, err, "Error removing user from group")
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully removed user %q to group %q\n", userID, groupID)
 		},
 	}
 }

--- a/cmd/humioctl/ingest_tokens_add.go
+++ b/cmd/humioctl/ingest_tokens_add.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 
-	"github.com/ryanuber/columnize"
 	"github.com/spf13/cobra"
 )
 
@@ -33,30 +32,15 @@ You can associate a parser with the ingest token using the --parser flag.
 Assigning a parser will make all data sent to Humio using this ingest token
 use the assigned parser at ingest time.`,
 		Args: cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			repo := args[0]
 			name := args[1]
-
-			// Get the HTTP client
 			client := NewApiClient(cmd)
 
-			token, err := client.IngestTokens().Add(repo, name, parserName)
+			ingestToken, err := client.IngestTokens().Add(repo, name, parserName)
+			exitOnError(cmd, err, "Error adding ingest token")
 
-			if err != nil {
-				return fmt.Errorf("error adding ingest token: %s", err)
-			}
-
-			var output []string
-			output = append(output, "Name | Token | Assigned Parser")
-			output = append(output, fmt.Sprintf("%v | %v | %v", token.Name, token.Token, valueOrEmpty(token.AssignedParser)))
-
-			table := columnize.SimpleFormat(output)
-
-			cmd.Println()
-			cmd.Println(table)
-			cmd.Println()
-
-			return nil
+			fmt.Fprintf(cmd.OutOrStdout(), "Added ingest token %q with parser %q: %s\n", ingestToken.Name, valueOrEmpty(ingestToken.AssignedParser), ingestToken.Token)
 		},
 	}
 

--- a/cmd/humioctl/ingest_tokens_list.go
+++ b/cmd/humioctl/ingest_tokens_list.go
@@ -15,10 +15,6 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/ryanuber/columnize"
 	"github.com/spf13/cobra"
 )
 
@@ -29,29 +25,18 @@ func newIngestTokensListCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			repo := args[0]
-
-			// Get the HTTP client
 			client := NewApiClient(cmd)
 
 			tokens, err := client.IngestTokens().List(repo)
+			exitOnError(cmd, err, "Error fetching token list")
 
-			if err != nil {
-				cmd.Printf("Error fetching token list: %s\n", err)
-				os.Exit(1)
-			}
-
-			var output []string
-			output = append(output, "Name | Token | Assigned Parser")
+			var rows [][]string
 			for i := 0; i < len(tokens); i++ {
-				token := tokens[i]
-				output = append(output, fmt.Sprintf("%v | %v | %v", token.Name, token.Token, valueOrEmpty(token.AssignedParser)))
+				ingestToken := tokens[i]
+				rows = append(rows, []string{ingestToken.Name, ingestToken.Token, valueOrEmpty(ingestToken.AssignedParser)})
 			}
 
-			table := columnize.SimpleFormat(output)
-
-			cmd.Println()
-			cmd.Println(table)
-			cmd.Println()
+			printOverviewTable(cmd, []string{"Name", "Token", "Assigned Parser"}, rows)
 		},
 	}
 

--- a/cmd/humioctl/ingest_tokens_remove.go
+++ b/cmd/humioctl/ingest_tokens_remove.go
@@ -15,8 +15,7 @@
 package main
 
 import (
-	"os"
-
+	"fmt"
 	"github.com/spf13/cobra"
 )
 
@@ -28,20 +27,14 @@ func newIngestTokensRemoveCmd() *cobra.Command {
 		ValidArgs: []string{"repo", "token-name"},
 		Args:      cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			repo := args[0]
-			name := args[1]
-
-			// Get the HTTP client
+			repoName := args[0]
+			tokenName := args[1]
 			client := NewApiClient(cmd)
 
-			err := client.IngestTokens().Remove(repo, name)
+			err := client.IngestTokens().Remove(repoName, tokenName)
+			exitOnError(cmd, err, "Error removing ingest token")
 
-			if err != nil {
-				cmd.Printf("Error removing ingest token: %s\n", err)
-				os.Exit(1)
-			}
-
-			cmd.Println("User Removed")
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully removed ingest token %q from repository %q\n", tokenName, repoName)
 		},
 	}
 

--- a/cmd/humioctl/ingest_tokens_show.go
+++ b/cmd/humioctl/ingest_tokens_show.go
@@ -15,8 +15,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -25,26 +23,20 @@ func newIngestTokensShowCmd() *cobra.Command {
 		Use:   "show [flags] <repo> <token-name>",
 		Short: "Show details about an ingest-token in a repository.",
 		Args:  cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-
+		Run: func(cmd *cobra.Command, args []string) {
 			repo := args[0]
 			name := args[1]
-
-			// Get the HTTP client
 			client := NewApiClient(cmd)
+
 			ingestToken, err := client.IngestTokens().Get(repo, name)
+			exitOnError(cmd, err, "Error fetching ingest token")
 
-			if err != nil {
-				return fmt.Errorf("error fetching ingest-token: %s", err)
+			details := [][]string{
+				{"Name", ingestToken.Name},
+				{"Token", ingestToken.Token},
+				{"Assigned Parser", ingestToken.AssignedParser},
 			}
-
-			var output []string
-			output = append(output, "Name | Token | Assigned parser")
-			output = append(output, fmt.Sprintf("%v | %v | %v", ingestToken.Name, ingestToken.Token, ingestToken.AssignedParser))
-
-			printTable(cmd, output)
-
-			return nil
+			printDetailsTable(cmd, details)
 		},
 	}
 

--- a/cmd/humioctl/license.go
+++ b/cmd/humioctl/license.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/humio/cli/api"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
@@ -34,24 +33,17 @@ func newLicenseCmd() *cobra.Command {
 	return cmd
 }
 
-func printLicenseInfo(cmd *cobra.Command, license api.License) {
-
-	var data [][]string
+func printLicenseDetailsTable(cmd *cobra.Command, license api.License) {
+	var details [][]string
 
 	if onprem, ok := license.(api.OnPremLicense); ok {
-		data = append(data, []string{"License ID", onprem.ID})
-		data = append(data, []string{"Issued To", onprem.IssuedTo})
-		data = append(data, []string{"Number Of Seats", fmt.Sprintf("%d", onprem.NumberOfSeats)})
+		details = append(details, []string{"License ID", onprem.ID})
+		details = append(details, []string{"Issued To", onprem.IssuedTo})
+		details = append(details, []string{"Number Of Seats", fmt.Sprintf("%d", onprem.NumberOfSeats)})
 	}
 
-	data = append(data, []string{"Issued At", license.IssuedAt()})
-	data = append(data, []string{"Expires At", license.ExpiresAt()})
+	details = append(details, []string{"Issued At", license.IssuedAt()})
+	details = append(details, []string{"Expires At", license.ExpiresAt()})
 
-	w := tablewriter.NewWriter(cmd.OutOrStdout())
-	w.AppendBulk(data)
-	w.SetBorder(false)
-	w.SetColumnSeparator(":")
-	w.SetColumnAlignment([]int{tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_LEFT})
-
-	w.Render()
+	printDetailsTable(cmd, details)
 }

--- a/cmd/humioctl/license_show.go
+++ b/cmd/humioctl/license_show.go
@@ -27,14 +27,14 @@ func newLicenseShowCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			client := NewApiClient(cmd)
-			license, apiErr := client.Licenses().Get()
+			license, err := client.Licenses().Get()
 			noLicense := api.OnPremLicense{}
 			if license == noLicense {
-				apiErr = errors.New("no license currently installed")
+				err = errors.New("no license currently installed")
 			}
-			exitOnError(cmd, apiErr, "error fetching the license")
-			printLicenseInfo(cmd, license)
-			cmd.Println()
+			exitOnError(cmd, err, "Error fetching the license")
+
+			printLicenseDetailsTable(cmd, license)
 		},
 	}
 

--- a/cmd/humioctl/notifiers_list.go
+++ b/cmd/humioctl/notifiers_list.go
@@ -15,38 +15,28 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
 func newNotifiersListCmd() *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "list [flags] <view>",
-		Short: "List all notifiers in a view.",
+		Use:   "list <repo-or-view>",
+		Short: "List all notifiers in a repository or view.",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-
-			view := args[0]
-
-			// Get the HTTP client
+		Run: func(cmd *cobra.Command, args []string) {
+			repoOrViewName := args[0]
 			client := NewApiClient(cmd)
-			notifiers, err := client.Notifiers().List(view)
 
-			if err != nil {
-				return fmt.Errorf("error fetching notifiers: %s", err)
-			}
+			notifiers, err := client.Notifiers().List(repoOrViewName)
+			exitOnError(cmd, err, "Error fetching notifiers")
 
-			var output []string
-			output = append(output, "Name | Type")
+			var rows [][]string
 			for i := 0; i < len(notifiers); i++ {
 				notifier := notifiers[i]
-				output = append(output, fmt.Sprintf("%v | %v", notifier.Name, notifier.Entity))
+				rows = append(rows, []string{notifier.Name, notifier.Entity})
 			}
 
-			printTable(cmd, output)
-
-			return nil
+			printOverviewTable(cmd, []string{"Name", "Type"}, rows)
 		},
 	}
 

--- a/cmd/humioctl/notifiers_remove.go
+++ b/cmd/humioctl/notifiers_remove.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -22,24 +23,22 @@ import (
 
 func newNotifiersRemoveCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "remove [flags] <view> <name>",
+		Use:   "remove <repo-or-view> <name>",
 		Short: "Removes an alert notifier.",
-		Long:  `Removes the alert notifier with name '<name>' in the view with name '<view>'.`,
+		Long:  `Removes the alert notifier with name '<name>' in the view with name '<repo-or-view>'.`,
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			view := args[0]
+			repoOrViewName := args[0]
 			name := args[1]
-
-			// Get the HTTP client
 			client := NewApiClient(cmd)
 
-			err := client.Notifiers().Delete(view, name)
+			err := client.Notifiers().Delete(repoOrViewName, name)
 			if err != nil {
-				cmd.Printf("Error removing ingest token: %s\n", err)
+				cmd.Printf("Error removing notifier: %s\n", err)
 				os.Exit(1)
 			}
 
-			cmd.Println("Notifier removed")
+			fmt.Fprintln(cmd.OutOrStdout(), "Notifier removed")
 		},
 	}
 

--- a/cmd/humioctl/notifiers_show.go
+++ b/cmd/humioctl/notifiers_show.go
@@ -15,36 +15,28 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
 func newNotifiersShowCmd() *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "show [flags] <view> <name>",
-		Short: "Show details about a notifier in a view.",
+		Use:   "show <repo-or-view> <name>",
+		Short: "Show details about a notifier in a repository or view.",
 		Args:  cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-
-			view := args[0]
+		Run: func(cmd *cobra.Command, args []string) {
+			repoOrViewName := args[0]
 			name := args[1]
-
-			// Get the HTTP client
 			client := NewApiClient(cmd)
-			notifier, err := client.Notifiers().Get(view, name)
 
-			if err != nil {
-				return fmt.Errorf("error fetching notifier: %s", err)
+			notifier, err := client.Notifiers().Get(repoOrViewName, name)
+			exitOnError(cmd, err, "Error fetching notifier")
+
+			details := [][]string{
+				{"Name", notifier.Name},
+				{"EntityType", notifier.Entity},
 			}
 
-			var output []string
-			output = append(output, "Name | EntityType")
-			output = append(output, fmt.Sprintf("%v | %v", notifier.Name, notifier.Entity))
-
-			printTable(cmd, output)
-
-			return nil
+			printDetailsTable(cmd, details)
 		},
 	}
 

--- a/cmd/humioctl/output.go
+++ b/cmd/humioctl/output.go
@@ -2,19 +2,7 @@ package main
 
 import (
 	"fmt"
-
-	"github.com/ryanuber/columnize"
-	"github.com/spf13/cobra"
 )
-
-func printTable(cmd *cobra.Command, rows []string) {
-
-	table := columnize.SimpleFormat(rows)
-
-	cmd.Println()
-	cmd.Println(table)
-	cmd.Println()
-}
 
 func yesNo(isTrue bool) string {
 	if isTrue {

--- a/cmd/humioctl/packages_uninstall.go
+++ b/cmd/humioctl/packages_uninstall.go
@@ -16,33 +16,23 @@ package main
 
 import (
 	"fmt"
-	"os"
-
-	"github.com/humio/cli/prompt"
-
 	"github.com/spf13/cobra"
 )
 
 func uninstallPackageCmd() *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "uninstall [flags] <view-or-repo-name> <package-name>",
+		Use:   "uninstall <repo-or-view> <package>",
 		Short: "Uninstall a package.",
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			out := prompt.NewPrompt(cmd.OutOrStdout())
-			viewName := args[0]
+			client := NewApiClient(cmd)
+			repoOrViewName := args[0]
 			packageName := args[1]
 
-			out.Info(fmt.Sprintf("Uninstalling package %s from view %s", packageName, viewName))
+			err := client.Packages().UninstallPackage(repoOrViewName, packageName)
+			exitOnError(cmd, err, "Errors uninstalling package")
 
-			// Get the HTTP client
-			client := NewApiClient(cmd)
-
-			err := client.Packages().UninstallPackage(viewName, packageName)
-			if err != nil {
-				out.Error(fmt.Sprintf("Errors uninstalling package: %s", err))
-				os.Exit(1)
-			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully uninstalled package %s from view/repo %s\n", packageName, repoOrViewName)
 		},
 	}
 

--- a/cmd/humioctl/packages_validate.go
+++ b/cmd/humioctl/packages_validate.go
@@ -21,14 +21,12 @@ import (
 
 	"github.com/humio/cli/api"
 
-	"github.com/humio/cli/prompt"
-
 	"github.com/spf13/cobra"
 )
 
 func validatePackageCmd() *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "validate [flags] <repo-or-view-name> <package-dir-or-zip>",
+		Use:   "validate <repo-or-view> <package-dir-or-zip>",
 		Short: "Validate a package's content.",
 		Long: `
 Packages can be validated from a directory or Zip File. You must specify the
@@ -39,46 +37,33 @@ repository or view to validate the package against.
 `,
 		Args: cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			out := prompt.NewPrompt(cmd.OutOrStdout())
-
-			viewName := args[0]
+			repoOrViewName := args[0]
 			dirPath := args[1]
+			client := NewApiClient(cmd)
 
 			if !filepath.IsAbs(dirPath) {
 				var err error
 				dirPath, err = filepath.Abs(dirPath)
-				if err != nil {
-					out.Error(fmt.Sprintf("Invalid path: %s", err))
-					os.Exit(1)
-				}
+				exitOnError(cmd, err, "Invalid path")
 				dirPath += "/"
 			}
 
-			out.Info(fmt.Sprintf("Validating Package in: %s", dirPath))
+			validationResult, err := client.Packages().Validate(repoOrViewName, dirPath)
+			exitOnError(cmd, err, "Errors validating package")
 
-			// Get the HTTP client
-			client := NewApiClient(cmd)
-
-			validationResult, apiErr := client.Packages().Validate(viewName, dirPath)
-			if apiErr != nil {
-				out.Error(fmt.Sprintf("Errors validating package: %s", apiErr))
+			if !validationResult.IsValid() {
+				printValidation(cmd, validationResult)
 				os.Exit(1)
 			}
-
-			if validationResult.IsValid() {
-				out.Info("Package is valid")
-			} else {
-				printValidation(out, validationResult)
-				os.Exit(1)
-			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully validated package in: %s\n", dirPath)
 		},
 	}
 
 	return &cmd
 }
 
-func printValidation(out *prompt.Prompt, validationResult *api.ValidationResponse) {
-	out.Error("Package is not valid")
-	out.Error(out.List(validationResult.InstallationErrors))
-	out.Error(out.List(validationResult.ParseErrors))
+func printValidation(cmd *cobra.Command, validationResult *api.ValidationResponse) {
+	cmd.PrintErrln("Package is not valid")
+	cmd.PrintErrln(validationResult.InstallationErrors)
+	cmd.PrintErrln(validationResult.ParseErrors)
 }

--- a/cmd/humioctl/parsers_export.go
+++ b/cmd/humioctl/parsers_export.go
@@ -15,10 +15,8 @@
 package main
 
 import (
-	"io/ioutil"
-	"os"
-
 	"github.com/spf13/cobra"
+	"io/ioutil"
 )
 
 func newParsersExportCmd() *cobra.Command {
@@ -31,27 +29,19 @@ func newParsersExportCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			repo := args[0]
 			parserName := args[1]
+			client := NewApiClient(cmd)
 
 			if outputName == "" {
 				outputName = parserName
 			}
 
-			// Get the HTTP client
-			client := NewApiClient(cmd)
-
-			yamlData, apiErr := client.Parsers().Export(repo, parserName)
-			if apiErr != nil {
-				cmd.Printf("Error fetching parsers: %s\n", apiErr)
-				os.Exit(1)
-			}
+			yamlData, err := client.Parsers().Export(repo, parserName)
+			exitOnError(cmd, err, "Error fetching parsers")
 
 			outFilePath := outputName + ".yaml"
 
-			writeErr := ioutil.WriteFile(outFilePath, []byte(yamlData), 0600)
-			if writeErr != nil {
-				cmd.Printf("Error saving the parser file: %s\n", writeErr)
-				os.Exit(1)
-			}
+			err = ioutil.WriteFile(outFilePath, []byte(yamlData), 0600)
+			exitOnError(cmd, err, "Error saving the parser file")
 		},
 	}
 

--- a/cmd/humioctl/parsers_list.go
+++ b/cmd/humioctl/parsers_list.go
@@ -15,38 +15,28 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
 func newParsersListCmd() *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "list [flags] <repo>",
+		Use:   "list <repo>",
 		Short: "List all installed parsers in a repository.",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-
+		Run: func(cmd *cobra.Command, args []string) {
 			repo := args[0]
-
-			// Get the HTTP client
 			client := NewApiClient(cmd)
+
 			parsers, err := client.Parsers().List(repo)
+			exitOnError(cmd, err, "Error fetching parsers")
 
-			if err != nil {
-				return fmt.Errorf("error fetching parsers: %s", err)
-			}
-
-			var output []string
-			output = append(output, "Name | Custom")
+			var rows [][]string
 			for i := 0; i < len(parsers); i++ {
 				parser := parsers[i]
-				output = append(output, fmt.Sprintf("%v | %v", parser.Name, checkmark(!parser.IsBuiltIn)))
+				rows = append(rows, []string{parser.Name, checkmark(!parser.IsBuiltIn)})
 			}
 
-			printTable(cmd, output)
-
-			return nil
+			printOverviewTable(cmd, []string{"Name", "Custom"}, rows)
 		},
 	}
 

--- a/cmd/humioctl/parsers_remove.go
+++ b/cmd/humioctl/parsers_remove.go
@@ -15,22 +15,24 @@
 package main
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 )
 
 func newParsersRemoveCmd() *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "remove [flags] <repo> <parser>",
+		Use:   "remove <repo> <parser>",
 		Short: "Remove (uninstall) a parser from a repository.",
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			repo := args[0]
 			parser := args[1]
-
 			client := NewApiClient(cmd)
 
-			apiError := client.Parsers().Remove(repo, parser)
-			exitOnError(cmd, apiError, "Error removing parser")
+			err := client.Parsers().Remove(repo, parser)
+			exitOnError(cmd, err, "Error removing parser")
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully removed parser %q from repository %q\n", parser, repo)
 		},
 	}
 

--- a/cmd/humioctl/profiles.go
+++ b/cmd/humioctl/profiles.go
@@ -49,11 +49,8 @@ You can change the default profile using:
 
 			if len(profiles) == 0 {
 				cmd.Println("You have no saved profiles")
-				cmd.Println()
 				cmd.Println("Use `humio profiles add <name>` to add one.")
 			}
-
-			cmd.Println()
 		},
 	}
 

--- a/cmd/humioctl/profiles_add.go
+++ b/cmd/humioctl/profiles_add.go
@@ -1,40 +1,40 @@
 package main
 
 import (
+	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
-	"github.com/humio/cli/cmd/humioctl/internal/viperkey"
-	"io/ioutil"
-	"net/url"
-	"os"
-	"path/filepath"
-	"strings"
-
 	"github.com/humio/cli/api"
+	"github.com/humio/cli/cmd/humioctl/internal/viperkey"
 	"github.com/humio/cli/prompt"
 	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
 )
 
 // usersCmd represents the users command
 func newProfilesAddCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "add <profile-name> [flags]",
+		Use:   "add <profile>",
 		Short: "Add a configuration profile",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			out := prompt.NewPrompt(cmd.OutOrStdout())
-
 			profileName := args[0]
 
-			profile, profileErr := collectProfileInfo(cmd)
-			exitOnError(cmd, profileErr, "failed to collect profile info")
+			profile, err := collectProfileInfo(cmd)
+			exitOnError(cmd, err, "Failed to collect profile info")
 
-			addAccount(out, profileName, profile)
+			addAccount(profileName, profile)
 
-			saveErr := saveConfig()
-			exitOnError(cmd, saveErr, "error saving config")
+			err = saveConfig()
+			exitOnError(cmd, err, "Error saving config")
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully added profile with name %q\n", profileName)
 		},
 	}
 
@@ -59,7 +59,7 @@ func saveConfig() error {
 	return nil
 }
 
-func addAccount(out *prompt.Prompt, newName string, profile *login) {
+func addAccount(newName string, profile *login) {
 	profiles := viper.GetStringMap(viperkey.Profiles)
 
 	profiles[newName] = map[string]interface{}{
@@ -109,16 +109,15 @@ func collectProfileInfo(cmd *cobra.Command) (*login, error) {
 
 	out := prompt.NewPrompt(cmd.OutOrStdout())
 	out.Info("Which Humio instance should we talk to?")
-	out.Output()
 	out.Description("If you are not using Humio Cloud enter the address of your Humio installation,")
 	out.Description("e.g. http://localhost:8080/ or https://humio.example.com/")
 
 	var parsedURL *url.URL
 	for {
 		var err error
-		out.Output("")
+		out.BlankLine()
 		addr, err = out.Ask("Address (default: https://cloud.humio.com/ [Hit Enter])")
-		exitOnError(cmd, err, "error reading humio server address")
+		exitOnError(cmd, err, "Error reading humio server address")
 
 		if addr == "" {
 			addr = "https://cloud.humio.com/"
@@ -137,30 +136,26 @@ func collectProfileInfo(cmd *cobra.Command) (*login, error) {
 		clientConfig.Address = parsedURL
 		client := api.NewClient(clientConfig)
 
-		out.Output()
 		cmd.Print("==> Testing Connection...")
-		out.Output()
 		_, statusErr := client.Status()
 		if statusErr != nil {
-			if strings.Contains(statusErr.Error(), "x509: certificate signed by unknown authority") {
+			if errors.Is(statusErr, x509.UnknownAuthorityError{}) {
 				cmd.Println(prompt.Colorize("[[red]Failed[reset]] Certificate not signed by a trusted Certificate Authority."))
 				out.Info("What is the absolute path to the CA certificate that should be used for TLS certificate validation?")
-				out.Output()
 				out.Description("If you require a custom CA certificate for validating the TLS certificate of the Humio cluster,")
 				out.Description("specify the path to the file containing the CA certificate in PEM format.")
 				out.Description("If left empty it is not possible to validate TLS certificate chain.")
-				out.Output()
 
 				caCertificateFilePath, err := out.Ask("Absolute path on local disk to CA certificate in PEM format")
-				exitOnError(cmd, err, "error reading Humio CA certificate file path")
+				exitOnError(cmd, err, "Error reading Humio CA certificate file path")
 				if caCertificateFilePath != "" {
 					// Read the file
 					// #nosec G304
 					caCertContent, err := ioutil.ReadFile(caCertificateFilePath)
-					exitOnError(cmd, err, "error reading Humio CA certificate file path")
+					exitOnError(cmd, err, "Error reading Humio CA certificate file path")
 					block, _ := pem.Decode(caCertContent)
 					if block == nil {
-						exitOnError(cmd, fmt.Errorf("expected PEM block"), "expected PEM encoded CA certificate file")
+						exitOnError(cmd, fmt.Errorf("expected PEM block"), "Expected PEM encoded CA certificate file")
 					}
 					caCertificate = string(caCertContent)
 					clientConfig.CACertificatePEM = caCertificate
@@ -169,22 +164,17 @@ func collectProfileInfo(cmd *cobra.Command) (*login, error) {
 			}
 		}
 
-		out.Output()
-		cmd.Print("==> Testing Connection...")
-		out.Output()
+		out.Print("==> Testing Connection...")
 		_, statusErr = client.Status()
 		if statusErr != nil {
-			if strings.Contains(statusErr.Error(), "x509: certificate is valid for") {
-				cmd.Printf("%s: %s\n", prompt.Colorize("[[red]Failed[reset]] Certificate not valid for"), clientConfig.Address)
-				out.Output()
+			if errors.Is(statusErr, x509.HostnameError{}) {
+				out.Printf("%s: %s\n", prompt.Colorize("[[red]Failed[reset]] Certificate not valid for"), clientConfig.Address)
 				out.Info("Disable hostname verification for TLS connections?")
-				out.Output()
 				out.Description("By default all connections will verify the hostname, but this option allows you to disable this if required.")
-				out.Output()
 				insecureString, err := out.Ask("Do you want to disable hostname verification? Type 'yes' to disable hostname verification")
-				exitOnError(cmd, err, "error reading humio ca certificate file path")
+				exitOnError(cmd, err, "Error reading humio ca certificate file path")
 				if insecureString == "yes" {
-					out.Output("Disabling hostname verification.")
+					out.Print("Disabling hostname verification.")
 					insecure = true
 					clientConfig.Insecure = true
 					client = api.NewClient(clientConfig)
@@ -192,14 +182,11 @@ func collectProfileInfo(cmd *cobra.Command) (*login, error) {
 			}
 		}
 
-		out.Output()
-		cmd.Print("==> Testing Connection...")
-		out.Output()
+		out.Print("==> Testing Connection...")
 		status, statusErr := client.Status()
 
 		if statusErr != nil {
 			cmd.Println(prompt.Colorize("[[red]Failed[reset]]"))
-			out.Output()
 			out.Error(fmt.Sprintf("Could not connect to the Humio server: %s\nIs the address connect and reachable?", statusErr))
 			continue
 		}
@@ -211,33 +198,25 @@ func collectProfileInfo(cmd *cobra.Command) (*login, error) {
 		} else {
 			cmd.Println(prompt.Colorize("[[green]Ok[reset]]"))
 		}
-
-		fmt.Println("")
 		break
 	}
 
 	out.Info("Paste in your Personal API Token")
-	out.Output()
 	out.Description("To use Humio's CLI you will need to get a copy of your API Token.")
 	out.Description("The API token can be found on the 'Account Settings' page of the UI.")
 	out.Description("If you are running Humio without authorization just leave the API Token field empty.")
-	out.Output()
 
 	if out.Confirm("Would you like us to open a browser on the account page?") {
 		_ = open.Start(fmt.Sprintf("%ssettings", addr))
 
-		out.Output()
 		out.Description("If the browser did not open, you can manually visit:")
 		out.Description(fmt.Sprintf("%ssettings", addr))
-		out.Output()
 	}
-
-	out.Output()
 
 	for {
 		var err error
 		token, err = out.AskSecret("API Token")
-		exitOnError(cmd, err, "error reading token")
+		exitOnError(cmd, err, "Error reading token")
 
 		// Create a new API client with the token
 		config := api.DefaultConfig()
@@ -260,12 +239,8 @@ func collectProfileInfo(cmd *cobra.Command) (*login, error) {
 		}
 
 		if username != "" {
-			out.Output()
-			out.Output()
 			cmd.Println(prompt.Colorize(fmt.Sprintf("==> Logged in as: [purple]%s[reset]", username)))
 		}
-
-		cmd.Println()
 		break
 	}
 

--- a/cmd/humioctl/profiles_remove.go
+++ b/cmd/humioctl/profiles_remove.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"github.com/humio/cli/cmd/humioctl/internal/viperkey"
 	"os"
 
-	"github.com/humio/cli/prompt"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -12,27 +12,23 @@ import (
 // usersCmd represents the users command
 func newProfilesRemoveCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "remove <profile-name> [flags]",
+		Use:   "remove <profile>",
 		Short: "Remove a configuration profile",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			profileName := args[0]
 
-			out := prompt.NewPrompt(cmd.OutOrStdout())
-
 			profiles := viper.GetStringMap(viperkey.Profiles)
-
 			if profiles[profileName] == nil {
 				cmd.Println("profile not found")
 				os.Exit(0)
 			}
 
 			delete(profiles, profileName)
+			err := saveConfig()
+			exitOnError(cmd, err, "Error saving config")
 
-			saveErr := saveConfig()
-			exitOnError(cmd, saveErr, "error saving config")
-
-			out.Output("Profile removed: ", profileName)
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully removed profile: %q\n", profileName)
 		},
 	}
 

--- a/cmd/humioctl/repos.go
+++ b/cmd/humioctl/repos.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/humio/cli/api"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
@@ -38,9 +37,8 @@ func newReposCmd() *cobra.Command {
 	return cmd
 }
 
-func printRepoTable(cmd *cobra.Command, repo api.Repository) {
-
-	data := [][]string{
+func printRepoDetailsTable(cmd *cobra.Command, repo api.Repository) {
+	details := [][]string{
 		{"ID", repo.ID},
 		{"Name", repo.Name},
 		{"Description", repo.Description},
@@ -50,10 +48,5 @@ func printRepoTable(cmd *cobra.Command, repo api.Repository) {
 		{"Retention (Days)", fmt.Sprintf("%d", int64(repo.RetentionDays))},
 	}
 
-	w := tablewriter.NewWriter(cmd.OutOrStdout())
-	w.AppendBulk(data)
-	w.SetBorder(false)
-	w.SetColumnSeparator(":")
-	w.SetColumnAlignment([]int{tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_LEFT})
-	w.Render()
+	printDetailsTable(cmd, details)
 }

--- a/cmd/humioctl/repos_create.go
+++ b/cmd/humioctl/repos_create.go
@@ -16,30 +16,23 @@ package main
 
 import (
 	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
 func newReposCreateCmd() *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "create [flags] <repo>",
+		Use:   "create <repo>",
 		Short: "Create a repository.",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			repoName := args[0]
-
 			client := NewApiClient(cmd)
 
-			apiErr := client.Repositories().Create(repoName)
-			exitOnError(cmd, apiErr, "error creating repository")
-			fmt.Printf("Sucessfully created repo %s\n", repoName)
+			err := client.Repositories().Create(repoName)
+			exitOnError(cmd, err, "Error creating repository")
 
-			repo, apiErr := client.Repositories().Get(repoName)
-			exitOnError(cmd, apiErr, "error fetching repository")
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully created repo %s\n", repoName)
 
-			printRepoTable(cmd, repo)
-
-			fmt.Println()
 		},
 	}
 

--- a/cmd/humioctl/repos_delete.go
+++ b/cmd/humioctl/repos_delete.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 )
 
@@ -28,11 +29,12 @@ func newReposDeleteCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			repo := args[0]
 			reason := args[1]
-
 			client := NewApiClient(cmd)
 
-			apiError := client.Repositories().Delete(repo, reason, allowDataDeletionFlag)
-			exitOnError(cmd, apiError, "error removing repository")
+			err := client.Repositories().Delete(repo, reason, allowDataDeletionFlag)
+			exitOnError(cmd, err, "Error removing repository")
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully deleted repository: %q\n", repo)
 		},
 	}
 

--- a/cmd/humioctl/repos_list.go
+++ b/cmd/humioctl/repos_list.go
@@ -18,7 +18,6 @@ import (
 	"sort"
 
 	"github.com/humio/cli/api"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
@@ -32,8 +31,8 @@ func newReposListCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			client := NewApiClient(cmd)
 
-			repos, apiErr := client.Repositories().List()
-			exitOnError(cmd, apiErr, "error fetching repository")
+			repos, err := client.Repositories().List()
+			exitOnError(cmd, err, "Error fetching repository")
 
 			sort.Slice(repos, func(i, j int) bool {
 				var a, b api.RepoListItem
@@ -56,13 +55,7 @@ func newReposListCmd() *cobra.Command {
 				rows[i] = []string{view.Name, ByteCountDecimal(view.SpaceUsed), view.ID}
 			}
 
-			w := tablewriter.NewWriter(cmd.OutOrStdout())
-			w.SetHeader([]string{"Name", "Space Used", "ID"})
-			w.AppendBulk(rows)
-			w.SetBorder(false)
-
-			w.Render()
-			cmd.Println()
+			printOverviewTable(cmd, []string{"Name", "Space Used", "ID"}, rows)
 		},
 	}
 

--- a/cmd/humioctl/repos_show.go
+++ b/cmd/humioctl/repos_show.go
@@ -15,27 +15,22 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
 func newReposShowCmd() *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "show [flags] <repo>",
+		Use:   "show <repo>",
 		Short: "Show details about a repository.",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			repoName := args[0]
-
 			client := NewApiClient(cmd)
 
-			repo, apiErr := client.Repositories().Get(repoName)
-			exitOnError(cmd, apiErr, "error fetching repository")
+			repo, err := client.Repositories().Get(repoName)
+			exitOnError(cmd, err, "Error fetching repository")
 
-			printRepoTable(cmd, repo)
-
-			fmt.Println()
+			printRepoDetailsTable(cmd, repo)
 		},
 	}
 

--- a/cmd/humioctl/repos_update.go
+++ b/cmd/humioctl/repos_update.go
@@ -23,41 +23,38 @@ import (
 func newReposUpdateCmd() *cobra.Command {
 	var allowDataDeletionFlag bool
 	var descriptionFlag stringPtrFlag
-	var retentionTimeFlag, ingestSizeBasedRetentionFlag, storageSizeBasedretentionFlag float64PtrFlag
+	var retentionTimeFlag, ingestSizeBasedRetentionFlag, storageSizeBasedRetentionFlag float64PtrFlag
 
 	cmd := cobra.Command{
-		Use:   "update",
+		Use:   "update [flags] <repo>",
 		Short: "Updates the settings of a repository",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			repoName := args[0]
+			client := NewApiClient(cmd)
 
-			if descriptionFlag.value == nil && retentionTimeFlag.value == nil && ingestSizeBasedRetentionFlag.value == nil && storageSizeBasedretentionFlag.value == nil {
-				exitOnError(cmd, fmt.Errorf("you must specify at least one flag to update"), "nothing specifed to update")
+			if descriptionFlag.value == nil && retentionTimeFlag.value == nil && ingestSizeBasedRetentionFlag.value == nil && storageSizeBasedRetentionFlag.value == nil {
+				exitOnError(cmd, fmt.Errorf("you must specify at least one flag to update"), "Nothing specified to update")
 			}
 
-			client := NewApiClient(cmd)
 			if descriptionFlag.value != nil {
 				err := client.Repositories().UpdateDescription(repoName, *descriptionFlag.value)
-				exitOnError(cmd, err, "error updating repository description")
+				exitOnError(cmd, err, "Error updating repository description")
 			}
 			if retentionTimeFlag.value != nil {
 				err := client.Repositories().UpdateTimeBasedRetention(repoName, *retentionTimeFlag.value, allowDataDeletionFlag)
-				exitOnError(cmd, err, "error updating repository retention time in days")
+				exitOnError(cmd, err, "Error updating repository retention time in days")
 			}
 			if ingestSizeBasedRetentionFlag.value != nil {
 				err := client.Repositories().UpdateIngestBasedRetention(repoName, *ingestSizeBasedRetentionFlag.value, allowDataDeletionFlag)
-				exitOnError(cmd, err, "error updating repository ingest size based retention")
+				exitOnError(cmd, err, "Error updating repository ingest size based retention")
 			}
-			if storageSizeBasedretentionFlag.value != nil {
-				err := client.Repositories().UpdateStorageBasedRetention(repoName, *storageSizeBasedretentionFlag.value, allowDataDeletionFlag)
-				exitOnError(cmd, err, "error updating repository storage size based retention")
+			if storageSizeBasedRetentionFlag.value != nil {
+				err := client.Repositories().UpdateStorageBasedRetention(repoName, *storageSizeBasedRetentionFlag.value, allowDataDeletionFlag)
+				exitOnError(cmd, err, "Error updating repository storage size based retention")
 			}
 
-			repo, apiErr := client.Repositories().Get(repoName)
-			exitOnError(cmd, apiErr, "error fetching repository")
-			printRepoTable(cmd, repo)
-			fmt.Println()
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully updated repository %q\n", repoName)
 		},
 	}
 
@@ -65,7 +62,7 @@ func newReposUpdateCmd() *cobra.Command {
 	cmd.Flags().Var(&descriptionFlag, "description", "The description of the repository.")
 	cmd.Flags().Var(&retentionTimeFlag, "retention-time", "The retention time in days for the repository.")
 	cmd.Flags().Var(&ingestSizeBasedRetentionFlag, "ingest-size-based-retention", "The ingest size based retention for the repository.")
-	cmd.Flags().Var(&storageSizeBasedretentionFlag, "storage-size-based-retention", "The storage size based retention for the repository.")
+	cmd.Flags().Var(&storageSizeBasedRetentionFlag, "storage-size-based-retention", "The storage size based retention for the repository.")
 
 	return &cmd
 }

--- a/cmd/humioctl/repos_update_user_group.go
+++ b/cmd/humioctl/repos_update_user_group.go
@@ -16,20 +16,20 @@ func newReposUpdateUserGroupCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			repoName := args[0]
 			userName := args[1]
+			client := NewApiClient(cmd)
 
 			var defaultGroups []api.DefaultGroupEnum
 			for _, group := range groups {
 				var defaultGroup api.DefaultGroupEnum
 				if !defaultGroup.ParseString(group) {
-					cmd.Println("the group '%s' was not valid (must be either 'Member', 'Admin' or 'Eliminator')")
+					cmd.Println("The group '%s' was not valid (must be either 'Member', 'Admin' or 'Eliminator')")
 					os.Exit(1)
 				}
 				defaultGroups = append(defaultGroups, defaultGroup)
 			}
 
-			client := NewApiClient(cmd)
-			apiErr := client.Repositories().UpdateUserGroup(repoName, userName, defaultGroups...)
-			exitOnError(cmd, apiErr, "error adding user")
+			err := client.Repositories().UpdateUserGroup(repoName, userName, defaultGroups...)
+			exitOnError(cmd, err, "Error adding user")
 		},
 	}
 	cmd.Flags().StringSliceVarP(&groups, "groups", "g", []string{api.DefaultGroupEnumMember.String()}, "the groups that the user should be added in")

--- a/cmd/humioctl/search.go
+++ b/cmd/humioctl/search.go
@@ -28,7 +28,7 @@ func newSearchCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "search <repo> <query>",
+		Use:   "search [flags] <repo> <query>",
 		Short: "Search",
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -120,7 +120,7 @@ func newSearchCmd() *cobra.Command {
 			}
 
 			if queryError, ok := err.(api.QueryError); ok {
-				fmt.Printf("There was an error in your query string:\n\n%s\n", queryError.Error())
+				cmd.PrintErrf("There was an error in your query string:\n\n%s\n", queryError.Error())
 				os.Exit(1)
 			}
 

--- a/cmd/humioctl/status.go
+++ b/cmd/humioctl/status.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"github.com/humio/cli/cmd/humioctl/internal/viperkey"
 	"github.com/humio/cli/prompt"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -30,27 +29,20 @@ func newStatusCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			client := NewApiClient(cmd)
-			serverStatus, serverErr := client.Status()
-			exitOnError(cmd, serverErr, "error getting server status")
+			serverStatus, err := client.Status()
+			exitOnError(cmd, err, "Error getting server status")
 
-			username, usernameErr := client.Viewer().Username()
-			exitOnError(cmd, usernameErr, "error getting the current user")
+			username, err := client.Viewer().Username()
+			exitOnError(cmd, err, "Error getting the current user")
 
-			data := [][]string{
+			details := [][]string{
 				{"Status", formatStatusText(serverStatus.Status)},
 				{"Address", viper.GetString(viperkey.Address)},
 				{"Version", serverStatus.Version},
 				{"Username", username},
 			}
 
-			w := tablewriter.NewWriter(cmd.OutOrStdout())
-			w.AppendBulk(data)
-			w.SetBorder(false)
-			w.SetColumnSeparator(":")
-			w.SetColumnAlignment([]int{tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_LEFT})
-
-			w.Render()
-			fmt.Println()
+			printDetailsTable(cmd, details)
 		},
 	}
 

--- a/cmd/humioctl/users.go
+++ b/cmd/humioctl/users.go
@@ -15,11 +15,7 @@
 package main
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/humio/cli/api"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
@@ -39,14 +35,8 @@ func newUsersCmd() *cobra.Command {
 	return cmd
 }
 
-func formatSimpleAccount(account api.User) string {
-	columns := []string{account.Username, account.FullName, yesNo(account.IsRoot), account.CreatedAt, account.ID}
-	return strings.Join(columns, " | ")
-}
-
-func printUserTable(cmd *cobra.Command, user api.User) {
-
-	data := [][]string{
+func printUserDetailsTable(cmd *cobra.Command, user api.User) {
+	details := [][]string{
 		{"Username", user.Username},
 		{"Name", user.FullName},
 		{"Is Root", yesNo(user.IsRoot)},
@@ -57,13 +47,5 @@ func printUserTable(cmd *cobra.Command, user api.User) {
 		{"ID", user.ID},
 	}
 
-	w := tablewriter.NewWriter(cmd.OutOrStdout())
-	w.AppendBulk(data)
-	w.SetBorder(false)
-	w.SetColumnSeparator(":")
-	w.SetColumnAlignment([]int{tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_LEFT})
-
-	fmt.Println()
-	w.Render()
-	fmt.Println()
+	printDetailsTable(cmd, details)
 }

--- a/cmd/humioctl/users_add.go
+++ b/cmd/humioctl/users_add.go
@@ -15,8 +15,7 @@
 package main
 
 import (
-	"os"
-
+	"fmt"
 	"github.com/humio/cli/api"
 	"github.com/spf13/cobra"
 )
@@ -31,12 +30,10 @@ func newUsersAddCmd() *cobra.Command {
 		Short: "Adds a user. [Root Only]",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-
 			username := args[0]
-
 			client := NewApiClient(cmd)
 
-			user, err := client.Users().Add(username, api.UserChangeSet{
+			_, err := client.Users().Add(username, api.UserChangeSet{
 				IsRoot:      rootFlag.value,
 				FullName:    nameFlag.value,
 				Company:     companyFlag.value,
@@ -44,13 +41,9 @@ func newUsersAddCmd() *cobra.Command {
 				Email:       emailFlag.value,
 				Picture:     pictureFlag.value,
 			})
+			exitOnError(cmd, err, "Error creating the user")
 
-			if err != nil {
-				cmd.Printf("Error creating the user: %s\n", err)
-				os.Exit(1)
-			}
-
-			printUserTable(cmd, user)
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully created user with username %q\n", username)
 		},
 	}
 

--- a/cmd/humioctl/users_list.go
+++ b/cmd/humioctl/users_list.go
@@ -26,17 +26,14 @@ func newUsersListCmd() *cobra.Command {
 			client := NewApiClient(cmd)
 
 			users, err := client.Users().List()
-			exitOnError(cmd, err, "error fetching user list")
+			exitOnError(cmd, err, "Error fetching user list")
 
-			rows := make([]string, len(users))
+			rows := make([][]string, len(users))
 			for i, user := range users {
-				rows[i] = formatSimpleAccount(user)
+				rows[i] = []string{user.Username, user.FullName, yesNo(user.IsRoot), user.CreatedAt, user.ID}
 			}
 
-			printTable(cmd, append([]string{
-				"Username | Name | Root | Created"},
-				rows...,
-			))
+			printOverviewTable(cmd, []string{"Username", "Name", "Root", "Created", "ID"}, rows)
 		},
 	}
 }

--- a/cmd/humioctl/users_remove.go
+++ b/cmd/humioctl/users_remove.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 )
 
@@ -26,13 +27,12 @@ func newUsersRemoveCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			username := args[0]
-
 			client := NewApiClient(cmd)
 
 			removedUser, err := client.Users().Remove(username)
 			exitOnError(cmd, err, "Error removing the user")
 
-			printUserTable(cmd, removedUser)
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully removed user with username %q with ID %q\n", removedUser.Username, removedUser.ID)
 		},
 	}
 

--- a/cmd/humioctl/users_rotate_api_token.go
+++ b/cmd/humioctl/users_rotate_api_token.go
@@ -6,7 +6,7 @@ import (
 
 func newUsersRotateApiTokenCmd() *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "rotate-api-token",
+		Use:   "rotate-api-token <user-id>",
 		Short: "Rotate and retrieve a user's API token [Root Only]",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -17,7 +17,6 @@ func newUsersRotateApiTokenCmd() *cobra.Command {
 			exitOnError(cmd, apiErr, "Error updating user")
 
 			cmd.Printf("New API Token: %s\n", newToken)
-			cmd.Println()
 		},
 	}
 

--- a/cmd/humioctl/users_show.go
+++ b/cmd/humioctl/users_show.go
@@ -25,12 +25,12 @@ func newUsersShowCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			username := args[0]
-
 			client := NewApiClient(cmd)
+
 			user, err := client.Users().Get(username)
 			exitOnError(cmd, err, "Error fetching user")
 
-			printUserTable(cmd, user)
+			printUserDetailsTable(cmd, user)
 		},
 	}
 

--- a/cmd/humioctl/users_update.go
+++ b/cmd/humioctl/users_update.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/humio/cli/api"
 	"github.com/spf13/cobra"
 )
@@ -25,14 +26,14 @@ func newUsersUpdateCmd() *cobra.Command {
 	var pictureFlag urlPtrFlag
 
 	cmd := cobra.Command{
-		Use:   "update",
+		Use:   "update [flags] <username>",
 		Short: "Updates a user's settings [Root Only]",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			username := args[0]
-
+			userName := args[0]
 			client := NewApiClient(cmd)
-			user, apiErr := client.Users().Update(username, api.UserChangeSet{
+
+			_, apiErr := client.Users().Update(userName, api.UserChangeSet{
 				IsRoot:      rootFlag.value,
 				FullName:    nameFlag.value,
 				Company:     companyFlag.value,
@@ -42,7 +43,7 @@ func newUsersUpdateCmd() *cobra.Command {
 			})
 			exitOnError(cmd, apiErr, "Error updating user")
 
-			printUserTable(cmd, user)
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully updated user with username %q\n", userName)
 		},
 	}
 

--- a/cmd/humioctl/util.go
+++ b/cmd/humioctl/util.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"github.com/olekukonko/tablewriter"
 	"net/url"
 	"os"
 	"strconv"
@@ -127,4 +128,20 @@ func (sf *float64PtrFlag) String() string {
 
 func (sf *float64PtrFlag) Type() string {
 	return "float64"
+}
+
+func printDetailsTable(cmd *cobra.Command, data [][]string) {
+	w := tablewriter.NewWriter(cmd.OutOrStdout())
+	w.AppendBulk(data)
+	w.SetBorder(false)
+	w.SetColumnAlignment([]int{tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_LEFT})
+	w.Render()
+}
+
+func printOverviewTable(cmd *cobra.Command, header []string, data [][]string) {
+	w := tablewriter.NewWriter(cmd.OutOrStdout())
+	w.AppendBulk(data)
+	w.SetBorder(false)
+	w.SetHeader(header)
+	w.Render()
 }

--- a/cmd/humioctl/views.go
+++ b/cmd/humioctl/views.go
@@ -15,11 +15,7 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/humio/cli/api"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
@@ -38,42 +34,15 @@ func newViewsCmd() *cobra.Command {
 	return cmd
 }
 
-func printViewTable(view *api.View) {
-
-	data := [][]string{
-		{"Name", view.Name},
-	}
-
-	w := tablewriter.NewWriter(os.Stdout)
-	w.AppendBulk(data)
-	w.SetBorder(false)
-	w.SetColumnSeparator(":")
-	w.SetColumnAlignment([]int{tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_LEFT})
-
-	fmt.Println()
-	w.Render()
-	fmt.Println()
-}
-
-func printViewConnectionsTable(view *api.View) {
+func printViewConnectionsTable(cmd *cobra.Command, view *api.View) {
 	if len(view.Connections) == 0 {
 		return
 	}
 
-	data := [][]string{}
-
+	var rows [][]string
 	for _, conn := range view.Connections {
-		data = append(data, []string{conn.RepoName, conn.Filter})
+		rows = append(rows, []string{view.Name, conn.RepoName, conn.Filter})
 	}
 
-	w := tablewriter.NewWriter(os.Stdout)
-	w.AppendBulk(data)
-	w.SetBorder(true)
-	w.SetHeader([]string{"Repository", "Query Prefix"})
-	w.SetColumnSeparator(":")
-	w.SetColumnAlignment([]int{tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_LEFT})
-
-	fmt.Println()
-	w.Render()
-	fmt.Println()
+	printOverviewTable(cmd, []string{"View", "Repository", "Query Prefix"}, rows)
 }

--- a/cmd/humioctl/views_create.go
+++ b/cmd/humioctl/views_create.go
@@ -20,33 +20,26 @@ import (
 )
 
 func newViewsCreateCmd() *cobra.Command {
-	connections := make(map[string] string)
+	connections := make(map[string]string)
 	description := ""
 
-	c := &cobra.Command{
-		Use:   "create <view-name>",
+	cmd := &cobra.Command{
+		Use:   "create [flags] <view-name>",
 		Short: "Create a view.",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			viewName := args[0]
-
 			client := NewApiClient(cmd)
 
-			apiErr := client.Views().Create(viewName, description, connections)
-			exitOnError(cmd, apiErr, "Error creating view")
-			fmt.Printf("Successfully created view %s\n", viewName)
+			err := client.Views().Create(viewName, description, connections)
+			exitOnError(cmd, err, "Error creating view")
 
-			view, apiErr := client.Views().Get(viewName)
-			exitOnError(cmd, apiErr, "error fetching view")
-
-			printViewTable(view)
-
-			fmt.Println()
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully created view: %q\n", viewName)
 		},
 	}
 
-	c.Flags().StringToStringVar(&connections, "connection", connections, "Sets a repository connection with the chosen filter.")
-	c.Flags().StringVar(&description, "description", description, "Sets an optional description")
+	cmd.Flags().StringToStringVar(&connections, "connection", connections, "Sets a repository connection with the chosen filter.")
+	cmd.Flags().StringVar(&description, "description", description, "Sets an optional description")
 
-	return c
+	return cmd
 }

--- a/cmd/humioctl/views_delete.go
+++ b/cmd/humioctl/views_delete.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"github.com/spf13/cobra"
 )
 
@@ -27,13 +26,12 @@ func newViewsDeleteCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			view := args[0]
 			reason := args[1]
-
-			fmt.Printf("Deleting view %s with reason %q\n", view, reason)
-
 			client := NewApiClient(cmd)
 
-			apiError := client.Views().Delete(view, reason)
-			exitOnError(cmd, apiError, "error removing view")
+			err := client.Views().Delete(view, reason)
+			exitOnError(cmd, err, "Error removing view")
+
+			cmd.Printf("Successfully deleted view %s with reason %q\n", view, reason)
 		},
 	}
 }

--- a/cmd/humioctl/views_list.go
+++ b/cmd/humioctl/views_list.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
@@ -26,21 +25,15 @@ func newViewsListCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			client := NewApiClient(cmd)
 
-			views, apiErr := client.Views().List()
-			exitOnError(cmd, apiErr, "Error while fetching view list")
+			views, err := client.Views().List()
+			exitOnError(cmd, err, "Error while fetching view list")
 
 			rows := make([][]string, len(views))
 			for i, view := range views {
 				rows[i] = []string{view.Name}
 			}
 
-			w := tablewriter.NewWriter(cmd.OutOrStdout())
-			w.AppendBulk(rows)
-			w.SetBorder(false)
-
-			cmd.Println()
-			w.Render()
-			cmd.Println()
+			printOverviewTable(cmd, []string{"Name"}, rows)
 		},
 	}
 }

--- a/cmd/humioctl/views_show.go
+++ b/cmd/humioctl/views_show.go
@@ -20,20 +20,17 @@ import (
 
 func newViewsShowCmd() *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "show [flags] <view>",
+		Use:   "show <view>",
 		Short: "Show details about a view.",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			viewName := args[0]
-
 			client := NewApiClient(cmd)
 
-			view, apiErr := client.Views().Get(viewName)
-			exitOnError(cmd, apiErr, "Error fetching view")
+			view, err := client.Views().Get(viewName)
+			exitOnError(cmd, err, "Error fetching view")
 
-			printViewTable(view)
-
-			printViewConnectionsTable(view)
+			printViewConnectionsTable(cmd, view)
 		},
 	}
 

--- a/cmd/humioctl/views_update.go
+++ b/cmd/humioctl/views_update.go
@@ -25,32 +25,28 @@ func newViewsUpdateCmd() *cobra.Command {
 	description := ""
 
 	cmd := cobra.Command{
-		Use:   "update",
+		Use:   "update [flags] <view>",
 		Short: "Updates the settings of a view",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			viewName := args[0]
+			client := NewApiClient(cmd)
 
 			if len(connections) == 0 && description == "" {
-				exitOnError(cmd, fmt.Errorf("you must specify at least one flag"), "nothing specified to update")
+				exitOnError(cmd, fmt.Errorf("you must specify at least one flag"), "Nothing specified to update")
 			}
-
-			client := NewApiClient(cmd)
 
 			if len(connections) > 0 {
 				err := client.Views().UpdateConnections(viewName, connections)
-				exitOnError(cmd, err, "error updating view connections")
+				exitOnError(cmd, err, "Error updating view connections")
 			}
 
 			if description != "" {
 				err := client.Views().UpdateDescription(viewName, description)
-				exitOnError(cmd, err, "error updating view description")
+				exitOnError(cmd, err, "Error updating view description")
 			}
 
-			view, apiErr := client.Views().Get(viewName)
-			exitOnError(cmd, apiErr, "error fetching view")
-			printViewTable(view)
-			fmt.Println()
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully updated view %q\n", viewName)
 		},
 	}
 

--- a/cmd/humioctl/welcome.go
+++ b/cmd/humioctl/welcome.go
@@ -26,37 +26,35 @@ func newWelcomeCmd() *cobra.Command {
 			}
 
 			owl := "[purple]" + prompt.Owl() + "[reset]"
-			out.Print((prompt.Colorize(owl)))
-			out.Output("")
+			out.Print(prompt.Colorize(owl))
+			out.BlankLine()
 			out.Title("Welcome to Humio")
-			out.Output("")
+			out.BlankLine()
 			out.Description("This will guide you through setting up the Humio CLI.")
-			out.Output("")
+			out.BlankLine()
 
 			profile, err := collectProfileInfo(cmd)
-			exitOnError(cmd, err, "failed to collect profile info")
+			exitOnError(cmd, err, "Failed to collect profile info")
 
 			viper.Set(viperkey.Address, profile.address)
 			viper.Set(viperkey.Token, profile.token)
 
-			addAccount(out, "default", profile)
+			addAccount("default", profile)
 
 			configFile := viper.ConfigFileUsed()
-			cmd.Println(prompt.Colorize("==> Writing settings to: [purple]" + configFile + "[reset]"))
+			out.Print(prompt.Colorize("==> Writing settings to: [purple]" + configFile + "[reset]"))
 
-			if saveErr := saveConfig(); saveErr != nil {
-				cmd.Printf("Error saving config: %s\n", saveErr)
-				os.Exit(1)
-			}
+			err = saveConfig()
+			exitOnError(cmd, err, "Error saving file")
 
-			cmd.Println()
+			out.BlankLine()
 			out.Description("The authentication info has been saved to the profile 'default'.")
 			out.Description("If you work with multiple user accounts or Humio servers you can")
 			out.Description("add more profiles using `humio profiles add <name>`.")
 
-			cmd.Println()
-			out.Output("Bye bye now! 🎉")
-			cmd.Println()
+			out.BlankLine()
+			out.Print("Bye bye now! 🎉")
+			out.BlankLine()
 		},
 	}
 

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -68,33 +68,36 @@ func (p *Prompt) AskSecret(question string) (string, error) {
 	return string(bytes), nil
 }
 
+func (p *Prompt) BlankLine() {
+	fmt.Fprintln(p.Out)
+}
+
 func (p *Prompt) Print(i ...interface{}) {
-	fmt.Fprint(p.Out, "  ")
 	fmt.Fprint(p.Out, i...)
 }
 
-func (p *Prompt) Output(i ...interface{}) {
-	p.Print(fmt.Sprintln(i...))
+func (p *Prompt) Printf(format string, i ...interface{}) {
+	fmt.Fprintf(p.Out, format, i...)
 }
 
 func (p *Prompt) Title(text string) {
 	c := "[underline][bold]" + text + "[reset]"
-	p.Output(Colorize(c))
+	p.Print(Colorize(c))
 }
 
 func (p *Prompt) Description(text string) {
 	c := "[gray]" + text + "[reset]"
-	p.Output(Colorize(c))
+	p.Print(Colorize(c))
 }
 
 func (p *Prompt) Error(text string) {
 	c := "[red]" + text + "[reset]"
-	p.Output(Colorize(c))
+	p.Print(Colorize(c))
 }
 
 func (p *Prompt) Info(text string) {
 	c := "[purple]" + text + "[reset]"
-	p.Output(Colorize(c))
+	p.Print(Colorize(c))
 }
 
 func Colorize(text string) string {


### PR DESCRIPTION
- Streamline use of the logger used by `humioctl`.
- `humioctl` Add/Create/Update subcommands now prints a short entry to StdOut when it succeeds
- Refactor uses of tables into 2 types of tables. One for regular tables with a known header, and one for a two-column tables for printing details about a specific entity.