### PR TITLE
fix: use syscall.Stdin to use the correct handle based on platform

### DIFF
--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"syscall"
 
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -58,7 +59,7 @@ func (p *Prompt) Confirm(text string) bool {
 
 func (p *Prompt) AskSecret(question string) (string, error) {
 	p.Print(question + ": ")
-	bytes, err := terminal.ReadPassword(0)
+	bytes, err := terminal.ReadPassword(int(syscall.Stdin))
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Stdin on Windows is not 0 and will return `The handle is invalid` when configuring `humioctl` for the first time.

See https://learn.microsoft.com/en-us/windows/console/getstdhandle 

This fixes #108 