### PR TITLE
fix: Modify graphql struct tag values to add required trailing quotes

### DIFF
--- a/api/roles.go
+++ b/api/roles.go
@@ -14,10 +14,10 @@ type Role struct {
 	ID                string   `graphql:"id"`
 	DisplayName       string   `graphql:"displayName"`
 	Color             string   `graphql:"color"`
-	Description       string   `graphql:"description`
+	Description       string   `graphql:"description"`
 	ViewPermissions   []string `graphql:"viewPermissions"`
-	SystemPermissions []string `graphql:"systemPermissions`
-	OrgPermissions    []string `graphql:"organizationPermissions`
+	SystemPermissions []string `graphql:"systemPermissions"`
+	OrgPermissions    []string `graphql:"organizationPermissions"`
 }
 
 func (c *Client) Roles() *Roles { return &Roles{client: c} }


### PR DESCRIPTION
Queries including Role will fail because `orgPermission` is used due to a missing quotation mark.  Description and SystemPermissions work despite the error because their names resolve to the correct parameter name.