### PR TITLE
Possible to set query ownership when installing package

### DIFF
--- a/api/packages.go
+++ b/api/packages.go
@@ -131,7 +131,7 @@ func (p *Packages) ListInstalled(viewName string) ([]InstalledPackage, error) {
 
 // InstallArchive installs a local package (zip file).
 // Deprecated: Should no longer be used. https://github.com/CrowdStrike/logscale-go-api-client-example
-func (p *Packages) InstallArchive(viewName string, pathToZip string) (*ValidationResponse, error) {
+func (p *Packages) InstallArchive(viewName string, pathToZip string, ownership string) (*ValidationResponse, error) {
 	// #nosec G304
 	fileReader, err := os.Open(pathToZip)
 	if err != nil {
@@ -140,7 +140,7 @@ func (p *Packages) InstallArchive(viewName string, pathToZip string) (*Validatio
 	// #nosec G307
 	defer fileReader.Close()
 
-	urlPath := "api/v1/packages/install?view=" + url.QueryEscape(viewName) + "&overwrite=true"
+	urlPath := "api/v1/packages/install?view=" + url.QueryEscape(viewName) + "&overwrite=true" + "&queryOwnershipType=" + ownership
 	response, err := p.client.HTTPRequestContext(context.Background(), "POST", urlPath, fileReader, ZIPContentType)
 	if err != nil {
 		return nil, err
@@ -235,7 +235,7 @@ func (p *Packages) CreateArchive(packageDirPath string, targetFileName string) e
 
 // InstallFromDirectory installs a package from a directory containing the package files.
 // Deprecated: Should no longer be used. https://github.com/CrowdStrike/logscale-go-api-client-example
-func (p *Packages) InstallFromDirectory(packageDirPath string, targetRepoOrView string) (*ValidationResponse, error) {
+func (p *Packages) InstallFromDirectory(packageDirPath string, targetRepoOrView string, ownership string) (*ValidationResponse, error) {
 	zipFilePath, err := createTempZipFromFolder(packageDirPath)
 	if err != nil {
 		return nil, err
@@ -251,7 +251,7 @@ func (p *Packages) InstallFromDirectory(packageDirPath string, targetRepoOrView 
 	defer zipFile.Close()
 	defer os.Remove(zipFile.Name())
 
-	return p.InstallArchive(targetRepoOrView, zipFilePath)
+	return p.InstallArchive(targetRepoOrView, zipFilePath, ownership)
 }
 
 func createTempZipFromFolder(baseFolder string) (string, error) {

--- a/api/packages.go
+++ b/api/packages.go
@@ -131,7 +131,7 @@ func (p *Packages) ListInstalled(viewName string) ([]InstalledPackage, error) {
 
 // InstallArchive installs a local package (zip file).
 // Deprecated: Should no longer be used. https://github.com/CrowdStrike/logscale-go-api-client-example
-func (p *Packages) InstallArchive(viewName string, pathToZip string, ownership string) (*ValidationResponse, error) {
+func (p *Packages) InstallArchive(viewName string, pathToZip string, queryOwnership string) (*ValidationResponse, error) {
 	// #nosec G304
 	fileReader, err := os.Open(pathToZip)
 	if err != nil {
@@ -140,7 +140,7 @@ func (p *Packages) InstallArchive(viewName string, pathToZip string, ownership s
 	// #nosec G307
 	defer fileReader.Close()
 
-	urlPath := "api/v1/packages/install?view=" + url.QueryEscape(viewName) + "&overwrite=true" + "&queryOwnershipType=" + ownership
+	urlPath := "api/v1/packages/install?view=" + url.QueryEscape(viewName) + "&overwrite=true" + "&queryOwnershipType=" + queryOwnership
 	response, err := p.client.HTTPRequestContext(context.Background(), "POST", urlPath, fileReader, ZIPContentType)
 	if err != nil {
 		return nil, err
@@ -235,7 +235,7 @@ func (p *Packages) CreateArchive(packageDirPath string, targetFileName string) e
 
 // InstallFromDirectory installs a package from a directory containing the package files.
 // Deprecated: Should no longer be used. https://github.com/CrowdStrike/logscale-go-api-client-example
-func (p *Packages) InstallFromDirectory(packageDirPath string, targetRepoOrView string, ownership string) (*ValidationResponse, error) {
+func (p *Packages) InstallFromDirectory(packageDirPath string, targetRepoOrView string, queryOwnership string) (*ValidationResponse, error) {
 	zipFilePath, err := createTempZipFromFolder(packageDirPath)
 	if err != nil {
 		return nil, err
@@ -251,7 +251,7 @@ func (p *Packages) InstallFromDirectory(packageDirPath string, targetRepoOrView 
 	defer zipFile.Close()
 	defer os.Remove(zipFile.Name())
 
-	return p.InstallArchive(targetRepoOrView, zipFilePath, ownership)
+	return p.InstallArchive(targetRepoOrView, zipFilePath, queryOwnership)
 }
 
 func createTempZipFromFolder(baseFolder string) (string, error) {

--- a/cmd/humioctl/packages_install.go
+++ b/cmd/humioctl/packages_install.go
@@ -27,7 +27,7 @@ import (
 
 func installPackageCmd() *cobra.Command {
 	var (
-		ownership string
+		queryOwnership string
 	)
 
 	cmd := cobra.Command{
@@ -37,10 +37,10 @@ func installPackageCmd() *cobra.Command {
 Packages can be installed from a directory, Github Repository URL, Zip File, or
 Zip File URL.
 
-  $ humioctl packages install myrepo /path/to/package/dir/ --ownership organization 
-  $ humioctl packages install myrepo /path/to/pazkage.zip --ownership organization
-  $ humioctl packages install myrepo https://github.com/org/mypackage-name -ownership organization
-  $ humioctl packages install myrepo https://content.example.com/mypackage-name.zip -ownership organization
+  $ humioctl packages install myrepo /path/to/package/dir/ --queryOwnership organization 
+  $ humioctl packages install myrepo /path/to/pazkage.zip --queryOwnership user
+  $ humioctl packages install myrepo https://github.com/org/mypackage-name -queryOwnership organization
+  $ humioctl packages install myrepo https://content.example.com/mypackage-name.zip -queryOwnership user
 `,
 		Args: cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -58,20 +58,20 @@ Zip File URL.
 			isDir, err := isDirectory(path)
 			exitOnError(cmd, err, "Errors installing archive")
 
-			if ownership == "" {
-				ownership = "user"
+			if queryOwnership == "" {
+				queryOwnership = "user"
 			}
 
-			if ownership != "organization" && ownership != "user" {
+			if queryOwnership != "organization" && queryOwnership != "user" {
 				cmd.PrintErrln("query ownership must be set to either `organization` or `user`")
 				os.Exit(1)
 			}
 
 			var validationResult *api.ValidationResponse
 			if isDir {
-				validationResult, err = client.Packages().InstallFromDirectory(path, repoOrViewName, ownership)
+				validationResult, err = client.Packages().InstallFromDirectory(path, repoOrViewName, queryOwnership)
 			} else {
-				validationResult, err = client.Packages().InstallArchive(repoOrViewName, path, ownership)
+				validationResult, err = client.Packages().InstallArchive(repoOrViewName, path, queryOwnership)
 			}
 			exitOnError(cmd, err, "Errors installing archive")
 
@@ -83,7 +83,7 @@ Zip File URL.
 		},
 	}
 
-	cmd.Flags().StringVarP(&ownership, "ownership", "o", "", "The query ownership of installed queries e.g. in triggers. Possible are `organization` and `user`. Defaults to `user`")
+	cmd.Flags().StringVarP(&queryOwnership, "queryOwnership", "q", "", "The query ownership of installed queries e.g. in triggers. Possible values are `organization` and `user`. Defaults to `user`")
 
 	return &cmd
 }

--- a/internal/api/packages.go
+++ b/internal/api/packages.go
@@ -146,7 +146,7 @@ func (p *Packages) ListInstalled(searchDomainName string) ([]InstalledPackage, e
 }
 
 // InstallArchive installs a local package (zip file).
-func (p *Packages) InstallArchive(viewName string, pathToZip string, ownership string) (*ValidationResponse, error) {
+func (p *Packages) InstallArchive(viewName string, pathToZip string, queryOwnership string) (*ValidationResponse, error) {
 	// #nosec G304
 	fileReader, err := os.Open(pathToZip)
 	if err != nil {
@@ -155,7 +155,7 @@ func (p *Packages) InstallArchive(viewName string, pathToZip string, ownership s
 	// #nosec G307
 	defer fileReader.Close()
 
-	urlPath := "api/v1/packages/install?view=" + url.QueryEscape(viewName) + "&overwrite=true" + "&queryOwnershipType=" + ownership
+	urlPath := "api/v1/packages/install?view=" + url.QueryEscape(viewName) + "&overwrite=true" + "&queryOwnershipType=" + queryOwnership
 	response, err := p.client.HTTPRequestContext(context.Background(), "POST", urlPath, fileReader, ZIPContentType)
 	if err != nil {
 		return nil, err
@@ -235,7 +235,7 @@ func (p *Packages) CreateArchive(packageDirPath string, targetFileName string) e
 }
 
 // InstallFromDirectory installs a package from a directory containing the package files.
-func (p *Packages) InstallFromDirectory(packageDirPath string, targetRepoOrView string, ownership string) (*ValidationResponse, error) {
+func (p *Packages) InstallFromDirectory(packageDirPath string, targetRepoOrView string, queryOwnership string) (*ValidationResponse, error) {
 	zipFilePath, err := createTempZipFromFolder(packageDirPath)
 	if err != nil {
 		return nil, err
@@ -251,7 +251,7 @@ func (p *Packages) InstallFromDirectory(packageDirPath string, targetRepoOrView 
 	defer zipFile.Close()
 	defer os.Remove(zipFile.Name())
 
-	return p.InstallArchive(targetRepoOrView, zipFilePath, ownership)
+	return p.InstallArchive(targetRepoOrView, zipFilePath, queryOwnership)
 }
 
 func createTempZipFromFolder(baseFolder string) (string, error) {

--- a/internal/api/packages.go
+++ b/internal/api/packages.go
@@ -146,7 +146,7 @@ func (p *Packages) ListInstalled(searchDomainName string) ([]InstalledPackage, e
 }
 
 // InstallArchive installs a local package (zip file).
-func (p *Packages) InstallArchive(viewName string, pathToZip string) (*ValidationResponse, error) {
+func (p *Packages) InstallArchive(viewName string, pathToZip string, ownership string) (*ValidationResponse, error) {
 	// #nosec G304
 	fileReader, err := os.Open(pathToZip)
 	if err != nil {
@@ -155,7 +155,7 @@ func (p *Packages) InstallArchive(viewName string, pathToZip string) (*Validatio
 	// #nosec G307
 	defer fileReader.Close()
 
-	urlPath := "api/v1/packages/install?view=" + url.QueryEscape(viewName) + "&overwrite=true"
+	urlPath := "api/v1/packages/install?view=" + url.QueryEscape(viewName) + "&overwrite=true" + "&queryOwnershipType=" + ownership
 	response, err := p.client.HTTPRequestContext(context.Background(), "POST", urlPath, fileReader, ZIPContentType)
 	if err != nil {
 		return nil, err
@@ -235,7 +235,7 @@ func (p *Packages) CreateArchive(packageDirPath string, targetFileName string) e
 }
 
 // InstallFromDirectory installs a package from a directory containing the package files.
-func (p *Packages) InstallFromDirectory(packageDirPath string, targetRepoOrView string) (*ValidationResponse, error) {
+func (p *Packages) InstallFromDirectory(packageDirPath string, targetRepoOrView string, ownership string) (*ValidationResponse, error) {
 	zipFilePath, err := createTempZipFromFolder(packageDirPath)
 	if err != nil {
 		return nil, err
@@ -251,7 +251,7 @@ func (p *Packages) InstallFromDirectory(packageDirPath string, targetRepoOrView 
 	defer zipFile.Close()
 	defer os.Remove(zipFile.Name())
 
-	return p.InstallArchive(targetRepoOrView, zipFilePath)
+	return p.InstallArchive(targetRepoOrView, zipFilePath, ownership)
 }
 
 func createTempZipFromFolder(baseFolder string) (string, error) {


### PR DESCRIPTION
Added a parameter for specifying if packages should install queries as owned by user or organization