### PR TITLE
Filter Alerts - Omit Throttle Time and Throttle Field when not present

### DIFF
--- a/api/filter-alerts.go
+++ b/api/filter-alerts.go
@@ -16,7 +16,7 @@ type FilterAlert struct {
 	Enabled             bool     `graphql:"enabled"             yaml:"enabled"                       json:"enabled"`
 	QueryOwnershipType  string   `graphql:"queryOwnership"      yaml:"queryOwnershipType"            json:"queryOwnershipType"`
 	ThrottleTimeSeconds int      `graphql:"throttleTimeSeconds" yaml:"throttleTimeSeconds,omitempty" json:"throttleTimeSeconds,omitempty"`
-	ThrottleField       string   `graphql:"throttleField"       yaml:"throttleField,omitempty"       json:"throttleField"`
+	ThrottleField       string   `graphql:"throttleField"       yaml:"throttleField,omitempty"       json:"throttleField,omitempty"`
 	RunAsUserID         string   `graphql:"runAsUserId"         yaml:"runAsUserId,omitempty"         json:"runAsUserId,omitempty"`
 }
 

--- a/api/internal/humiographql/filter-alerts.go
+++ b/api/internal/humiographql/filter-alerts.go
@@ -29,8 +29,8 @@ type CreateFilterAlert struct {
 	ActionIdsOrNames    []graphql.String   `json:"actionIdsOrNames"`
 	Labels              []graphql.String   `json:"labels"`
 	Enabled             graphql.Boolean    `json:"enabled"`
-	ThrottleTimeSeconds Long               `json:"throttleTimeSeconds"`
-	ThrottleField       graphql.String     `json:"throttleField"`
+	ThrottleTimeSeconds Long               `json:"throttleTimeSeconds,omitempty"`
+	ThrottleField       graphql.String     `json:"throttleField,omitempty"`
 	RunAsUserID         graphql.String     `json:"runAsUserId,omitempty"`
 	QueryOwnershipType  QueryOwnershipType `json:"queryOwnershipType"`
 }
@@ -44,8 +44,8 @@ type UpdateFilterAlert struct {
 	ActionIdsOrNames    []graphql.String   `json:"actionIdsOrNames"`
 	Labels              []graphql.String   `json:"labels"`
 	Enabled             graphql.Boolean    `json:"enabled"`
-	ThrottleTimeSeconds Long               `json:"throttleTimeSeconds"`
-	ThrottleField       graphql.String     `json:"throttleField"`
+	ThrottleTimeSeconds Long               `json:"throttleTimeSeconds,omitempty"`
+	ThrottleField       graphql.String     `json:"throttleField,omitempty"`
 	RunAsUserID         graphql.String     `json:"runAsUserId,omitempty"`
 	QueryOwnershipType  QueryOwnershipType `json:"queryOwnershipType"`
 }


### PR DESCRIPTION
Filter Alerts included the null values for `ThrottleTimeSeconds` and `ThrottleField` when installing from a yaml file.

This corrects that.