### PR TITLE
Add only-views flag to `views list` sub-command

### DIFF
--- a/api/views.go
+++ b/api/views.go
@@ -1,9 +1,10 @@
 package api
 
 import (
-	graphql "github.com/cli/shurcooL-graphql"
 	"sort"
 	"strings"
+
+	graphql "github.com/cli/shurcooL-graphql"
 )
 
 type Views struct {
@@ -66,7 +67,8 @@ func (c *Views) Get(name string) (*View, error) {
 }
 
 type ViewListItem struct {
-	Name string
+	Name     string
+	Typename string `graphql:"__typename"`
 }
 
 func (c *Views) List() ([]ViewListItem, error) {

--- a/cmd/humioctl/views_list.go
+++ b/cmd/humioctl/views_list.go
@@ -19,8 +19,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const viewTypeName = "View"
+
 func newViewsListCmd() *cobra.Command {
-	return &cobra.Command{
+	var viewOnly bool
+
+	cmd := cobra.Command{
 		Use:   "list",
 		Short: "Lists all views you have access to",
 		Run: func(cmd *cobra.Command, args []string) {
@@ -31,10 +35,18 @@ func newViewsListCmd() *cobra.Command {
 
 			rows := make([][]format.Value, len(views))
 			for i, view := range views {
-				rows[i] = []format.Value{format.String(view.Name)}
+				if viewOnly && view.Typename == viewTypeName {
+					rows[i] = []format.Value{format.String(view.Name)}
+				} else {
+					rows[i] = []format.Value{format.String(view.Name)}
+				}
 			}
 
 			printOverviewTable(cmd, []string{"Name"}, rows)
 		},
 	}
+
+	cmd.Flags().BoolVar(&viewOnly, "only-views", false, "Display only Views (i.e. do not include Repositories).")
+
+	return &cmd
 }

--- a/cmd/humioctl/views_list.go
+++ b/cmd/humioctl/views_list.go
@@ -35,8 +35,10 @@ func newViewsListCmd() *cobra.Command {
 
 			rows := make([][]format.Value, len(views))
 			for i, view := range views {
-				if viewOnly && view.Typename == viewTypeName {
-					rows[i] = []format.Value{format.String(view.Name)}
+				if viewOnly {
+					if view.Typename == viewTypeName {
+						rows[i] = []format.Value{format.String(view.Name)}
+					}
 				} else {
 					rows[i] = []format.Value{format.String(view.Name)}
 				}


### PR DESCRIPTION
Given the name of the sub-command I was surprised to discover that the returned list included repositories as well. It seems quite reasonable to include a flag to force the issue in the cases where one truly only wants to list views.