### PR TITLE
add `repos block-ingest` command

### DIFF
--- a/api/repositories.go
+++ b/api/repositories.go
@@ -360,3 +360,19 @@ func (r *Repositories) UpdateAutomaticSearch(name string, automaticSearch bool) 
 
 	return r.client.Mutate(&mutation, variables)
 }
+
+func (r *Repositories) BlockIngest(name string, seconds int) error {
+	var mutation struct {
+		BlockIngest struct {
+			// We have to make a selection, so just take __typename
+			Typename graphql.String `graphql:"__typename"`
+		} `graphql:"blockIngest(repositoryName: $name, seconds: $seconds)"`
+	}
+
+	variables := map[string]interface{}{
+		"name":    graphql.String(name),
+		"seconds": graphql.Int(seconds),
+	}
+
+	return r.client.Mutate(&mutation, variables)
+}

--- a/cmd/humioctl/repos.go
+++ b/cmd/humioctl/repos.go
@@ -32,6 +32,7 @@ func newReposCmd() *cobra.Command {
 	cmd.AddCommand(newReposUpdateCmd())
 	cmd.AddCommand(newReposDeleteCmd())
 	cmd.AddCommand(newReposUpdateUserGroupCmd())
+	cmd.AddCommand(newReposBlockIngestCmd())
 
 	return cmd
 }

--- a/cmd/humioctl/repos_block_ingest.go
+++ b/cmd/humioctl/repos_block_ingest.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+func newReposBlockIngestCmd() *cobra.Command {
+	var allRepos bool
+
+	cmd := &cobra.Command{
+		Use:   "block-ingest [flags] [repository] <seconds>",
+		Short: "Block ingest for a repository",
+		Long: `Block ingest for one or all repositories for a specified number of seconds.
+
+Examples:
+  # Block ingest for a specific repository
+  humioctl repos block-ingest myrepo 3600
+
+  # Block ingest for all repositories
+  humioctl repos block-ingest --all 3600`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := NewApiClient(cmd)
+
+			if !allRepos && len(args) != 2 {
+				return fmt.Errorf("requires repository name and seconds, or --all flag with seconds")
+			}
+
+			var seconds int
+			var err error
+
+			if allRepos {
+				if len(args) != 1 {
+					return fmt.Errorf("when using --all, only specify seconds")
+				}
+				seconds, err = strconv.Atoi(args[0])
+			} else {
+				seconds, err = strconv.Atoi(args[1])
+			}
+
+			if err != nil {
+				return fmt.Errorf("invalid duration: %w", err)
+			}
+
+			if allRepos {
+				repos, err := client.Repositories().List()
+				if err != nil {
+					return fmt.Errorf("error listing repositories: %w", err)
+				}
+
+				type result struct {
+					repoName string
+					err      error
+				}
+				results := make(chan result, len(repos))
+
+				for _, repo := range repos {
+					go func(repoName string) {
+						err := client.Repositories().BlockIngest(repoName, seconds)
+						results <- result{repoName: repoName, err: err}
+					}(repo.Name)
+				}
+
+				for i := 0; i < len(repos); i++ {
+					res := <-results
+					if res.err != nil {
+						fmt.Fprintf(cmd.ErrOrStderr(), "Error blocking ingest for repository %q: %v\n", res.repoName, res.err)
+					} else {
+						fmt.Fprintf(cmd.OutOrStdout(), "Successfully blocked ingest for repository %q\n", res.repoName)
+					}
+				}
+
+				return nil
+			}
+
+			err = client.Repositories().BlockIngest(args[0], seconds)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully blocked ingest for repository %q\n", args[0])
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&allRepos, "all", false, "Block ingest for all repositories")
+
+	return cmd
+}


### PR DESCRIPTION
Implements the [blockIngest()](https://library.humio.com/logscale-graphql-reference-mutations/graphql-mutation-field-blockingest.html) mutation and adds a subcommand to block ingest for one or all repos (in parallel).

Crowdstrike has recommended we block all ingest prior to disruptive changes to our Logscale instance, so this command will make it easy for us to do so.

```bash
⇒ bin/humioctl repos block-ingest --help
Block ingest for one or all repositories for a specified number of seconds.

Examples:
  # Block ingest for a specific repository
  humioctl repos block-ingest myrepo 3600

  # Block ingest for all repositories
  humioctl repos block-ingest --all 3600

Usage:
  humioctl repos block-ingest [flags] [repository] <seconds>
```