### PR TITLE
Add retention settings to repo create command

### DIFF
--- a/api/internal/humiographql/conversion.go
+++ b/api/internal/humiographql/conversion.go
@@ -1,0 +1,14 @@
+package humiographql
+
+import "time"
+
+func ConvertDaysToMillis(days int64) int64 {
+	milliseconds := int64(time.Duration(days) * 24 * time.Hour / time.Millisecond)
+	return milliseconds
+}
+
+func ConvertGBToBytes(gb float64) float64 {
+	// Data sizes in LogScale are expressed in SI units using decimal (Base 10).
+	const bytesInGB = 1e9 // 1 GB = 1,000,000,000 bytes (SI units)
+	return gb * bytesInGB
+}

--- a/cmd/humioctl/repos_create.go
+++ b/cmd/humioctl/repos_create.go
@@ -21,6 +21,10 @@ import (
 )
 
 func newReposCreateCmd() *cobra.Command {
+	var descriptionFlag string
+	var retentionTimeFlag int64
+	var ingestSizeBasedRetentionFlag, storageSizeBasedRetentionFlag float64
+
 	cmd := cobra.Command{
 		Use:   "create <repo>",
 		Short: "Create a repository.",
@@ -29,13 +33,23 @@ func newReposCreateCmd() *cobra.Command {
 			repoName := args[0]
 			client := NewApiClient(cmd)
 
-			err := client.Repositories().Create(repoName)
+			err := client.Repositories().Create(repoName,
+				descriptionFlag,
+				retentionTimeFlag,
+				ingestSizeBasedRetentionFlag,
+				storageSizeBasedRetentionFlag,
+			)
 			exitOnError(cmd, err, "Error creating repository")
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Successfully created repo %s\n", repoName)
 
 		},
 	}
+
+	cmd.Flags().StringVar(&descriptionFlag, "description", "", "The description of the repository.")
+	cmd.Flags().Int64Var(&retentionTimeFlag, "retention-time", 0, "The retention time in days for the repository.")
+	cmd.Flags().Float64Var(&ingestSizeBasedRetentionFlag, "retention-ingest", 0, "The ingest size based retention in GB for the repository.")
+	cmd.Flags().Float64Var(&storageSizeBasedRetentionFlag, "retention-storage", 0, "The storage size based retention in GB for the repository.")
 
 	return &cmd
 }


### PR DESCRIPTION
This change:

- Adds 4 flags to the `repos create` command. This allows the user to set a description, retention based on time, retention based on ingest and retention based on storage at repository creation time.

Example:
```
$ humioctl repos create newRepo1 --retention-time 72 --retention-ingest 130 --retention-storage 250 --description "Repo with retention settings"

$ humioctl repos show newRepo1
                        ID | mvVSvk4VVjoVZ9ToloNANTpj      
                      Name | newRepo1                      
               Description | Repo with retention settings  
                Space Used | 0 B                           
   Ingest Retention (Size) | 130.0 GB                      
  Storage Retention (Size) | 250.0 GB                      
          Retention (Days) | 72                            
      S3 Archiving Enabled | false                         
       S3 Archiving Bucket |                               
       S3 Archiving Region |                               
       S3 Archiving Format |                               
          Automatic Search | true
```