### PR TITLE
Disable cgo for deployment builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,6 +3,8 @@ project_name: humioctl
 builds:
   - binary: humioctl
     main: ./cmd/humioctl
+    env:
+      - CGO_ENABLED=0
     goos:
       - windows
       - darwin


### PR DESCRIPTION
Disable cgo as I believe it is unnecessary for this tool and it is also causing problems for people that have older versions of libc on their system.

Fixes #140 