### PR TITLE
Aggregate alerts

### DIFF
--- a/api/aggregate-alerts.go
+++ b/api/aggregate-alerts.go
@@ -1,0 +1,242 @@
+package api
+
+import (
+	"fmt"
+	graphql "github.com/cli/shurcooL-graphql"
+	"github.com/humio/cli/api/internal/humiographql"
+)
+
+type AggregateAlert struct {
+	ID                    string   `graphql:"id"                    yaml:"-"                       json:"id"`
+	Name                  string   `graphql:"name"                  yaml:"name"                    json:"name"`
+	Description           string   `graphql:"description"           yaml:"description,omitempty"   json:"description,omitempty"`
+	QueryString           string   `graphql:"queryString"           yaml:"queryString"             json:"queryString"`
+	SearchIntervalSeconds int      `graphql:"searchIntervalSeconds" yaml:"searchIntervalSeconds"   json:"searchIntervalSeconds"`
+	ActionNames           []string `graphql:"actionNames"           yaml:"actionNames"             json:"actionNames"`
+	Labels                []string `graphql:"labels"                yaml:"labels"                  json:"labels"`
+	Enabled               bool     `graphql:"enabled"               yaml:"enabled"                 json:"enabled"`
+	ThrottleField         string   `graphql:"throttleField"         yaml:"throttleField,omitempty" json:"throttleField,omitempty"`
+	ThrottleTimeSeconds   int      `graphql:"throttleTimeSeconds"   yaml:"throttleTimeSeconds"     json:"throttleTimeSeconds"`
+	QueryOwnershipType    string   `graphql:"queryOwnership"        yaml:"queryOwnershipType"      json:"queryOwnershipType"`
+	TriggerMode           string   `graphql:"triggerMode"           yaml:"triggerMode"             json:"triggerMode"`
+	QueryTimestampType    string   `graphql:"queryTimestampType"    yaml:"queryTimestampType"      json:"queryTimestampType"`
+	RunAsUserID           string   `graphql:"runAsUserId"           yaml:"runAsUserId,omitempty"   json:"runAsUserId,omitempty"`
+}
+
+type AggregateAlerts struct {
+	client *Client
+}
+
+func (c *Client) AggregateAlerts() *AggregateAlerts { return &AggregateAlerts{client: c} }
+
+func (a *AggregateAlerts) List(viewName string) ([]AggregateAlert, error) {
+	var query struct {
+		SearchDomain struct {
+			AggregateAlerts []humiographql.AggregateAlert `graphql:"aggregateAlerts"`
+		} `graphql:"searchDomain(name: $viewName)"`
+	}
+
+	variables := map[string]any{
+		"viewName": graphql.String(viewName),
+	}
+
+	err := a.client.Query(&query, variables)
+	if err != nil {
+		return nil, err
+	}
+
+	var aggregateAlerts = make([]AggregateAlert, len(query.SearchDomain.AggregateAlerts))
+	for i := range query.SearchDomain.AggregateAlerts {
+		aggregateAlerts[i] = mapHumioGraphqlAggregateAlertToAggregateAlert(query.SearchDomain.AggregateAlerts[i])
+	}
+
+	return aggregateAlerts, err
+}
+
+func (a *AggregateAlerts) Update(viewName string, updatedAggregateAlert *AggregateAlert) (*AggregateAlert, error) {
+	if updatedAggregateAlert == nil {
+		return nil, fmt.Errorf("updatedAggregateAlert must not be nil")
+	}
+
+	if updatedAggregateAlert.ID == "" {
+		return nil, fmt.Errorf("updatedAggregateAlert must have non-empty ID")
+	}
+
+	var mutation struct {
+		humiographql.AggregateAlert `graphql:"updateAggregateAlert(input: $input)"`
+	}
+
+	actionNames := make([]graphql.String, len(updatedAggregateAlert.ActionNames))
+	for i, actionName := range updatedAggregateAlert.ActionNames {
+		actionNames[i] = graphql.String(actionName)
+	}
+
+	labels := make([]graphql.String, len(updatedAggregateAlert.Labels))
+	for i, label := range updatedAggregateAlert.Labels {
+		labels[i] = graphql.String(label)
+	}
+
+	updateAlert := humiographql.UpdateAggregateAlert{
+		ViewName:              humiographql.RepoOrViewName(viewName),
+		ID:                    graphql.String(updatedAggregateAlert.ID),
+		Name:                  graphql.String(updatedAggregateAlert.Name),
+		Description:           graphql.String(updatedAggregateAlert.Description),
+		QueryString:           graphql.String(updatedAggregateAlert.QueryString),
+		SearchIntervalSeconds: humiographql.Long(updatedAggregateAlert.SearchIntervalSeconds),
+		ActionIdsOrNames:      actionNames,
+		Labels:                labels,
+		Enabled:               graphql.Boolean(updatedAggregateAlert.Enabled),
+		RunAsUserID:           graphql.String(updatedAggregateAlert.RunAsUserID),
+		ThrottleField:         graphql.String(updatedAggregateAlert.ThrottleField),
+		ThrottleTimeSeconds:   humiographql.Long(updatedAggregateAlert.ThrottleTimeSeconds),
+		TriggerMode:           humiographql.TriggerMode(updatedAggregateAlert.TriggerMode),
+		QueryTimestampType:    humiographql.QueryTimestampType(updatedAggregateAlert.QueryTimestampType),
+		QueryOwnershipType:    humiographql.QueryOwnershipType(updatedAggregateAlert.QueryOwnershipType),
+	}
+
+	variables := map[string]any{
+		"input": updateAlert,
+	}
+
+	err := a.client.Mutate(&mutation, variables)
+	if err != nil {
+		return nil, err
+	}
+
+	aggregateAlert := mapHumioGraphqlAggregateAlertToAggregateAlert(mutation.AggregateAlert)
+
+	return &aggregateAlert, nil
+}
+
+func (a *AggregateAlerts) Create(viewName string, newAggregateAlert *AggregateAlert) (*AggregateAlert, error) {
+	if newAggregateAlert == nil {
+		return nil, fmt.Errorf("newAggregateAlert must not be nil")
+	}
+
+	var mutation struct {
+		humiographql.AggregateAlert `graphql:"createAggregateAlert(input: $input)"`
+	}
+
+	actionNames := make([]graphql.String, len(newAggregateAlert.ActionNames))
+	for i, actionName := range newAggregateAlert.ActionNames {
+		actionNames[i] = graphql.String(actionName)
+	}
+
+	labels := make([]graphql.String, len(newAggregateAlert.Labels))
+	for i, label := range newAggregateAlert.Labels {
+		labels[i] = graphql.String(label)
+	}
+
+	createAggregateAlert := humiographql.CreateAggregateAlert{
+		ViewName:              humiographql.RepoOrViewName(viewName),
+		Name:                  graphql.String(newAggregateAlert.Name),
+		Description:           graphql.String(newAggregateAlert.Description),
+		QueryString:           graphql.String(newAggregateAlert.QueryString),
+		SearchIntervalSeconds: humiographql.Long(newAggregateAlert.SearchIntervalSeconds),
+		ActionIdsOrNames:      actionNames,
+		Labels:                labels,
+		Enabled:               graphql.Boolean(newAggregateAlert.Enabled),
+		ThrottleField:         graphql.String(newAggregateAlert.ThrottleField),
+		ThrottleTimeSeconds:   humiographql.Long(newAggregateAlert.ThrottleTimeSeconds),
+		RunAsUserID:           graphql.String(newAggregateAlert.RunAsUserID),
+		TriggerMode:           humiographql.TriggerMode(newAggregateAlert.TriggerMode),
+		QueryTimestampType:    humiographql.QueryTimestampType(newAggregateAlert.QueryTimestampType),
+		QueryOwnershipType:    humiographql.QueryOwnershipType(newAggregateAlert.QueryOwnershipType),
+	}
+
+	variables := map[string]any{
+		"input": createAggregateAlert,
+	}
+
+	err := a.client.Mutate(&mutation, variables)
+	if err != nil {
+		return nil, err
+	}
+
+	aggregateAlert := mapHumioGraphqlAggregateAlertToAggregateAlert(mutation.AggregateAlert)
+
+	return &aggregateAlert, nil
+}
+
+func (a *AggregateAlerts) Delete(viewName, aggregateAlertID string) error {
+	if aggregateAlertID == "" {
+		return fmt.Errorf("aggregateAlertID is empty")
+	}
+
+	var mutation struct {
+		DidDelete bool `graphql:"deleteAggregateAlert(input: { viewName: $viewName, id: $id })"`
+	}
+
+	variables := map[string]any{
+		"viewName": humiographql.RepoOrViewName(viewName),
+		"id":       graphql.String(aggregateAlertID),
+	}
+
+	err := a.client.Mutate(&mutation, variables)
+
+	if !mutation.DidDelete {
+		return fmt.Errorf("unable to remove aggregate alert in repo/view '%s' with id '%s'", viewName, aggregateAlertID)
+	}
+
+	return err
+}
+
+func (a *AggregateAlerts) Get(viewName string, aggregateAlertID string) (*AggregateAlert, error) {
+	var query struct {
+		SearchDomain struct {
+			AggregateAlert humiographql.AggregateAlert `graphql:"aggregateAlert(id: $aggregateAlertId)"`
+		} `graphql:"searchDomain(name: $viewName) "`
+	}
+
+	variables := map[string]any{
+		"viewName":         graphql.String(viewName),
+		"aggregateAlertId": graphql.String(aggregateAlertID),
+	}
+
+	err := a.client.Query(&query, variables)
+	if err != nil {
+		return nil, err
+	}
+
+	aggregateAlert := mapHumioGraphqlAggregateAlertToAggregateAlert(query.SearchDomain.AggregateAlert)
+
+	return &aggregateAlert, nil
+}
+
+func mapHumioGraphqlAggregateAlertToAggregateAlert(input humiographql.AggregateAlert) AggregateAlert {
+	var queryOwnershipType, runAsUserID string
+	switch input.QueryOwnership.QueryOwnershipTypeName {
+	case humiographql.QueryOwnershipTypeNameOrganization:
+		queryOwnershipType = QueryOwnershipTypeOrganization
+	case humiographql.QueryOwnershipTypeNameUser:
+		queryOwnershipType = QueryOwnershipTypeUser
+		runAsUserID = string(input.QueryOwnership.ID)
+	}
+
+	var actionNames = make([]string, len(input.Actions))
+	for i := range input.Actions {
+		actionNames[i] = string(input.Actions[i].Name)
+	}
+
+	var labels = make([]string, len(input.Labels))
+	for i := range input.Labels {
+		labels[i] = string(input.Labels[i])
+	}
+
+	return AggregateAlert{
+		ID:                    string(input.ID),
+		Name:                  string(input.Name),
+		Description:           string(input.Description),
+		QueryString:           string(input.QueryString),
+		SearchIntervalSeconds: int(input.SearchIntervalSeconds),
+		ActionNames:           actionNames,
+		Labels:                labels,
+		Enabled:               bool(input.Enabled),
+		ThrottleField:         string(input.ThrottleField),
+		ThrottleTimeSeconds:   int(input.ThrottleTimeSeconds),
+		QueryOwnershipType:    queryOwnershipType,
+		TriggerMode:           string(input.TriggerMode),
+		QueryTimestampType:    string(input.QueryTimestampType),
+		RunAsUserID:           runAsUserID,
+	}
+}

--- a/api/aggregate-alerts.go
+++ b/api/aggregate-alerts.go
@@ -29,7 +29,11 @@ type AggregateAlerts struct {
 
 func (c *Client) AggregateAlerts() *AggregateAlerts { return &AggregateAlerts{client: c} }
 
-func (a *AggregateAlerts) List(viewName string) ([]AggregateAlert, error) {
+func (a *AggregateAlerts) List(viewName string) ([]*AggregateAlert, error) {
+	if viewName == "" {
+		return nil, fmt.Errorf("viewName must not be empty")
+	}
+
 	var query struct {
 		SearchDomain struct {
 			AggregateAlerts []humiographql.AggregateAlert `graphql:"aggregateAlerts"`
@@ -45,15 +49,20 @@ func (a *AggregateAlerts) List(viewName string) ([]AggregateAlert, error) {
 		return nil, err
 	}
 
-	var aggregateAlerts = make([]AggregateAlert, len(query.SearchDomain.AggregateAlerts))
+	var aggregateAlerts = make([]*AggregateAlert, len(query.SearchDomain.AggregateAlerts))
 	for i := range query.SearchDomain.AggregateAlerts {
-		aggregateAlerts[i] = mapHumioGraphqlAggregateAlertToAggregateAlert(query.SearchDomain.AggregateAlerts[i])
+		alert := mapHumioGraphqlAggregateAlertToAggregateAlert(query.SearchDomain.AggregateAlerts[i])
+		aggregateAlerts[i] = &alert
 	}
 
-	return aggregateAlerts, err
+	return aggregateAlerts, nil
 }
 
 func (a *AggregateAlerts) Update(viewName string, updatedAggregateAlert *AggregateAlert) (*AggregateAlert, error) {
+	if viewName == "" {
+		return nil, fmt.Errorf("viewName must not be empty")
+	}
+
 	if updatedAggregateAlert == nil {
 		return nil, fmt.Errorf("updatedAggregateAlert must not be nil")
 	}
@@ -109,6 +118,10 @@ func (a *AggregateAlerts) Update(viewName string, updatedAggregateAlert *Aggrega
 }
 
 func (a *AggregateAlerts) Create(viewName string, newAggregateAlert *AggregateAlert) (*AggregateAlert, error) {
+	if viewName == "" {
+		return nil, fmt.Errorf("viewName must not be empty")
+	}
+
 	if newAggregateAlert == nil {
 		return nil, fmt.Errorf("newAggregateAlert must not be nil")
 	}
@@ -159,6 +172,10 @@ func (a *AggregateAlerts) Create(viewName string, newAggregateAlert *AggregateAl
 }
 
 func (a *AggregateAlerts) Delete(viewName, aggregateAlertID string) error {
+	if viewName == "" {
+		return fmt.Errorf("viewName must not be empty")
+	}
+
 	if aggregateAlertID == "" {
 		return fmt.Errorf("aggregateAlertID is empty")
 	}
@@ -186,6 +203,14 @@ func (a *AggregateAlerts) Get(viewName string, aggregateAlertID string) (*Aggreg
 		SearchDomain struct {
 			AggregateAlert humiographql.AggregateAlert `graphql:"aggregateAlert(id: $aggregateAlertId)"`
 		} `graphql:"searchDomain(name: $viewName) "`
+	}
+
+	if viewName == "" {
+		return nil, fmt.Errorf("viewName must not be empty")
+	}
+
+	if aggregateAlertID == "" {
+		return nil, fmt.Errorf("aggregateAlertID must not be empty")
 	}
 
 	variables := map[string]any{

--- a/api/error.go
+++ b/api/error.go
@@ -12,6 +12,7 @@ const (
 	EntityTypeAlert           EntityType = "alert"
 	EntityTypeFilterAlert     EntityType = "filter-alert"
 	EntityTypeScheduledSearch EntityType = "scheduled-search"
+	EntityTypeAggregateAlert  EntityType = "aggregate-alert"
 )
 
 func (e EntityType) String() string {
@@ -66,6 +67,13 @@ func FilterAlertNotFound(name string) error {
 func ScheduledSearchNotFound(name string) error {
 	return EntityNotFound{
 		entityType: EntityTypeScheduledSearch,
+		key:        name,
+	}
+}
+
+func AggregateAlertNotFound(name string) error {
+	return EntityNotFound{
+		entityType: EntityTypeAggregateAlert,
 		key:        name,
 	}
 }

--- a/api/internal/humiographql/action.go
+++ b/api/internal/humiographql/action.go
@@ -1,0 +1,7 @@
+package humiographql
+
+import graphql "github.com/cli/shurcooL-graphql"
+
+type Action struct {
+	Name graphql.String `graphql:"name"`
+}

--- a/api/internal/humiographql/aggregate-alerts.go
+++ b/api/internal/humiographql/aggregate-alerts.go
@@ -1,0 +1,54 @@
+package humiographql
+
+import graphql "github.com/cli/shurcooL-graphql"
+
+type AggregateAlert struct {
+	ID                    graphql.String     `graphql:"id"`
+	Name                  graphql.String     `graphql:"name"`
+	Description           graphql.String     `graphql:"description"`
+	QueryString           graphql.String     `graphql:"queryString"`
+	SearchIntervalSeconds Long               `graphql:"searchIntervalSeconds"`
+	ThrottleTimeSeconds   Long               `graphql:"throttleTimeSeconds"`
+	ThrottleField         graphql.String     `graphql:"throttleField"`
+	Actions               []Action           `graphql:"actions"`
+	Labels                []graphql.String   `graphql:"labels"`
+	Enabled               graphql.Boolean    `graphql:"enabled"`
+	QueryOwnership        QueryOwnership     `graphql:"queryOwnership"`
+	TriggerMode           TriggerMode        `graphql:"triggerMode"`
+	QueryTimestampType    QueryTimestampType `graphql:"queryTimestampType"`
+}
+
+type CreateAggregateAlert struct {
+	ViewName              RepoOrViewName     `json:"viewName"`
+	Name                  graphql.String     `json:"name"`
+	Description           graphql.String     `json:"description,omitempty"`
+	QueryString           graphql.String     `json:"queryString"`
+	SearchIntervalSeconds Long               `json:"searchIntervalSeconds"`
+	ThrottleTimeSeconds   Long               `json:"throttleTimeSeconds"`
+	ThrottleField         graphql.String     `json:"throttleField,omitempty"`
+	ActionIdsOrNames      []graphql.String   `json:"actionIdsOrNames"`
+	Labels                []graphql.String   `json:"labels"`
+	Enabled               graphql.Boolean    `json:"enabled"`
+	RunAsUserID           graphql.String     `json:"runAsUserId,omitempty"`
+	QueryOwnershipType    QueryOwnershipType `json:"queryOwnershipType"`
+	TriggerMode           TriggerMode        `json:"triggerMode,omitempty"`
+	QueryTimestampType    QueryTimestampType `json:"queryTimestampType"`
+}
+
+type UpdateAggregateAlert struct {
+	ViewName              RepoOrViewName     `json:"viewName"`
+	ID                    graphql.String     `json:"id"`
+	Name                  graphql.String     `json:"name"`
+	Description           graphql.String     `json:"description,omitempty"`
+	QueryString           graphql.String     `json:"queryString"`
+	SearchIntervalSeconds Long               `json:"searchIntervalSeconds"`
+	ThrottleTimeSeconds   Long               `json:"throttleTimeSeconds"`
+	ThrottleField         graphql.String     `json:"throttleField,omitempty"`
+	ActionIdsOrNames      []graphql.String   `json:"actionIdsOrNames"`
+	Labels                []graphql.String   `json:"labels"`
+	Enabled               graphql.Boolean    `json:"enabled"`
+	RunAsUserID           graphql.String     `json:"runAsUserId,omitempty"`
+	QueryOwnershipType    QueryOwnershipType `json:"queryOwnershipType"`
+	TriggerMode           TriggerMode        `json:"triggerMode"`
+	QueryTimestampType    QueryTimestampType `json:"queryTimestampType"`
+}

--- a/api/internal/humiographql/filter-alerts.go
+++ b/api/internal/humiographql/filter-alerts.go
@@ -17,10 +17,6 @@ type FilterAlert struct {
 	QueryOwnership      QueryOwnership   `graphql:"queryOwnership"`
 }
 
-type Action struct {
-	Name graphql.String `graphql:"name"`
-}
-
 type CreateFilterAlert struct {
 	ViewName            RepoOrViewName     `json:"viewName"`
 	Name                graphql.String     `json:"name"`

--- a/api/internal/humiographql/query-timestamp-type.go
+++ b/api/internal/humiographql/query-timestamp-type.go
@@ -1,0 +1,8 @@
+package humiographql
+
+type QueryTimestampType string
+
+const (
+	QueryTimestampTypeIngestTimestamp QueryTimestampType = "IngestTimestamp"
+	QueryTimestampTypeEventTimestamp  QueryTimestampType = "EventTimestamp"
+)

--- a/api/internal/humiographql/trigger-mode.go
+++ b/api/internal/humiographql/trigger-mode.go
@@ -1,0 +1,8 @@
+package humiographql
+
+type TriggerMode string
+
+const (
+	TriggerModeCompleteMode  TriggerMode = "CompleteMode"
+	TriggerModeImmediateMode TriggerMode = "ImmediateMode"
+)

--- a/cmd/humioctl/aggregate_alerts.go
+++ b/cmd/humioctl/aggregate_alerts.go
@@ -1,0 +1,34 @@
+// Copyright © 2024 CrowdStrike
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newAggregateAlertsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "aggregate-alerts",
+		Short: "Manage aggregate alerts",
+	}
+
+	cmd.AddCommand(newAggregateAlertsListCmd())
+	cmd.AddCommand(newAggregateAlertsInstallCmd())
+	cmd.AddCommand(newAggregateAlertsExportCmd())
+	cmd.AddCommand(newAggregateAlertsRemoveCmd())
+	cmd.AddCommand(newAggregateAlertsShowCmd())
+
+	return cmd
+}

--- a/cmd/humioctl/aggregate_alerts_export.go
+++ b/cmd/humioctl/aggregate_alerts_export.go
@@ -41,7 +41,7 @@ func newAggregateAlertsExportCmd() *cobra.Command {
 			aggregateAlerts, err := client.AggregateAlerts().List(view)
 			exitOnError(cmd, err, "Could not list aggregate alerts")
 
-			var aggregateAlert api.AggregateAlert
+			var aggregateAlert *api.AggregateAlert
 			for _, fa := range aggregateAlerts {
 				if fa.Name == aggregateAlertName {
 					aggregateAlert = fa

--- a/cmd/humioctl/aggregate_alerts_export.go
+++ b/cmd/humioctl/aggregate_alerts_export.go
@@ -1,0 +1,67 @@
+// Copyright © 2024 CrowdStrike
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/humio/cli/api"
+	"os"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+func newAggregateAlertsExportCmd() *cobra.Command {
+	var outputName string
+
+	cmd := cobra.Command{
+		Use:   "export [flags] <view> <aggregate-alert>",
+		Short: "Export an aggregate alert <aggregate-alert> in <view> to a file.",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			view := args[0]
+			aggregateAlertName := args[1]
+			client := NewApiClient(cmd)
+
+			if outputName == "" {
+				outputName = aggregateAlertName
+			}
+
+			aggregateAlerts, err := client.AggregateAlerts().List(view)
+			exitOnError(cmd, err, "Could not list aggregate alerts")
+
+			var aggregateAlert api.AggregateAlert
+			for _, fa := range aggregateAlerts {
+				if fa.Name == aggregateAlertName {
+					aggregateAlert = fa
+				}
+			}
+
+			if aggregateAlert.ID == "" {
+				exitOnError(cmd, api.AggregateAlertNotFound(aggregateAlertName), "Could not find aggregate alert")
+			}
+
+			yamlData, err := yaml.Marshal(&aggregateAlert)
+			exitOnError(cmd, err, "Failed to serialize the aggregate alert")
+
+			outFilePath := outputName + ".yaml"
+			err = os.WriteFile(outFilePath, yamlData, 0600)
+			exitOnError(cmd, err, "Error saving the aggregate alert file")
+		},
+	}
+
+	cmd.Flags().StringVarP(&outputName, "output", "o", "", "The file path where the aggregate alert should be written. Defaults to ./<aggregate-alert-name>.yaml")
+
+	return &cmd
+}

--- a/cmd/humioctl/aggregate_alerts_install.go
+++ b/cmd/humioctl/aggregate_alerts_install.go
@@ -1,0 +1,79 @@
+// Copyright © 2024 CrowdStrike
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/humio/cli/api"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+func newAggregateAlertsInstallCmd() *cobra.Command {
+	var (
+		filePath, url string
+	)
+
+	cmd := cobra.Command{
+		Use:   "install [flags] <view>",
+		Short: "Installs an aggregate alert in a view",
+		Long: `Install an aggregate alert from a URL or from a local file.
+
+The install command allows you to install aggregate alerts from a URL or from a local file, e.g.
+
+  $ humioctl aggregate-alerts install viewName --url=https://example.com/acme/aggregate-alert.yaml
+
+  $ humioctl aggregate-alerts install viewName --file=./aggregate-alert.yaml
+`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var content []byte
+			var err error
+
+			// Check that we got the right number of argument
+			// if we only got <view> you must supply --file or --url.
+			if l := len(args); l == 1 {
+				if filePath != "" {
+					content, err = getBytesFromFile(filePath)
+				} else if url != "" {
+					content, err = getBytesFromURL(url)
+				} else {
+					cmd.Printf("You must specify a path using --file or --url\n")
+					os.Exit(1)
+				}
+			}
+			exitOnError(cmd, err, "Could to load the aggregate alert")
+
+			client := NewApiClient(cmd)
+			viewName := args[0]
+
+			var aggregateAlert api.AggregateAlert
+			err = yaml.Unmarshal(content, &aggregateAlert)
+			exitOnError(cmd, err, "Could not unmarshal the aggregate alert")
+
+			_, err = client.AggregateAlerts().Create(viewName, &aggregateAlert)
+			exitOnError(cmd, err, "Could not create the aggregate alert")
+
+			fmt.Fprintln(cmd.OutOrStdout(), "Aggregate alert created")
+		},
+	}
+
+	cmd.Flags().StringVar(&filePath, "file", "", "The local file path to the aggregate alert to install.")
+	cmd.Flags().StringVar(&url, "url", "", "A URL to fetch the aggregate alert file from.")
+	cmd.MarkFlagsMutuallyExclusive("file", "url")
+	return &cmd
+}

--- a/cmd/humioctl/aggregate_alerts_list.go
+++ b/cmd/humioctl/aggregate_alerts_list.go
@@ -1,0 +1,60 @@
+// Copyright © 2024 CrowdStrike
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/humio/cli/cmd/internal/format"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+func newAggregateAlertsListCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "list <view>",
+		Short: "List all aggregate alerts in a view.",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			view := args[0]
+			client := NewApiClient(cmd)
+
+			aggregateAlerts, err := client.AggregateAlerts().List(view)
+			exitOnError(cmd, err, "Error fetching aggregate alerts")
+
+			var rows = make([][]format.Value, len(aggregateAlerts))
+			for i := range aggregateAlerts {
+				aggregateAlert := aggregateAlerts[i]
+				rows[i] = []format.Value{
+					format.String(aggregateAlert.ID),
+					format.String(aggregateAlert.Name),
+					format.String(aggregateAlert.Description),
+					format.String(strings.Join(aggregateAlert.ActionNames, ", ")),
+					format.String(strings.Join(aggregateAlert.Labels, ", ")),
+					format.Bool(aggregateAlert.Enabled),
+					format.String(aggregateAlert.ThrottleField),
+					format.Int(aggregateAlert.ThrottleTimeSeconds),
+					format.Int(aggregateAlert.SearchIntervalSeconds),
+					format.String(aggregateAlert.QueryTimestampType),
+					format.String(aggregateAlert.TriggerMode),
+					format.String(aggregateAlert.RunAsUserID),
+					format.String(aggregateAlert.QueryOwnershipType),
+				}
+			}
+
+			printOverviewTable(cmd, []string{"ID", "Name", "Description", "Action Names", "Labels", "Enabled", "Throttle Field", "Throttle Time Seconds", "Search Interval Seconds", "Query Timestamp Type", "Trigger Mode", "Run As UserID", "Query Ownership Type"}, rows)
+		},
+	}
+
+	return &cmd
+}

--- a/cmd/humioctl/aggregate_alerts_remove.go
+++ b/cmd/humioctl/aggregate_alerts_remove.go
@@ -1,0 +1,57 @@
+// Copyright © 2024 CrowdStrike
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"github.com/humio/cli/api"
+
+	"github.com/spf13/cobra"
+)
+
+func newAggregateAlertsRemoveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove <view> <name>",
+		Short: "Removes an aggregate alert.",
+		Long:  `Removes the aggregate alert with name '<name>' in the view with name '<view>'.`,
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			viewName := args[0]
+			aggregateAlertName := args[1]
+			client := NewApiClient(cmd)
+
+			aggregateAlerts, err := client.AggregateAlerts().List(viewName)
+			exitOnError(cmd, err, "Could not list aggregate alerts")
+
+			var aggregateAlert api.AggregateAlert
+			for _, fa := range aggregateAlerts {
+				if fa.Name == aggregateAlertName {
+					aggregateAlert = fa
+				}
+			}
+
+			if aggregateAlert.ID == "" {
+				exitOnError(cmd, api.AggregateAlertNotFound(aggregateAlertName), "Could not find aggregate alert")
+			}
+
+			err = client.AggregateAlerts().Delete(viewName, aggregateAlert.ID)
+			exitOnError(cmd, err, "Could not remove alert")
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully removed aggregate alert %q from view %q\n", aggregateAlertName, viewName)
+		},
+	}
+
+	return cmd
+}

--- a/cmd/humioctl/aggregate_alerts_remove.go
+++ b/cmd/humioctl/aggregate_alerts_remove.go
@@ -35,7 +35,7 @@ func newAggregateAlertsRemoveCmd() *cobra.Command {
 			aggregateAlerts, err := client.AggregateAlerts().List(viewName)
 			exitOnError(cmd, err, "Could not list aggregate alerts")
 
-			var aggregateAlert api.AggregateAlert
+			var aggregateAlert *api.AggregateAlert
 			for _, fa := range aggregateAlerts {
 				if fa.Name == aggregateAlertName {
 					aggregateAlert = fa

--- a/cmd/humioctl/aggregate_alerts_show.go
+++ b/cmd/humioctl/aggregate_alerts_show.go
@@ -1,0 +1,70 @@
+// Copyright © 2024 CrowdStrike
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/humio/cli/api"
+	"github.com/humio/cli/cmd/internal/format"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+func newAggregateAlertsShowCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "show <view> <name>",
+		Short: "Show details about an aggregate alert in a view.",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			view := args[0]
+			name := args[1]
+			client := NewApiClient(cmd)
+
+			aggregateAlerts, err := client.AggregateAlerts().List(view)
+			exitOnError(cmd, err, "Could not list aggregate alert")
+
+			var aggregateAlert api.AggregateAlert
+			for _, fa := range aggregateAlerts {
+				if fa.Name == name {
+					aggregateAlert = fa
+				}
+			}
+
+			if aggregateAlert.ID == "" {
+				exitOnError(cmd, api.AggregateAlertNotFound(name), "Could not find aggregate alert")
+			}
+
+			details := [][]format.Value{
+				{format.String("ID"), format.String(aggregateAlert.ID)},
+				{format.String("Name"), format.String(aggregateAlert.Name)},
+				{format.String("Description"), format.String(aggregateAlert.Description)},
+				{format.String("Query String"), format.String(aggregateAlert.QueryString)},
+				{format.String("Search Interval Seconds"), format.Int(aggregateAlert.SearchIntervalSeconds)},
+				{format.String("Actions"), format.String(strings.Join(aggregateAlert.ActionNames, ", "))},
+				{format.String("Labels"), format.String(strings.Join(aggregateAlert.Labels, ", "))},
+				{format.String("Enabled"), format.Bool(aggregateAlert.Enabled)},
+				{format.String("Throttle Field"), format.String(aggregateAlert.ThrottleField)},
+				{format.String("Throttle Time Seconds"), format.Int(aggregateAlert.ThrottleTimeSeconds)},
+				{format.String("Query Timestamp Type"), format.String(aggregateAlert.QueryTimestampType)},
+				{format.String("Trigger Mode"), format.String(aggregateAlert.TriggerMode)},
+				{format.String("Run As User ID"), format.String(aggregateAlert.RunAsUserID)},
+				{format.String("Query Ownership Type"), format.String(aggregateAlert.QueryOwnershipType)},
+			}
+
+			printDetailsTable(cmd, details)
+		},
+	}
+
+	return &cmd
+}

--- a/cmd/humioctl/aggregate_alerts_show.go
+++ b/cmd/humioctl/aggregate_alerts_show.go
@@ -34,7 +34,7 @@ func newAggregateAlertsShowCmd() *cobra.Command {
 			aggregateAlerts, err := client.AggregateAlerts().List(view)
 			exitOnError(cmd, err, "Could not list aggregate alert")
 
-			var aggregateAlert api.AggregateAlert
+			var aggregateAlert *api.AggregateAlert
 			for _, fa := range aggregateAlerts {
 				if fa.Name == name {
 					aggregateAlert = fa

--- a/cmd/humioctl/root.go
+++ b/cmd/humioctl/root.go
@@ -123,6 +123,7 @@ Common Management Commands:
 	rootCmd.AddCommand(newAlertsCmd())
 	rootCmd.AddCommand(newFilterAlertsCmd())
 	rootCmd.AddCommand(newScheduledSearchesCmd())
+	rootCmd.AddCommand(newAggregateAlertsCmd())
 	rootCmd.AddCommand(newPackagesCmd())
 	rootCmd.AddCommand(newGroupsCmd())
 	rootCmd.AddCommand(newFilesCmd())


### PR DESCRIPTION
Adds aggregate-alerts to humio/cli

```
➜  cli git:(fjerlov/aggregate-alert) ✗ ./bin/humioctl aggregate-alerts
Manage aggregate alerts

Usage:
  humioctl aggregate-alerts [command]

Available Commands:
  export      Export a aggregate alert <aggregate-alert> in <view> to a file.
  install     Installs a aggregate alert in a view
  list        List all aggregate alerts in a view.
  remove      Removes a aggregate alert.
  show        Show details about a aggregate alert in a view.
```

```
/Users/fjerlov/Library/Caches/JetBrains/GoLand2023.3/tmp/GoLand/___list aggregate-alerts list DemoView
                 ID                |      NAME       |  DESCRIPTION  | ACTION NAMES | LABELS | ENABLED | THROTTLE FIELD | THROTTLE TIME SECONDS | SEARCH INTERVAL SECONDS | QUERY TIMESTAMP TYPE | TRIGGER MODE  |      RUN AS USERID       | QUERY OWNERSHIP TYPE  
+----------------------------------+-----------------+---------------+--------------+--------+---------+----------------+-----------------------+-------------------------+----------------------+---------------+--------------------------+----------------------+
  SvhhCj21ZV9dRkQd0FBohuCeUVQly77a | aggregate-alert | asdakmsdasd-2 | testing      | label2 | false   | asd            |                  7200 |                    7200 | EventTimestamp       | ImmediateMode | pMeYeiIlF3NljnMAIcEcRnUK | User                  
```

```
/Users/fjerlov/Library/Caches/JetBrains/GoLand2023.3/tmp/GoLand/___show aggregate-alerts show DemoView aggregate-alert
                       ID | SvhhCj21ZV9dRkQd0FBohuCeUVQly77a  
                     Name | aggregate-alert                   
              Description | asdakmsdasd-2                     
             Query String | foo=* bar=* | count()             
  Search Interval Seconds | 7200                              
                  Actions | testing                           
                   Labels | label2                            
                  Enabled | false                             
           Throttle Field | asd                               
    Throttle Time Seconds | 7200                              
     Query Timestamp Type | EventTimestamp                    
             Trigger Mode | ImmediateMode                     
           Run As User ID | pMeYeiIlF3NljnMAIcEcRnUK          
     Query Ownership Type | User                              

Process finished with the exit code 0

```

aggregate-alert.yaml
```
name: aggregate-alert
description: asdakmsdasd-2
queryString: foo=* bar=* | count()
searchIntervalSeconds: 7200
actionNames:
- testing
labels:
- label2
enabled: false
throttleField: asd
throttleTimeSeconds: 7200
queryOwnershipType: User
triggerMode: ImmediateMode
queryTimestampType: EventTimestamp
runAsUserId: pMeYeiIlF3NljnMAIcEcRnUK
```