### PR TITLE
Adding create,delete,update API call for Humio CLI

### DIFF
--- a/api/groups.go
+++ b/api/groups.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+
 	"github.com/shurcooL/graphql"
 )
 
@@ -14,9 +15,36 @@ type Group struct {
 	DisplayName string
 }
 
+type GroupChangeSet struct {
+	DefaultQueryPrefix *string
+	DefaultRole        *Role
+	// searchDomainRoles                []SearchDomainRole
+	// reconcileSearchDomainQueryPrefix bool
+	GroupID *string
+}
+
 func (c *Client) Groups() *Groups { return &Groups{client: c} }
 
 var ErrUserNotFound = errors.New("user not found")
+
+func (g *Groups) Find(groupName string) (*Group, error) {
+	var query struct {
+		Page struct {
+			Groups []Group `graphql:"page"`
+		} `graphql:"groupsPage(search: $groupName, pageNumber:1, pageSize:1)"`
+	}
+
+	variables := map[string]interface{}{
+		"groupName": graphql.String(groupName),
+	}
+
+	err := g.client.Query(&query, variables)
+	if err != nil {
+		return nil, err
+	}
+
+	return &query.Page.Groups[0], nil
+}
 
 func (g *Groups) List() ([]Group, error) {
 	var query struct {
@@ -31,6 +59,75 @@ func (g *Groups) List() ([]Group, error) {
 	}
 
 	return query.Page.Groups, nil
+}
+
+// TODO:
+// A way to link a list of repos/views to a group, which also contains a link to a corresponding role.
+// A way to link a list of users to a group.
+// I suspect the way we would like to "link" these things is by referencing the names of the resources; however, it's possible it may not be that simple, or that there may be a built-in way to do this. For example, how the views manage connections to repos https://github.com/humio/humio-operator/blob/master/api/v1alpha1/humioview_types.go#L53-L54. There may be cases where we have to pass a generated ID as the link, but then first have to look up the resource by name to fetch the ID to make it human-usable.
+
+func (g *Groups) Create(groupName string) error {
+	var mutation struct {
+		addGroup struct {
+			Group struct {
+				ID string
+			}
+		} `graphql:"addGroup(displayName: $groupName)"`
+	}
+
+	variables := map[string]interface{}{
+		"groupName": graphql.String(groupName),
+	}
+
+	err := g.client.Mutate(&mutation, variables)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *Groups) Delete(groupID string) error {
+	var mutation struct {
+		removeGroup struct {
+			Group struct {
+				ID string
+			}
+		} `graphql:"removeGroup(groupId: $groupID)"`
+	}
+
+	variables := map[string]interface{}{
+		"groupID": graphql.String(groupID),
+	}
+
+	err := g.client.Mutate(&mutation, variables)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *Groups) Update(displayName string, changeset GroupChangeSet) error {
+	var mutation struct {
+		updateGroup struct {
+			Group struct {
+				ID string
+			}
+		} `graphql:"updateGroup(input:{groupId:$groupID, displayName: $displayName})"`
+	}
+
+	variables := map[string]interface{}{
+		"groupID":     graphql.String(*changeset.GroupID),
+		"displayName": graphql.String(displayName),
+	}
+
+	err := g.client.Mutate(&mutation, variables)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (g *Groups) AddUserToGroup(groupID string, userID string) error {

--- a/api/roles.go
+++ b/api/roles.go
@@ -1,0 +1,70 @@
+package api
+
+type Roles struct {
+	client *Client
+}
+
+type Role struct {
+	DisplayName             string
+	ViewPermissions         []string
+	SystemPermissions       []string
+	OrganizationPermissions []string
+}
+
+type SearchDomainRole struct {
+	DomainName *string
+	Role       *Role
+}
+
+//TODO: This whole block is reserved for future development
+
+// func (r *Roles) Create(displayName string, changeset GroupChangeSet) error {
+// 	// var mutation struct {
+// 	// 	RemoveUsersFromGroup struct {
+// 	// 		Group struct {
+// 	// 			ID string
+// 	// 		}
+// 	// 	} `graphql:"removeUsersFromGroup(input:{users:[$userID], groupId: $groupID})"`
+// 	// }
+
+// 	// variables := map[string]interface{}{
+// 	// 	"userID":  graphql.String(userID),
+// 	// 	"groupID": graphql.String(groupID),
+// 	// }
+
+// 	// return g.client.Mutate(&mutation, variables)
+// }
+
+// func (g *Roles) Delete(displayName string) error {
+// 	// var mutation struct {
+// 	// 	RemoveUsersFromGroup struct {
+// 	// 		Group struct {
+// 	// 			ID string
+// 	// 		}
+// 	// 	} `graphql:"removeUsersFromGroup(input:{users:[$userID], groupId: $groupID})"`
+// 	// }
+
+// 	// variables := map[string]interface{}{
+// 	// 	"userID":  graphql.String(userID),
+// 	// 	"groupID": graphql.String(groupID),
+// 	// }
+
+// 	// return g.client.Mutate(&mutation, variables)
+// }
+
+// func (g *Roles) Update(displayName string, changeset GroupChangeSet) error {
+// 	// var mutation struct {
+// 	// 	RemoveUsersFromGroup struct {
+// 	// 		Group struct {
+// 	// 			ID string
+// 	// 		}
+// 	// 	} `graphql:"removeUsersFromGroup(input:{users:[$userID], groupId: $groupID})"`
+// 	// }
+
+// 	// variables := map[string]interface{}{
+// 	// 	"userID":  graphql.String(userID),
+// 	// 	"groupID": graphql.String(groupID),
+// 	// }
+
+// 	// return g.client.Mutate(&mutation, variables)
+// }

--- a/cmd/humioctl/groups.go
+++ b/cmd/humioctl/groups.go
@@ -11,6 +11,10 @@ func newGroupsCmd() *cobra.Command {
 	cmd.AddCommand(newGroupsAddUserCmd())
 	cmd.AddCommand(newGroupsRemoveUserCmd())
 	cmd.AddCommand(newGroupsList())
+	cmd.AddCommand(newGroupsFind())
+	cmd.AddCommand(newGroupsCreate())
+	cmd.AddCommand(newGroupsDelete())
+	cmd.AddCommand(newGroupsUpdate())
 
 	return cmd
 }

--- a/cmd/humioctl/groups_create.go
+++ b/cmd/humioctl/groups_create.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newGroupsCreate() *cobra.Command {
+	return &cobra.Command{
+		Use:   "create",
+		Short: "create group",
+		Run: func(cmd *cobra.Command, args []string) {
+			client := NewApiClient(cmd)
+
+			groupName := args[0]
+
+			err := client.Groups().Create(groupName)
+			exitOnError(cmd, err, "Error creating groups")
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully created group %s", groupName)
+		},
+	}
+}

--- a/cmd/humioctl/groups_delete.go
+++ b/cmd/humioctl/groups_delete.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newGroupsDelete() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete",
+		Short: "delete group",
+		Run: func(cmd *cobra.Command, args []string) {
+			client := NewApiClient(cmd)
+
+			groupID := args[0]
+
+			err := client.Groups().Delete(groupID)
+			exitOnError(cmd, err, "Error deleting groups")
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully created group with GroupID: %s", groupID)
+		},
+	}
+}

--- a/cmd/humioctl/groups_find.go
+++ b/cmd/humioctl/groups_find.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newGroupsFind() *cobra.Command {
+	return &cobra.Command{
+		Use:   "find",
+		Short: "find group by name",
+		Run: func(cmd *cobra.Command, args []string) {
+			client := NewApiClient(cmd)
+
+			group, err := client.Groups().Find(args[0])
+			exitOnError(cmd, err, "Error finding group")
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully found group %s with id %s", group.DisplayName, group.ID)
+		},
+	}
+}

--- a/cmd/humioctl/groups_update.go
+++ b/cmd/humioctl/groups_update.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/humio/cli/api"
+	"github.com/spf13/cobra"
+)
+
+func newGroupsUpdate() *cobra.Command {
+	return &cobra.Command{
+		Use:   "update",
+		Short: "update group",
+		Run: func(cmd *cobra.Command, args []string) {
+			client := NewApiClient(cmd)
+
+			groupID := args[0]
+			displayName := args[1]
+			changeSet := api.GroupChangeSet{
+				GroupID: &groupID,
+			}
+
+			err := client.Groups().Update(displayName, changeSet)
+			exitOnError(cmd, err, "Error updating groups")
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully updated group %s, with GroupID: %s", displayName, groupID)
+		},
+	}
+}


### PR DESCRIPTION
1. This PR ignores the Role creation part as this can be done separately.

2. As you can see, Update graphQL command doesn't really 'update'. I think we need to make an upstream change to make this a useful command. Preferably something like `AddUserInput` with more values.
