### PR TITLE
search: add json-progress flag, to allow easy collection of metadata

### DIFF
--- a/cmd/humioctl/search.go
+++ b/cmd/humioctl/search.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -21,12 +22,13 @@ import (
 
 func newSearchCmd() *cobra.Command {
 	var (
-		start      string
-		end        string
-		live       bool
-		fmtStr     string
-		noWrap     bool
-		noProgress bool
+		start        string
+		end          string
+		live         bool
+		fmtStr       string
+		noWrap       bool
+		noProgress   bool
+		jsonProgress bool
 	)
 
 	cmd := &cobra.Command{
@@ -39,6 +41,14 @@ func newSearchCmd() *cobra.Command {
 			client := NewApiClient(cmd)
 
 			ctx := contextCancelledOnInterrupt(context.Background())
+
+			// get the search start time, used for json output
+			startMillis := time.Now().UnixMilli()
+
+			// set noProgress if getting json
+			if jsonProgress {
+				noProgress = true
+			}
 
 			// run in lambda func to be able to defer and delete the query job
 			err := func() error {
@@ -90,6 +100,10 @@ func newSearchCmd() *cobra.Command {
 					if progress != nil {
 						progress.Update(result)
 					}
+					if jsonProgress {
+						jsonProgress, _ := printQueryResultProgressJson(result, args, startMillis)
+						fmt.Printf("%s\n", jsonProgress)
+					}
 					result, err = poller.WaitAndPollContext(ctx)
 					if err != nil {
 						return err
@@ -101,7 +115,15 @@ func newSearchCmd() *cobra.Command {
 					progress.Finish()
 				}
 
-				printer.print(result)
+				if jsonProgress {
+					jsonProgress, _ := printQueryResultProgressJson(result, args, startMillis)
+					fmt.Printf("%s\n", jsonProgress)
+				}
+
+				// no output if using jsonProgress
+				if !jsonProgress {
+					printer.print(result)
+				}
 
 				if live {
 					for {
@@ -139,6 +161,7 @@ func newSearchCmd() *cobra.Command {
 		"{@timestamp:-40} left aligns and right pads to 40 characters.")
 	cmd.Flags().BoolVarP(&noWrap, "no-wrap", "n", false, "Do not autowrap long strings.")
 	cmd.Flags().BoolVar(&noProgress, "no-progress", false, "Do not should progress information.")
+	cmd.Flags().BoolVar(&jsonProgress, "json-progress", false, "Print progress in json format. This disables progress and output, useful for logging search metadata.")
 
 	return cmd
 }
@@ -212,6 +235,44 @@ func (b *queryResultProgressBar) additionalInfoHits() string {
 
 func (b *queryResultProgressBar) Finish() {
 	b.bar.Finish()
+}
+
+type queryResultProgressJson struct {
+	StartMillis int64   `json:"startMillis"`
+	Repo        string  `json:"repo"`
+	QueryString string  `json:"queryString"`
+	TotalWork   uint64  `json:"totalWork"`
+	WorkDone    uint64  `json:"workDone"`
+	TimeMillis  uint64  `json:"timeMillis"`
+	EpsValue    float64 `json:"epsValue"`
+	BpsValue    float64 `json:"bpsValue"`
+	EventCount  uint64  `json:"eventCount"`
+	Done        bool    `json:"done"`
+}
+
+func printQueryResultProgressJson(result api.QueryResult, args []string, startMillis int64) (string, error) {
+	var epsValue, bpsValue float64
+
+	if result.Metadata.TimeMillis > 0 {
+		epsValue = float64(result.Metadata.ProcessedEvents) / float64(result.Metadata.TimeMillis) * 1000
+		bpsValue = float64(result.Metadata.ProcessedBytes) / float64(result.Metadata.TimeMillis) * 1000
+	}
+
+	jsonResult := &queryResultProgressJson{
+		StartMillis: startMillis,
+		Repo:        args[0],
+		QueryString: args[1],
+		TotalWork:   result.Metadata.TotalWork,
+		WorkDone:    result.Metadata.WorkDone,
+		TimeMillis:  result.Metadata.TimeMillis,
+		EpsValue:    epsValue,
+		BpsValue:    bpsValue,
+		EventCount:  result.Metadata.EventCount,
+		Done:        result.Done,
+	}
+
+	data, err := json.Marshal(jsonResult)
+	return string(data), err
 }
 
 type queryJobPoller struct {

--- a/cmd/humioctl/search.go
+++ b/cmd/humioctl/search.go
@@ -238,9 +238,12 @@ func (b *queryResultProgressBar) Finish() {
 }
 
 type queryResultProgressJson struct {
+	Timestamp   int64   `json:"timestamp"`
 	StartMillis int64   `json:"startMillis"`
 	Repo        string  `json:"repo"`
 	QueryString string  `json:"queryString"`
+	Start       uint64  `json:"start"`
+	End         uint64  `json:"end"`
 	TotalWork   uint64  `json:"totalWork"`
 	WorkDone    uint64  `json:"workDone"`
 	TimeMillis  uint64  `json:"timeMillis"`
@@ -258,10 +261,15 @@ func printQueryResultProgressJson(result api.QueryResult, args []string, startMi
 		bpsValue = float64(result.Metadata.ProcessedBytes) / float64(result.Metadata.TimeMillis) * 1000
 	}
 
+	timestamp := time.Now().UnixMilli()
+
 	jsonResult := &queryResultProgressJson{
+		Timestamp:   timestamp,
 		StartMillis: startMillis,
 		Repo:        args[0],
 		QueryString: args[1],
+		Start:       result.Metadata.QueryStart,
+		End:         result.Metadata.QueryEnd,
 		TotalWork:   result.Metadata.TotalWork,
 		WorkDone:    result.Metadata.WorkDone,
 		TimeMillis:  result.Metadata.TimeMillis,


### PR DESCRIPTION
Added the --json-progress flag to the search options, as it can be useful to get just the search metadata (time, work, bps, eps) to analyse, or feed back into LogScale.

```
./humioctl search humio "* | count()" --start "30d" --json-progress
{"startMillis":1684743601339,"repo":"humio","queryString":"* | count()","totalWork":0,"workDone":0,"timeMillis":1,"epsValue":0,"bpsValue":0,"eventCount":0,"done":false}
{"startMillis":1684743601339,"repo":"humio","queryString":"* | count()","totalWork":0,"workDone":0,"timeMillis":1,"epsValue":0,"bpsValue":0,"eventCount":0,"done":false}
{"startMillis":1684743601339,"repo":"humio","queryString":"* | count()","totalWork":135,"workDone":95,"timeMillis":316,"epsValue":5698933.544303797,"bpsValue":3641665379.746835,"eventCount":1800863,"done":false}
{"startMillis":1684743601339,"repo":"humio","queryString":"* | count()","totalWork":135,"workDone":95,"timeMillis":316,"epsValue":5698933.544303797,"bpsValue":3641665379.746835,"eventCount":1800863,"done":false}
{"startMillis":1684743601339,"repo":"humio","queryString":"* | count()","totalWork":135,"workDone":108,"timeMillis":1318,"epsValue":6642142.640364188,"bpsValue":3158683620.637329,"eventCount":8754344,"done":false}
{"startMillis":1684743601339,"repo":"humio","queryString":"* | count()","totalWork":135,"workDone":108,"timeMillis":1318,"epsValue":6642142.640364188,"bpsValue":3158683620.637329,"eventCount":8754344,"done":false}
{"startMillis":1684743601339,"repo":"humio","queryString":"* | count()","totalWork":135,"workDone":135,"timeMillis":3210,"epsValue":7202546.105919003,"bpsValue":3546733072.8971963,"eventCount":23120173,"done":true}
```