### PR TITLE
Allow configuration of S3 archiving on a repository

### DIFF
--- a/api/internal/humiographql/s3-configuration.go
+++ b/api/internal/humiographql/s3-configuration.go
@@ -1,0 +1,55 @@
+package humiographql
+
+import (
+	"fmt"
+	"strings"
+)
+
+type S3Configuration struct {
+	Bucket   string            `graphql:"bucket"`
+	Region   string            `graphql:"region"`
+	Disabled bool              `graphql:"disabled"`
+	Format   S3ArchivingFormat `graphql:"format"`
+}
+
+// IsEnabled - determine if S3Configuration is enabled based on values and the Disabled field
+// to avoid a bool defaulting to false
+func (s *S3Configuration) IsEnabled() bool {
+	if s.IsConfigured() == false {
+		return false
+	}
+	return !s.Disabled
+}
+
+func (s *S3Configuration) IsConfigured() bool {
+	if s.Bucket != "" && s.Region != "" && s.Format != "" {
+		return true
+	}
+	return false
+}
+
+// S3ArchivingFormat - the format in which to store the archived data on S3, either RAW or NDJSON
+type S3ArchivingFormat string
+
+const DefaultS3ArchivingFormat = S3ArchivingFormat("NDSON")
+
+var ValidS3ArchivingFormats = []S3ArchivingFormat{"NDJSON", "RAW"}
+
+// NewS3ArchivingFormat - creates a S3ArchivingFormat and ensures the value is uppercase
+func NewS3ArchivingFormat(format string) (S3ArchivingFormat, error) {
+	f := S3ArchivingFormat(strings.ToUpper(string(format)))
+	err := f.Validate()
+	if err != nil {
+		return "", err
+	}
+	return f, nil
+}
+
+func (f *S3ArchivingFormat) Validate() error {
+	for _, v := range ValidS3ArchivingFormats {
+		if v == *f {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid S3 archiving format. Valid formats: %s", ValidS3ArchivingFormats)
+}

--- a/cmd/humioctl/repos.go
+++ b/cmd/humioctl/repos.go
@@ -45,6 +45,10 @@ func printRepoDetailsTable(cmd *cobra.Command, repo api.Repository) {
 		{format.String("Ingest Retention (Size)"), ByteCountDecimal(repo.IngestRetentionSizeGB * 1e9)},
 		{format.String("Storage Retention (Size)"), ByteCountDecimal(repo.StorageRetentionSizeGB * 1e9)},
 		{format.String("Retention (Days)"), format.Int(repo.RetentionDays)},
+		{format.String("S3 Archiving Enabled"), format.Bool(repo.S3ArchivingConfiguration.IsEnabled())},
+		{format.String("S3 Archiving Bucket"), format.String(repo.S3ArchivingConfiguration.Bucket)},
+		{format.String("S3 Archiving Region"), format.String(repo.S3ArchivingConfiguration.Region)},
+		{format.String("S3 Archiving Format"), format.String(repo.S3ArchivingConfiguration.Format)},
 	}
 
 	printDetailsTable(cmd, details)

--- a/cmd/humioctl/repos_update.go
+++ b/cmd/humioctl/repos_update.go
@@ -34,7 +34,7 @@ func newReposUpdateCmd() *cobra.Command {
 			client := NewApiClient(cmd)
 
 			if descriptionFlag.value == nil && retentionTimeFlag.value == nil && ingestSizeBasedRetentionFlag.value == nil && storageSizeBasedRetentionFlag.value == nil &&
-				s3ArchivingBucketFlag.value == nil && s3ArchivingRegionFlag.value == nil && s3ArchivingFormatFlag.value == nil {
+				enableS3ArchivingFlag == false && disableS3ArchivingFlag == false && s3ArchivingBucketFlag.value == nil && s3ArchivingRegionFlag.value == nil && s3ArchivingFormatFlag.value == nil {
 				exitOnError(cmd, fmt.Errorf("you must specify at least one flag to update"), "Nothing specified to update")
 			}
 			if descriptionFlag.value != nil {

--- a/cmd/humioctl/repos_update.go
+++ b/cmd/humioctl/repos_update.go
@@ -21,8 +21,8 @@ import (
 )
 
 func newReposUpdateCmd() *cobra.Command {
-	var allowDataDeletionFlag bool
-	var descriptionFlag stringPtrFlag
+	var allowDataDeletionFlag, enableS3ArchivingFlag, disableS3ArchivingFlag bool
+	var descriptionFlag, s3ArchivingBucketFlag, s3ArchivingRegionFlag, s3ArchivingFormatFlag stringPtrFlag
 	var retentionTimeFlag, ingestSizeBasedRetentionFlag, storageSizeBasedRetentionFlag float64PtrFlag
 
 	cmd := cobra.Command{
@@ -33,10 +33,10 @@ func newReposUpdateCmd() *cobra.Command {
 			repoName := args[0]
 			client := NewApiClient(cmd)
 
-			if descriptionFlag.value == nil && retentionTimeFlag.value == nil && ingestSizeBasedRetentionFlag.value == nil && storageSizeBasedRetentionFlag.value == nil {
+			if descriptionFlag.value == nil && retentionTimeFlag.value == nil && ingestSizeBasedRetentionFlag.value == nil && storageSizeBasedRetentionFlag.value == nil &&
+				s3ArchivingBucketFlag.value == nil && s3ArchivingRegionFlag.value == nil && s3ArchivingFormatFlag.value == nil {
 				exitOnError(cmd, fmt.Errorf("you must specify at least one flag to update"), "Nothing specified to update")
 			}
-
 			if descriptionFlag.value != nil {
 				err := client.Repositories().UpdateDescription(repoName, *descriptionFlag.value)
 				exitOnError(cmd, err, "Error updating repository description")
@@ -54,6 +54,21 @@ func newReposUpdateCmd() *cobra.Command {
 				exitOnError(cmd, err, "Error updating repository storage size based retention")
 			}
 
+			if s3ArchivingBucketFlag.value != nil && s3ArchivingRegionFlag.value != nil && s3ArchivingFormatFlag.value != nil {
+				err := client.Repositories().UpdateS3ArchivingConfiguration(repoName, *s3ArchivingBucketFlag.value, *s3ArchivingRegionFlag.value, *s3ArchivingFormatFlag.value)
+				exitOnError(cmd, err, "Error updating S3 archiving configuration")
+			}
+
+			if disableS3ArchivingFlag == true {
+				err := client.Repositories().DisableS3Archiving(repoName)
+				exitOnError(cmd, err, "Error disabling S3 archiving")
+			}
+
+			if enableS3ArchivingFlag == true {
+				err := client.Repositories().EnableS3Archiving(repoName)
+				exitOnError(cmd, err, "Error enabling S3 archiving")
+			}
+
 			fmt.Fprintf(cmd.OutOrStdout(), "Successfully updated repository %q\n", repoName)
 		},
 	}
@@ -63,6 +78,13 @@ func newReposUpdateCmd() *cobra.Command {
 	cmd.Flags().Var(&retentionTimeFlag, "retention-time", "The retention time in days for the repository.")
 	cmd.Flags().Var(&ingestSizeBasedRetentionFlag, "ingest-size-based-retention", "The ingest size based retention for the repository.")
 	cmd.Flags().Var(&storageSizeBasedRetentionFlag, "storage-size-based-retention", "The storage size based retention for the repository.")
+	cmd.Flags().BoolVar(&enableS3ArchivingFlag, "enable-s3-archiving", false, "Enable S3 Archiving")
+	cmd.Flags().BoolVar(&disableS3ArchivingFlag, "disable-s3-archiving", false, "Disable S3 Archiving")
+	cmd.Flags().Var(&s3ArchivingBucketFlag, "s3-archiving-bucket", "The name of the bucket to be used for S3 Archiving")
+	cmd.Flags().Var(&s3ArchivingRegionFlag, "s3-archiving-region", "The S3 region to be used for S3 Archiving")
+	cmd.Flags().Var(&s3ArchivingFormatFlag, "s3-archiving-format", "The S3 archiving format to be used for S3 Archiving. Formats: RAW, NDJSON")
+	cmd.MarkFlagsRequiredTogether("s3-archiving-bucket", "s3-archiving-region", "s3-archiving-format")
+	cmd.MarkFlagsMutuallyExclusive("enable-s3-archiving", "disable-s3-archiving")
 
 	return &cmd
 }


### PR DESCRIPTION
This change:
- Adds flags to `humioctl repos update` to allow the enabling, disabling and configuration of the S3 archiving feature.
- Adds S3 configuration to `humioctl repos show` output

Flags added:
- `--enable-s3-archiving` - checks to see if S3 archiving configuration exists and then enables S3 archiving
- `--disable-s3-archiving` - checks to see if S3 archiving configuration exists and then disables S3 archiving
- `--s3-archiving-bucket` - provides the bucket for the S3 archiving configuration, this value is validated to make sure it's not empty
- `--s3-archiving-region` - provides the region for the S3 archiving configuration, this value is validated to make sure it's not empty
- `--s3-archiving-format` - provides the format for the S3 archiving format, this value is validated to be "NDJSON" or "RAW".

All of the `--s3-archiving-*` flags are required to apply the configuration.


Example of `humioctl repos show` with S3 archiving configured and enabled:
```
$ humioctl --address http://logscale.logscale.svc.cluster.local:8080 --token-file token repos show syssed58
                        ID | rm5rNZ2QLmP4jTm7OW4diair  
                      Name | tmp_repository                  
               Description |                           
                Space Used | 0 B                       
   Ingest Retention (Size) | 0 B                       
  Storage Retention (Size) | 0 B                       
          Retention (Days) | 1                         
      S3 Archiving Enabled | true                      
       S3 Archiving Bucket | s3archiving
       S3 Archiving Region | us-east-1                 
       S3 Archiving Format | NDJSON  
```

Example of `humio repos show` without S3 archiving configured:
```
$ humioctl --address http://logscale.logscale.svc.cluster.local:8080 --token-file token repos show humio-usage
                        ID | jj0BhbAYUeIgX5DexROJgUe7  
                      Name | humio-usage               
               Description |                           
                Space Used | 224.6 kB                  
   Ingest Retention (Size) | 0 B                       
  Storage Retention (Size) | 0 B                       
          Retention (Days) | 0                         
      S3 Archiving Enabled | false                     
       S3 Archiving Bucket |                           
       S3 Archiving Region |                           
       S3 Archiving Format |        
```

Validation examples:
```
humioctl:~$ humioctl --address http://logscale.logscale.svc.cluster.local:8080 --token-file token repos update --s3-archiving-bucket "" --s3-archiving-region "" --s3-archiving-format "" tmp_repository
Error updating S3 archiving configuration: bucket name cannot have an empty value
humioctl:~$ humioctl --address http://logscale.logscale.svc.cluster.local:8080 --token-file token repos update --s3-archiving-bucket s3archiving--s3-archiving-region "" --s3-archiving-format "" tmp_repository
Error updating S3 archiving configuration: region cannot have an empty value
humioctl:~$ humioctl --address http://logscale.logscale.svc.cluster.local:8080 --token-file token repos update --s3-archiving-bucket s3archiving--s3-archiving-region us-east-1 --s3-archiving-format "" tmp_repository
Error updating S3 archiving configuration: invalid S3 archiving format. Valid formats: [NDJSON RAW]
humioctl:~$ humioctl --address http://logscale.logscale.svc.cluster.local:8080 --token-file token repos update --s3-archiving-bucket s3archiving--s3-archiving-region us-east-1 --s3-archiving-format "ndjson" tmp_repository
Successfully updated repository "tmp_repository"
```

