### PR TITLE
Make ingest fail if no repository is specified instead of defaulting …

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ HUMIO_CA_CERTIFICATE=<ca-certificate>
 
 # If access to the Humio server uses an untrusted certificate and you
 # are unable to provide a CA certificate, you can disable TLS certificate verification.
-# NB: This should only ever be used on test/sandbox clusters where you are in full
+# NB: This should only ever be used on test clusters where you are in full
 # control of the involved systems and underlying network.
 # Do not use this for prodution use-cases.
 HUMIO_INSECURE=<bool>

--- a/cmd/humioctl/ingest.go
+++ b/cmd/humioctl/ingest.go
@@ -97,12 +97,10 @@ func newIngestCmd() *cobra.Command {
 	var retries, batchSizeLines, batchSizeBytes, batchTimeoutMs int
 
 	cmd := cobra.Command{
-		Use:   "ingest [flags] [<repo>]",
+		Use:   "ingest [flags] repo",
 		Short: "Send data to Humio.",
 		Long: `Listens to stdin and sends all input to the repository <repo>.
 If the --ingest-token flag is specified, the repo associated with the ingest token will be used.
-Otherwise, if <repo> is not specified, Humio will use your 'sandbox' repository as
-destination.
 
 It can be handy to specify the parser to be used to ingest the
 data on arrival - i.e. the type of data you are sending.
@@ -120,11 +118,10 @@ has the same effect.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var repo string
 
-			// Default to sending to the sandbox
 			if l := len(args); l == 1 {
 				repo = args[0]
 			} else {
-				repo = "sandbox"
+				log.Fatal("Must specify repo to ingest data")
 			}
 
 			var opts []func(config *api.Config)

--- a/e2e/tests.bats
+++ b/e2e/tests.bats
@@ -31,7 +31,6 @@ load './node_modules/bats-assert/load'
   run $humioctl views list
   assert_success
   assert_output -p "humio-audit"
-  assert_output -p "sandbox"
 }
 
 @test "views show" {


### PR DESCRIPTION
…to sandboxes; Don't mention sandboxes in readme and help texts; Only test whether audit repository is present