### PR TITLE
Add rotation support for user personal token

### DIFF
--- a/api/personal-tokens.go
+++ b/api/personal-tokens.go
@@ -1,0 +1,25 @@
+package api
+
+
+
+type PersonalTokens struct {
+	client *Client
+}
+
+func (c *Client) PersonalTokens() *PersonalTokens { return &PersonalTokens{client: c} }
+
+func (i *PersonalTokens) Create() (string, error) {
+	variables := map[string]interface{}{
+	}
+
+	var mutation struct {
+		ApiToken string `graphql:"createPersonalUserToken(input: {})"`
+	}
+
+  err := i.client.Mutate(&mutation, variables)
+	if err != nil {
+		return "", err
+	}
+
+	return mutation.ApiToken, nil
+}

--- a/cmd/humioctl/personal_tokens.go
+++ b/cmd/humioctl/personal_tokens.go
@@ -1,0 +1,30 @@
+// Copyright © 2020 Humio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newPersonalTokensCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "personal-tokens",
+		Short: "Manage personal tokens",
+	}
+
+	cmd.AddCommand(newPersonalTokensRotateCmd())
+
+	return cmd
+}

--- a/cmd/humioctl/personal_tokens_create.go
+++ b/cmd/humioctl/personal_tokens_create.go
@@ -1,0 +1,41 @@
+// Copyright © 2018 Humio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newPersonalTokensRotateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rotate",
+		Short: "Rotate the personal token for current user",
+		Long: `Rotate the personal token for current user.
+
+It will inherit the same permissions as the user.
+It will create a new personal token, replacing existing one`,
+		Run: func(cmd *cobra.Command, args []string) {
+			client := NewApiClient(cmd)
+
+			personalToken, err := client.PersonalTokens().Create()
+			exitOnError(cmd, err, "Error generating new personal user token")
+
+			fmt.Fprintf(cmd.OutOrStdout(), "New personal user token generated: %s \n", personalToken)
+		},
+	}
+	return cmd
+}

--- a/cmd/humioctl/root.go
+++ b/cmd/humioctl/root.go
@@ -111,6 +111,7 @@ Common Management Commands:
 	rootCmd.AddCommand(newIngestCmd())
 	rootCmd.AddCommand(newProfilesCmd())
 	rootCmd.AddCommand(newIngestTokensCmd())
+	rootCmd.AddCommand(newPersonalTokensCmd())
 	rootCmd.AddCommand(newViewsCmd())
 	rootCmd.AddCommand(newCompletionCmd())
 	rootCmd.AddCommand(newLicenseCmd())


### PR DESCRIPTION
This allows the use of [createPersonalUserToken()](https://library.humio.com/logscale-graphql-reference-mutations/graphql-mutation-field-createpersonalusertoken.html)] to create a new user personal token, replacing the existing one - effectively allow a rotation of the user personal token via CLI. This will be useful for our team's effort in implementing credentials automation with Humio/LogScale integration.

I am still trying to get a trial license to test the expiration and IP filter settings - as we are only have access to the cloud instance at the moment - so support for customizing token expiration date will be added later.