### PR TITLE
API: accept a slice of connection strings

### DIFF
--- a/api/views.go
+++ b/api/views.go
@@ -89,7 +89,7 @@ type ViewConnectionInput struct {
 	Filter         graphql.String `json:"filter"`
 }
 
-func (c *Views) Create(name, description string, connections map[string]string) error {
+func (c *Views) Create(name, description string, connections map[string][]string) error {
 	var mutation struct {
 		CreateView struct {
 			Name        string
@@ -98,13 +98,15 @@ func (c *Views) Create(name, description string, connections map[string]string) 
 	}
 
 	var viewConnections []ViewConnectionInput
-	for k, v := range connections {
-		viewConnections = append(
-			viewConnections,
-			ViewConnectionInput{
-				RepositoryName: graphql.String(k),
-				Filter:         graphql.String(v),
-			})
+	for repo, conns := range connections {
+		for _, conn := range conns {
+			viewConnections = append(
+				viewConnections,
+				ViewConnectionInput{
+					RepositoryName: graphql.String(repo),
+					Filter:         graphql.String(conn),
+				})
+		}
 	}
 
 	variables := map[string]interface{}{

--- a/api/views.go
+++ b/api/views.go
@@ -1,9 +1,10 @@
 package api
 
 import (
-	graphql "github.com/cli/shurcooL-graphql"
 	"sort"
 	"strings"
+
+	graphql "github.com/cli/shurcooL-graphql"
 )
 
 type Views struct {
@@ -130,7 +131,7 @@ func (c *Views) Delete(name, reason string) error {
 	return c.client.Mutate(&mutation, variables)
 }
 
-func (c *Views) UpdateConnections(name string, connections map[string]string) error {
+func (c *Views) UpdateConnections(name string, connections map[string][]string) error {
 	var mutation struct {
 		View struct {
 			Name string
@@ -138,13 +139,15 @@ func (c *Views) UpdateConnections(name string, connections map[string]string) er
 	}
 
 	var viewConnections []ViewConnectionInput
-	for k, v := range connections {
-		viewConnections = append(
-			viewConnections,
-			ViewConnectionInput{
-				RepositoryName: graphql.String(k),
-				Filter:         graphql.String(v),
-			})
+	for repo, conns := range connections {
+		for _, conn := range conns {
+			viewConnections = append(
+				viewConnections,
+				ViewConnectionInput{
+					RepositoryName: graphql.String(repo),
+					Filter:         graphql.String(conn),
+				})
+		}
 	}
 
 	variables := map[string]interface{}{

--- a/cmd/humioctl/views_update.go
+++ b/cmd/humioctl/views_update.go
@@ -21,7 +21,8 @@ import (
 )
 
 func newViewsUpdateCmd() *cobra.Command {
-	connections := make(map[string]string)
+	connsFlag := make(map[string]string)
+	connections := make(map[string][]string)
 	description := ""
 
 	cmd := cobra.Command{
@@ -43,11 +44,14 @@ namely "repo1" and "repo2":
 			viewName := args[0]
 			client := NewApiClient(cmd)
 
-			if len(connections) == 0 && description == "" {
+			if len(connsFlag) == 0 && description == "" {
 				exitOnError(cmd, fmt.Errorf("you must specify at least one flag"), "Nothing specified to update")
 			}
 
-			if len(connections) > 0 {
+			if len(connsFlag) > 0 {
+				for k, v := range connsFlag {
+					connections[k] = append(connections[k], v)
+				}
 				err := client.Views().UpdateConnections(viewName, connections)
 				exitOnError(cmd, err, "Error updating view connections")
 			}
@@ -61,7 +65,7 @@ namely "repo1" and "repo2":
 		},
 	}
 
-	cmd.Flags().StringToStringVar(&connections, "connection", connections, "Sets a repository connection with the chosen filter.")
+	cmd.Flags().StringToStringVar(&connsFlag, "connection", connsFlag, "Sets a repository connection with the chosen filter.")
 	cmd.Flags().StringVar(&description, "description", description, "Sets the view description.")
 
 	return &cmd


### PR DESCRIPTION
It is possible to have multiple connections to the same repository. However, the API currently only accepts a single string for each repository. This change will switch the accepted type to `map[string][]string` so that callers can do something like the following:

```
repo1=somestring
repo1=otherstring
repo2=*
```

The `humioctl views update` sub-command has been modified to pass this data type. Due to the complexity of parsing this on the command line I opted to take only the last supplied value for each repo. Here is some example output from testing it locally:

```shell
❯ bin/humioctl --address http://localhost:8081 views create --connection "humio-usage=*" husage
Successfully created view: "husage"

❯ bin/humioctl --address http://localhost:8081 views update --connection "humio-usage=everything,humio-usage=*" husage
Successfully updated view "husage"

❯ bin/humioctl --address http://localhost:8081 views show husage
   VIEW  | REPOSITORY  | QUERY PREFIX  
+--------+-------------+--------------+
  husage | humio-usage | *             

❯ bin/humioctl --address http://localhost:8081 views update --connection "humio-usage=everything" husage
Successfully updated view "husage"

❯ bin/humioctl --address http://localhost:8081 views show husage
   VIEW  | REPOSITORY  | QUERY PREFIX  
+--------+-------------+--------------+
  husage | humio-usage | everything    

❯ bin/humioctl --address http://localhost:8081 views update --connection "humio-usage=*,humio=everything" husage
Successfully updated view "husage"

❯ bin/humioctl --address http://localhost:8081 views show husage
   VIEW  | REPOSITORY  | QUERY PREFIX  
+--------+-------------+--------------+
  husage | humio-usage | *             
  husage | humio       | everything    

❯ bin/humioctl --address http://localhost:8081 views update --connection "humio-usage=*,humio=everything,humio-usage=everything" husage
Successfully updated view "husage"

❯ bin/humioctl --address http://localhost:8081 views show husage
   VIEW  | REPOSITORY  | QUERY PREFIX  
+--------+-------------+--------------+
  husage | humio-usage | everything    
  husage | humio       | everything    

❯ bin/humioctl --address http://localhost:8081 views show husage

❯ bin/humioctl --address http://localhost:8081 views update --connection "humio-usage=*,humio=everything,humio-usage=everything,humio-usage=*" husage
Successfully updated view "husage"

❯ bin/humioctl --address http://localhost:8081 views show husage
   VIEW  | REPOSITORY  | QUERY PREFIX  
+--------+-------------+--------------+
  husage | humio-usage | *             
  husage | humio       | everything    
```

Some notes on this PR:
- there are no unit tests because there are no unit tests in this repository :cry:
- I attempted to add an "e2e" test but that seems to be failing completely and unused