### PR TITLE
Add enable/disable automatic search option on repos and view

### DIFF
--- a/api/repositories.go
+++ b/api/repositories.go
@@ -21,6 +21,7 @@ type Repository struct {
 	StorageRetentionSizeGB   float64                      `graphql:"storageSizeBasedRetention"`
 	SpaceUsed                int64                        `graphql:"compressedByteSize"`
 	S3ArchivingConfiguration humiographql.S3Configuration `graphql:"s3ArchivingConfiguration"`
+	AutomaticSearch          bool                         `graphql:"automaticSearch"`
 }
 
 func (c *Client) Repositories() *Repositories { return &Repositories{client: c} }
@@ -325,6 +326,22 @@ func (r *Repositories) UpdateS3ArchivingConfiguration(name string, bucket string
 		"bucket": graphql.String(bucket),
 		"region": graphql.String(region),
 		"format": archivingFormat,
+	}
+
+	return r.client.Mutate(&mutation, variables)
+}
+
+func (r *Repositories) UpdateAutomaticSearch(name string, automaticSearch bool) error {
+	var mutation struct {
+		SetAutomaticSearching struct {
+			// We have to make a selection, so just take __typename
+			Typename graphql.String `graphql:"__typename"`
+		} `graphql:"setAutomaticSearching(name: $name, automaticSearch: $automaticSearch)"`
+	}
+
+	variables := map[string]interface{}{
+		"name":            graphql.String(name),
+		"automaticSearch": graphql.Boolean(automaticSearch),
 	}
 
 	return r.client.Mutate(&mutation, variables)

--- a/cmd/humioctl/repos.go
+++ b/cmd/humioctl/repos.go
@@ -49,6 +49,7 @@ func printRepoDetailsTable(cmd *cobra.Command, repo api.Repository) {
 		{format.String("S3 Archiving Bucket"), format.String(repo.S3ArchivingConfiguration.Bucket)},
 		{format.String("S3 Archiving Region"), format.String(repo.S3ArchivingConfiguration.Region)},
 		{format.String("S3 Archiving Format"), format.String(repo.S3ArchivingConfiguration.Format)},
+		{format.String("Automatic Search"), format.Bool(repo.AutomaticSearch)},
 	}
 
 	printDetailsTable(cmd, details)

--- a/cmd/humioctl/views_list.go
+++ b/cmd/humioctl/views_list.go
@@ -37,14 +37,16 @@ func newViewsListCmd() *cobra.Command {
 			for i, view := range views {
 				if viewOnly {
 					if view.Typename == viewTypeName {
-						rows[i] = []format.Value{format.String(view.Name)}
+						rows[i] = []format.Value{format.String(view.Name),
+							format.Bool(view.AutomaticSearch)}
 					}
 				} else {
-					rows[i] = []format.Value{format.String(view.Name)}
+					rows[i] = []format.Value{format.String(view.Name),
+						format.Bool(view.AutomaticSearch)}
 				}
 			}
 
-			printOverviewTable(cmd, []string{"Name"}, rows)
+			printOverviewTable(cmd, []string{"Name", "Automatic Search"}, rows)
 		},
 	}
 


### PR DESCRIPTION
This change:

- Adds flags to `humioctl repos update` and `humioctl views update` commands to allow enabling and disabling of the automatic search option when opening the search page.
- Adds the `Automatic Search` field to the output of the `humioctl repos show <repo>` and `humioctl views list` commands.

Examples:
```
$ humioctl repos update test-01 --enable-automatic-search
Successfully updated repository "test-01"

$ humioctl repos show test-01                            
    ID | UwpQawtLNh4FHD6SNOAcTQOJ  
    Name | test-01                   
 <... removed for brevity ...>
    Automatic Search | true

$ humioctl views update view-01 --disable-automatic-search
Successfully updated view "view-01"

$ humioctl views list --only-views                        
   NAME   | AUTOMATIC SEARCH  
+---------+------------------+
  view-01 | false             
  view-02 | false             
```
