### PR TITLE
Scheduled Search V2

### DIFF
--- a/cmd/humioctl/alerts_show.go
+++ b/cmd/humioctl/alerts_show.go
@@ -46,7 +46,7 @@ func newAlertsShowCmd() *cobra.Command {
 				{format.String("Is Starred"), format.Bool(alert.IsStarred)},
 				{format.String("Last Error"), format.StringPtr(alert.LastError)},
 				{format.String("Throttle Field"), format.StringPtr(alert.ThrottleField)},
-				{format.String("Time Of Last Trigger"), format.IntPtr(alert.TimeOfLastTrigger)},
+				{format.String("Time Of Last Trigger"), format.Int64Ptr(alert.TimeOfLastTrigger)},
 				{format.String("Run As User ID"), format.String(alert.RunAsUserID)},
 				{format.String("Query Ownership Type"), format.String(alert.QueryOwnershipType)},
 			}

--- a/cmd/humioctl/filter_alerts_list.go
+++ b/cmd/humioctl/filter_alerts_list.go
@@ -43,7 +43,7 @@ func newFilterAlertsListCmd() *cobra.Command {
 					format.StringPtr(filterAlert.Description),
 					format.String(strings.Join(filterAlert.ActionNames, ", ")),
 					format.String(strings.Join(filterAlert.Labels, ", ")),
-					format.IntPtr(filterAlert.ThrottleTimeSeconds),
+					format.Int64Ptr(filterAlert.ThrottleTimeSeconds),
 					format.StringPtr(filterAlert.ThrottleField),
 					format.String(filterAlert.OwnershipRunAsID),
 					format.String(filterAlert.QueryOwnershipType),

--- a/cmd/humioctl/filter_alerts_show.go
+++ b/cmd/humioctl/filter_alerts_show.go
@@ -54,7 +54,7 @@ func newFilterAlertsShowCmd() *cobra.Command {
 				{format.String("Query String"), format.String(filterAlert.QueryString)},
 				{format.String("Labels"), format.String(strings.Join(filterAlert.Labels, ", "))},
 				{format.String("Actions"), format.String(strings.Join(filterAlert.ActionNames, ", "))},
-				{format.String("Throttle Time Seconds"), format.IntPtr(filterAlert.ThrottleTimeSeconds)},
+				{format.String("Throttle Time Seconds"), format.Int64Ptr(filterAlert.ThrottleTimeSeconds)},
 				{format.String("Throttle Field"), format.StringPtr(filterAlert.ThrottleField)},
 				{format.String("Run As User ID"), format.String(filterAlert.OwnershipRunAsID)},
 				{format.String("Query Ownership Type"), format.String(filterAlert.QueryOwnershipType)},

--- a/cmd/humioctl/root.go
+++ b/cmd/humioctl/root.go
@@ -123,6 +123,7 @@ Common Management Commands:
 	rootCmd.AddCommand(newAlertsCmd())
 	rootCmd.AddCommand(newFilterAlertsCmd())
 	rootCmd.AddCommand(newScheduledSearchesCmd())
+	rootCmd.AddCommand(newScheduledSearchesV2Cmd())
 	rootCmd.AddCommand(newAggregateAlertsCmd())
 	rootCmd.AddCommand(newPackagesCmd())
 	rootCmd.AddCommand(newGroupsCmd())

--- a/cmd/humioctl/scheduled_searches_v2.go
+++ b/cmd/humioctl/scheduled_searches_v2.go
@@ -1,0 +1,35 @@
+// Copyright © 2025 CrowdStrike
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newScheduledSearchesV2Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "scheduled-searches-v2",
+		Short: "Manage scheduled searches",
+	}
+
+	cmd.AddCommand(newScheduledSearchesV2ListCmd())
+	cmd.AddCommand(newScheduledSearchesV2InstallCmd())
+	cmd.AddCommand(newScheduledSearchesV2ExportCmd())
+	cmd.AddCommand(newScheduledSearchesV2ExportAllCmd())
+	cmd.AddCommand(newScheduledSearchesV2RemoveCmd())
+	cmd.AddCommand(newScheduledSearchesV2ShowCmd())
+
+	return cmd
+}

--- a/cmd/humioctl/scheduled_searches_v2_export.go
+++ b/cmd/humioctl/scheduled_searches_v2_export.go
@@ -1,0 +1,106 @@
+// Copyright © 2025 CrowdStrike
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+
+	"github.com/humio/cli/internal/api"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+func newScheduledSearchesV2ExportCmd() *cobra.Command {
+	var outputName string
+
+	cmd := cobra.Command{
+		Use:   "export [flags] <view> <scheduled-search>",
+		Short: "Export a scheduled search <scheduled-search> in <view> to a file.",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			view := args[0]
+			scheduledSearchName := args[1]
+			client := NewApiClient(cmd)
+
+			if outputName == "" {
+				outputName = scheduledSearchName
+			}
+
+			scheduledSearches, err := client.ScheduledSearchesV2().List(view)
+			exitOnError(cmd, err, "Could not list scheduled searches")
+
+			var scheduledSearch api.ScheduledSearchV2
+			for _, ss := range scheduledSearches {
+				if ss.Name == scheduledSearchName {
+					scheduledSearch = ss
+				}
+			}
+
+			if scheduledSearch.ID == "" {
+				exitOnError(cmd, api.ScheduledSearchNotFound(scheduledSearchName), "Could not find scheduled search")
+			}
+
+			yamlData, err := yaml.Marshal(&scheduledSearch)
+			exitOnError(cmd, err, "Failed to serialize the scheduled search")
+
+			outFilePath := outputName + ".yaml"
+			err = os.WriteFile(outFilePath, yamlData, 0600)
+			exitOnError(cmd, err, "Error saving the scheduled search file")
+		},
+	}
+
+	cmd.Flags().StringVarP(&outputName, "output", "o", "", "The file path where the scheduled search should be written. Defaults to ./<scheduled-search-name>.yaml")
+
+	return &cmd
+}
+
+func newScheduledSearchesV2ExportAllCmd() *cobra.Command {
+	var outputDirectory string
+
+	cmd := cobra.Command{
+		Use:   "export-all <view>",
+		Short: "Export all scheduled searches",
+		Long:  `Export all scheduled searches to yaml files with naming <sanitized-scheduled-search-name>.yaml.`,
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			view := args[0]
+			client := NewApiClient(cmd)
+
+			var scheduledSearches []api.ScheduledSearchV2
+			scheduledSearches, err := client.ScheduledSearchesV2().List(view)
+			exitOnError(cmd, err, "Error fetching scheduled searches")
+
+			for i := range scheduledSearches {
+				yamlData, err := yaml.Marshal(&scheduledSearches[i])
+				exitOnError(cmd, err, "Failed to serialize the scheduled search")
+				scheduledSearchFilename := sanitizeTriggerName(scheduledSearches[i].Name) + ".yaml"
+
+				var outFilePath string
+				if outputDirectory != "" {
+					outFilePath = outputDirectory + "/" + scheduledSearchFilename
+				} else {
+					outFilePath = scheduledSearchFilename
+				}
+
+				err = os.WriteFile(outFilePath, yamlData, 0600)
+				exitOnError(cmd, err, "Error saving the scheduled search to file")
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&outputDirectory, "outputDirectory", "d", "", "The file path where the scheduled searches should be written. Defaults to current directory.")
+
+	return &cmd
+}

--- a/cmd/humioctl/scheduled_searches_v2_list.go
+++ b/cmd/humioctl/scheduled_searches_v2_list.go
@@ -1,0 +1,81 @@
+// Copyright © 2025 CrowdStrike
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/humio/cli/internal/format"
+	"github.com/spf13/cobra"
+)
+
+func newScheduledSearchesV2ListCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "list <view>",
+		Short: "List all scheduled searches in a view.",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			view := args[0]
+			client := NewApiClient(cmd)
+
+			scheduledSearches, err := client.ScheduledSearchesV2().List(view)
+			exitOnError(cmd, err, "Error fetching scheduled searches")
+
+			var rows = make([][]format.Value, len(scheduledSearches))
+			for i := range scheduledSearches {
+				scheduledSearch := scheduledSearches[i]
+
+				rows[i] = []format.Value{
+					format.String(scheduledSearch.ID),
+					format.String(scheduledSearch.Name),
+					format.StringPtr(scheduledSearch.Description),
+					format.String(strconv.FormatInt(scheduledSearch.SearchIntervalSeconds, 10)),
+					format.Int64Ptr(scheduledSearch.SearchIntervalOffsetSeconds),
+					format.String(scheduledSearch.QueryTimestampType),
+					format.Int64Ptr(scheduledSearch.MaxWaitTimeSeconds),
+					format.IntPtr(scheduledSearch.BackfillLimitV2),
+					format.String(scheduledSearch.TimeZone),
+					format.String(scheduledSearch.Schedule),
+					format.String(strings.Join(scheduledSearch.ActionNames, ", ")),
+					format.String(strings.Join(scheduledSearch.Labels, ", ")),
+					format.Bool(scheduledSearch.Enabled),
+					format.String(scheduledSearch.OwnershipRunAsID),
+					format.String(scheduledSearch.QueryOwnershipType),
+				}
+			}
+
+			printOverviewTable(cmd, []string{
+				"ID",
+				"Name",
+				"Description",
+				"Search Interval Seconds",
+				"Search Interval Offset Seconds",
+				"Query Timestamp Type",
+				"Max Wait Time",
+				"Backfill Limit",
+				"Time Zone",
+				"Schedule",
+				"Action Names",
+				"Labels",
+				"Enabled",
+				"Run As User ID",
+				"Query Ownership Type",
+			}, rows)
+		},
+	}
+
+	return &cmd
+}

--- a/cmd/humioctl/scheduled_searches_v2_remove.go
+++ b/cmd/humioctl/scheduled_searches_v2_remove.go
@@ -1,0 +1,57 @@
+// Copyright © 2025 CrowdStrike
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/humio/cli/internal/api"
+	"github.com/spf13/cobra"
+)
+
+func newScheduledSearchesV2RemoveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove <view> <name>",
+		Short: "Removes a scheduled search.",
+		Long:  `Removes the scheduled search with name '<name>' in the view with name '<view>'.`,
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			viewName := args[0]
+			scheduledSearchName := args[1]
+			client := NewApiClient(cmd)
+
+			scheduledSearches, err := client.ScheduledSearchesV2().List(viewName)
+			exitOnError(cmd, err, "Could not list scheduled searches")
+
+			var scheduledSearch api.ScheduledSearchV2
+			for _, ss := range scheduledSearches {
+				if ss.Name == scheduledSearchName {
+					scheduledSearch = ss
+				}
+			}
+
+			if scheduledSearch.ID == "" {
+				exitOnError(cmd, api.ScheduledSearchNotFound(scheduledSearchName), "Could not find scheduled search")
+			}
+
+			err = client.ScheduledSearchesV2().Delete(viewName, scheduledSearch.ID)
+			exitOnError(cmd, err, "Could not remove scheduled search")
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Successfully removed scheduled search %q from view %q\n", scheduledSearchName, viewName)
+		},
+	}
+
+	return cmd
+}

--- a/cmd/humioctl/scheduled_searches_v2_show.go
+++ b/cmd/humioctl/scheduled_searches_v2_show.go
@@ -1,0 +1,73 @@
+// Copyright © 2025 CrowdStrike
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"strings"
+
+	"github.com/humio/cli/internal/api"
+	"github.com/humio/cli/internal/format"
+	"github.com/spf13/cobra"
+)
+
+func newScheduledSearchesV2ShowCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "show <view> <name>",
+		Short: "Show details about a scheduled search in a view.",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			view := args[0]
+			name := args[1]
+			client := NewApiClient(cmd)
+
+			scheduledSearches, err := client.ScheduledSearchesV2().List(view)
+			exitOnError(cmd, err, "Could not list scheduled searches")
+
+			var scheduledSearch api.ScheduledSearchV2
+			for _, ss := range scheduledSearches {
+				if ss.Name == name {
+					scheduledSearch = ss
+				}
+			}
+
+			if scheduledSearch.ID == "" {
+				exitOnError(cmd, api.ScheduledSearchNotFound(name), "Could not find scheduled search")
+			}
+
+			details := [][]format.Value{
+				{format.String("ID"), format.String(scheduledSearch.ID)},
+				{format.String("Name"), format.String(scheduledSearch.Name)},
+				{format.String("Description"), format.StringPtr(scheduledSearch.Description)},
+				{format.String("Query String"), format.String(scheduledSearch.QueryString)},
+				{format.String("Search Interval Seconds"), format.Int(scheduledSearch.SearchIntervalSeconds)},
+				{format.String("Search Interval Offset Seconds"), format.Int64Ptr(scheduledSearch.SearchIntervalOffsetSeconds)},
+				{format.String("Query Timestamp Type"), format.String(scheduledSearch.QueryTimestampType)},
+				{format.String("Max Wait Time Seconds"), format.Int64Ptr(scheduledSearch.MaxWaitTimeSeconds)},
+				{format.String("Backfill Limit"), format.IntPtr(scheduledSearch.BackfillLimitV2)},
+				{format.String("Time Zone"), format.String(scheduledSearch.TimeZone)},
+				{format.String("Schedule"), format.String(scheduledSearch.Schedule)},
+				{format.String("Enabled"), format.Bool(scheduledSearch.Enabled)},
+				{format.String("Actions"), format.String(strings.Join(scheduledSearch.ActionNames, ", "))},
+				{format.String("Run As User ID"), format.String(scheduledSearch.OwnershipRunAsID)},
+				{format.String("Labels"), format.String(strings.Join(scheduledSearch.Labels, ", "))},
+				{format.String("Query Ownership Type"), format.String(scheduledSearch.QueryOwnershipType)},
+			}
+
+			printDetailsTable(cmd, details)
+		},
+	}
+
+	return &cmd
+}

--- a/internal/api/humiographql/genqlient.yaml
+++ b/internal/api/humiographql/genqlient.yaml
@@ -16,6 +16,7 @@ operations:
   - graphql/repositories.graphql
   - graphql/roles.graphql
   - graphql/scheduled-search.graphql
+  - graphql/scheduled-search-v2.graphql
   - graphql/searchdomains.graphql
   - graphql/token.graphql
   - graphql/viewer.graphql

--- a/internal/api/humiographql/graphql/scheduled-search-v2.graphql
+++ b/internal/api/humiographql/graphql/scheduled-search-v2.graphql
@@ -1,0 +1,85 @@
+fragment ScheduledSearchV2Details on ScheduledSearch {
+    id
+    name
+    description
+    queryString
+    searchIntervalSeconds
+    searchIntervalOffsetSeconds
+    maxWaitTimeSeconds
+    timeZone
+    schedule
+    backfillLimitV2
+    enabled
+    actionsV2 {
+        name
+    }
+    labels
+    queryTimestampType
+
+    # @genqlient(typename: "SharedQueryOwnershipType")
+    queryOwnership {
+        ...QueryOwnership
+    }
+}
+
+query ListScheduledSearchesV2(
+    $SearchDomainName: String!
+) {
+    searchDomain(
+        name: $SearchDomainName
+    ) {
+        scheduledSearches {
+            ...ScheduledSearchV2Details
+        }
+    }
+}
+
+mutation CreateScheduledSearchV2(
+    $SearchDomainName: String!
+    $Name: String!
+    $Description: String
+    $QueryString: String!
+    $SearchIntervalSeconds: Long!
+    $SearchIntervalOffsetSeconds: Long
+    $MaxWaitTimeSeconds: Long
+    $Schedule: String!
+    $TimeZone: String!
+    $BackfillLimit: Int
+    $Enabled: Boolean!
+    $ActionIdsOrNames: [String!]!
+    $RunAsUserID: String
+    $Labels: [String!]!
+    $QueryTimestampType: QueryTimestampType!
+    $QueryOwnershipType: QueryOwnershipType!
+) {
+    createScheduledSearchV2(input: {
+        viewName: $SearchDomainName
+        name: $Name
+        description: $Description
+        queryString: $QueryString
+        searchIntervalSeconds: $SearchIntervalSeconds
+        searchIntervalOffsetSeconds: $SearchIntervalOffsetSeconds
+        maxWaitTimeSeconds: $MaxWaitTimeSeconds
+        schedule: $Schedule
+        timeZone: $TimeZone
+        backfillLimit: $BackfillLimit
+        enabled: $Enabled
+        actionIdsOrNames: $ActionIdsOrNames
+        runAsUserId: $RunAsUserID
+        labels: $Labels
+        queryTimestampType: $QueryTimestampType
+        queryOwnershipType: $QueryOwnershipType
+    }) {
+        ...ScheduledSearchV2Details
+    }
+}
+
+mutation DeleteScheduledSearchV2ByID(
+    $SearchDomainName: String!
+    $ScheduledSearchID: String!
+) {
+    deleteScheduledSearch(input: {
+        viewName: $SearchDomainName
+        id: $ScheduledSearchID
+    })
+}

--- a/internal/api/humiographql/humiographql.go
+++ b/internal/api/humiographql/humiographql.go
@@ -194,12 +194,16 @@ type ActionDetailsEmailAction struct {
 	// An action that can be invoked from a trigger.
 	Name string `json:"name"`
 	// List of email addresses to send an email to.
+	// Stability: Long-term
 	Recipients []string `json:"recipients"`
 	// Subject of the email. Can be templated with values from the result.
+	// Stability: Long-term
 	SubjectTemplate *string `json:"subjectTemplate"`
 	// Body of the email. Can be templated with values from the result.
+	// Stability: Long-term
 	EmailBodyTemplate *string `json:"emailBodyTemplate"`
 	// Defines whether the action should use the configured proxy to make web requests.
+	// Stability: Long-term
 	UseProxy bool `json:"useProxy"`
 }
 
@@ -227,8 +231,10 @@ func (v *ActionDetailsEmailAction) GetUseProxy() bool { return v.UseProxy }
 // Field entry in a Slack message
 type ActionDetailsFieldsSlackFieldEntry struct {
 	// Key of a Slack field.
+	// Stability: Long-term
 	FieldName string `json:"fieldName"`
 	// Value of a Slack field.
+	// Stability: Long-term
 	Value string `json:"value"`
 }
 
@@ -244,8 +250,10 @@ func (v *ActionDetailsFieldsSlackFieldEntry) GetValue() string { return v.Value 
 // A http request header.
 type ActionDetailsHeadersHttpHeaderEntry struct {
 	// Key of a http(s) header.
+	// Stability: Long-term
 	Header string `json:"header"`
 	// Value of a http(s) header.
+	// Stability: Long-term
 	Value string `json:"value"`
 }
 
@@ -265,6 +273,7 @@ type ActionDetailsHumioRepoAction struct {
 	// An action that can be invoked from a trigger.
 	Name string `json:"name"`
 	// Humio ingest token for the dataspace that the action should ingest into.
+	// Stability: Long-term
 	IngestToken string `json:"ingestToken"`
 }
 
@@ -287,10 +296,13 @@ type ActionDetailsOpsGenieAction struct {
 	// An action that can be invoked from a trigger.
 	Name string `json:"name"`
 	// OpsGenie webhook url to send the request to.
+	// Stability: Long-term
 	ApiUrl string `json:"apiUrl"`
 	// Key to authenticate with OpsGenie.
+	// Stability: Long-term
 	GenieKey string `json:"genieKey"`
 	// Defines whether the action should use the configured proxy to make web requests.
+	// Stability: Long-term
 	UseProxy bool `json:"useProxy"`
 }
 
@@ -319,10 +331,13 @@ type ActionDetailsPagerDutyAction struct {
 	// An action that can be invoked from a trigger.
 	Name string `json:"name"`
 	// Severity level to give to the message.
+	// Stability: Long-term
 	Severity string `json:"severity"`
 	// Routing key to authenticate with PagerDuty.
+	// Stability: Long-term
 	RoutingKey string `json:"routingKey"`
 	// Defines whether the action should use the configured proxy to make web requests.
+	// Stability: Long-term
 	UseProxy bool `json:"useProxy"`
 }
 
@@ -351,10 +366,13 @@ type ActionDetailsSlackAction struct {
 	// An action that can be invoked from a trigger.
 	Name string `json:"name"`
 	// Slack webhook url to send the request to.
+	// Stability: Long-term
 	Url string `json:"url"`
 	// Fields to include within the Slack message. Can be templated with values from the result.
+	// Stability: Long-term
 	Fields []ActionDetailsFieldsSlackFieldEntry `json:"fields"`
 	// Defines whether the action should use the configured proxy to make web requests.
+	// Stability: Long-term
 	UseProxy bool `json:"useProxy"`
 }
 
@@ -383,12 +401,16 @@ type ActionDetailsSlackPostMessageAction struct {
 	// An action that can be invoked from a trigger.
 	Name string `json:"name"`
 	// Api token to authenticate with Slack.
+	// Stability: Long-term
 	ApiToken string `json:"apiToken"`
 	// List of Slack channels to message.
+	// Stability: Long-term
 	Channels []string `json:"channels"`
 	// Fields to include within the Slack message. Can be templated with values from the result.
+	// Stability: Long-term
 	Fields []ActionDetailsFieldsSlackFieldEntry `json:"fields"`
 	// Defines whether the action should use the configured proxy to make web requests.
+	// Stability: Long-term
 	UseProxy bool `json:"useProxy"`
 }
 
@@ -422,6 +444,7 @@ type ActionDetailsUploadFileAction struct {
 	// An action that can be invoked from a trigger.
 	Name string `json:"name"`
 	// File name for the uploaded file.
+	// Stability: Long-term
 	FileName string `json:"fileName"`
 }
 
@@ -444,10 +467,13 @@ type ActionDetailsVictorOpsAction struct {
 	// An action that can be invoked from a trigger.
 	Name string `json:"name"`
 	// Type of the VictorOps message to make.
+	// Stability: Long-term
 	MessageType string `json:"messageType"`
 	// VictorOps webhook url to send the request to.
+	// Stability: Long-term
 	NotifyUrl string `json:"notifyUrl"`
 	// Defines whether the action should use the configured proxy to make web requests.
+	// Stability: Long-term
 	UseProxy bool `json:"useProxy"`
 }
 
@@ -476,16 +502,22 @@ type ActionDetailsWebhookAction struct {
 	// An action that can be invoked from a trigger.
 	Name string `json:"name"`
 	// Method to use for the request.
+	// Stability: Long-term
 	Method string `json:"method"`
 	// Url to send the http(s) request to.
+	// Stability: Long-term
 	Url string `json:"url"`
 	// Headers of the http(s) request.
+	// Stability: Long-term
 	Headers []ActionDetailsHeadersHttpHeaderEntry `json:"headers"`
 	// Body of the http(s) request. Can be templated with values from the result.
+	// Stability: Long-term
 	WebhookBodyTemplate string `json:"WebhookBodyTemplate"`
 	// Flag indicating whether SSL should be ignored for the request.
+	// Stability: Long-term
 	IgnoreSSL bool `json:"ignoreSSL"`
 	// Defines whether the action should use the configured proxy to make web requests.
+	// Stability: Long-term
 	UseProxy bool `json:"useProxy"`
 }
 
@@ -591,6 +623,7 @@ func (v *AddIngestTokenAddIngestTokenV3IngestToken) __premarshalJSON() (*__prema
 // AddIngestTokenResponse is returned by AddIngestToken on success.
 type AddIngestTokenResponse struct {
 	// Create a new Ingest API Token.
+	// Stability: Long-term
 	AddIngestTokenV3 AddIngestTokenAddIngestTokenV3IngestToken `json:"addIngestTokenV3"`
 }
 
@@ -801,6 +834,7 @@ func __marshalAddUserAddUserV2UserOrPendingUser(v *AddUserAddUserV2UserOrPending
 // AddUserResponse is returned by AddUser on success.
 type AddUserResponse struct {
 	// Add or invite a user. Calling this with an invitation token, will activate the account. By activating the account the client accepts LogScale's Terms and Conditions: https://www.humio.com/terms-and-conditions
+	// Stability: Long-term
 	AddUserV2 AddUserAddUserV2UserOrPendingUser `json:"-"`
 }
 
@@ -883,6 +917,7 @@ func (v *AddUserToGroupAddUsersToGroupAddUsersToGroupMutation) GetTypename() *st
 // AddUserToGroupResponse is returned by AddUserToGroup on success.
 type AddUserToGroupResponse struct {
 	// Adds users to an existing group.
+	// Stability: Long-term
 	AddUsersToGroup AddUserToGroupAddUsersToGroupAddUsersToGroupMutation `json:"addUsersToGroup"`
 }
 
@@ -897,30 +932,43 @@ func (v *AddUserToGroupResponse) GetAddUsersToGroup() AddUserToGroupAddUsersToGr
 // An aggregate alert.
 type AggregateAlertDetails struct {
 	// Id of the aggregate alert.
+	// Stability: Long-term
 	Id string `json:"id"`
 	// Name of the aggregate alert.
+	// Stability: Long-term
 	Name string `json:"name"`
 	// Description of the aggregate alert.
+	// Stability: Long-term
 	Description *string `json:"description"`
 	// LogScale query to execute.
+	// Stability: Long-term
 	QueryString string `json:"queryString"`
 	// Search interval in seconds.
+	// Stability: Long-term
 	SearchIntervalSeconds int64 `json:"searchIntervalSeconds"`
 	// Throttle time in seconds.
+	// Stability: Long-term
 	ThrottleTimeSeconds int64 `json:"throttleTimeSeconds"`
 	// A field to throttle on. Can only be set if throttleTimeSeconds is set.
+	// Stability: Long-term
 	ThrottleField *string `json:"throttleField"`
 	// List of actions to fire on query result.
+	// Stability: Long-term
 	Actions []AggregateAlertDetailsActionsAction `json:"-"`
 	// Labels attached to the aggregate alert.
+	// Stability: Long-term
 	Labels []string `json:"labels"`
 	// Flag indicating whether the aggregate alert is enabled.
+	// Stability: Long-term
 	Enabled bool `json:"enabled"`
 	// Trigger mode used for triggering the alert.
+	// Stability: Long-term
 	TriggerMode TriggerMode `json:"triggerMode"`
 	// Timestamp type to use for a query.
+	// Stability: Long-term
 	QueryTimestampType QueryTimestampType `json:"queryTimestampType"`
 	// Ownership of the query run by this alert
+	// Stability: Long-term
 	QueryOwnership SharedQueryOwnershipType `json:"-"`
 }
 
@@ -1430,32 +1478,45 @@ func (v *AggregateAlertDetailsActionsWebhookAction) GetName() string { return v.
 // An alert.
 type AlertDetails struct {
 	// Id of the alert.
+	// Stability: Long-term
 	Id string `json:"id"`
 	// Name of the alert.
+	// Stability: Long-term
 	Name string `json:"name"`
 	// LogScale query to execute.
+	// Stability: Long-term
 	QueryString string `json:"queryString"`
 	// Start of the relative time interval for the query.
+	// Stability: Long-term
 	QueryStart string `json:"queryStart"`
 	// Field to throttle on.
+	// Stability: Long-term
 	ThrottleField *string `json:"throttleField"`
 	// Unix timestamp for when the alert was last triggered.
+	// Stability: Long-term
 	TimeOfLastTrigger *int64 `json:"timeOfLastTrigger"`
 	// Flag indicating whether the calling user has 'starred' the alert.
 	IsStarred bool `json:"isStarred"`
 	// Name of the alert.
+	// Stability: Long-term
 	Description *string `json:"description"`
 	// Throttle time in milliseconds.
+	// Stability: Long-term
 	ThrottleTimeMillis int64 `json:"throttleTimeMillis"`
 	// Flag indicating whether the alert is enabled.
+	// Stability: Long-term
 	Enabled bool `json:"enabled"`
 	// List of ids for actions to fire on query result.
+	// Stability: Long-term
 	Actions []string `json:"actions"`
 	// Labels attached to the alert.
+	// Stability: Long-term
 	Labels []string `json:"labels"`
 	// Last error encountered while running the alert.
+	// Stability: Long-term
 	LastError *string `json:"lastError"`
 	// Ownership of the query run by this alert
+	// Stability: Long-term
 	QueryOwnership SharedQueryOwnershipType `json:"-"`
 }
 
@@ -1619,6 +1680,7 @@ func (v *AssignParserToIngestTokenAssignParserToIngestTokenV2IngestToken) GetTyp
 // AssignParserToIngestTokenResponse is returned by AssignParserToIngestToken on success.
 type AssignParserToIngestTokenResponse struct {
 	// Assign an ingest token to be associated with a parser.
+	// Stability: Long-term
 	AssignParserToIngestTokenV2 AssignParserToIngestTokenAssignParserToIngestTokenV2IngestToken `json:"assignParserToIngestTokenV2"`
 }
 
@@ -1632,6 +1694,7 @@ func (v *AssignParserToIngestTokenResponse) GetAssignParserToIngestTokenV2() Ass
 //
 // Information about the LogScale cluster.
 type ClusterNode struct {
+	// Stability: Long-term
 	Nodes []ClusterNodeNodesClusterNode `json:"nodes"`
 }
 
@@ -1643,41 +1706,62 @@ func (v *ClusterNode) GetNodes() []ClusterNodeNodesClusterNode { return v.Nodes 
 //
 // A node in the a LogScale Cluster.
 type ClusterNodeNodesClusterNode struct {
-	Id                    int     `json:"id"`
-	Name                  string  `json:"name"`
-	Uri                   string  `json:"uri"`
-	Uuid                  string  `json:"uuid"`
+	// Stability: Long-term
+	Id int `json:"id"`
+	// Stability: Long-term
+	Name string `json:"name"`
+	// Stability: Long-term
+	Uri string `json:"uri"`
+	// Stability: Long-term
+	Uuid string `json:"uuid"`
+	// Stability: Long-term
 	ClusterInfoAgeSeconds float64 `json:"clusterInfoAgeSeconds"`
 	// The size in GB of data this node needs to receive.
+	// Stability: Long-term
 	InboundSegmentSize float64 `json:"inboundSegmentSize"`
 	// The size in GB of data this node has that others need.
-	OutboundSegmentSize     float64 `json:"outboundSegmentSize"`
-	CanBeSafelyUnregistered bool    `json:"canBeSafelyUnregistered"`
+	// Stability: Short-term
+	OutboundSegmentSize float64 `json:"outboundSegmentSize"`
+	// Stability: Long-term
+	CanBeSafelyUnregistered bool `json:"canBeSafelyUnregistered"`
 	// The size in GB of data currently on this node.
+	// Stability: Long-term
 	CurrentSize float64 `json:"currentSize"`
 	// The size in GB of the data currently on this node that are in the primary storage location.
+	// Stability: Long-term
 	PrimarySize float64 `json:"primarySize"`
 	// The size in GB of the data currently on this node that are in the secondary storage location. Zero if no secondary is configured.
+	// Stability: Long-term
 	SecondarySize float64 `json:"secondarySize"`
 	// The total size in GB of the primary storage location on this node.
+	// Stability: Long-term
 	TotalSizeOfPrimary float64 `json:"totalSizeOfPrimary"`
 	// The total size in GB of the secondary storage location on this node. Zero if no secondary is configured.
+	// Stability: Long-term
 	TotalSizeOfSecondary float64 `json:"totalSizeOfSecondary"`
 	// The size in GB of the free space on this node of the primary storage location.
+	// Stability: Long-term
 	FreeOnPrimary float64 `json:"freeOnPrimary"`
 	// The size in GB of the free space on this node of the secondary storage location. Zero if no secondary is configured.
+	// Stability: Long-term
 	FreeOnSecondary float64 `json:"freeOnSecondary"`
 	// The size in GB of work-in-progress data files.
+	// Stability: Long-term
 	WipSize float64 `json:"wipSize"`
 	// The size in GB of data once the node has received the data allocated to it.
+	// Stability: Long-term
 	TargetSize float64 `json:"targetSize"`
 	// The size in GB of data that only exists on this node - i.e. only one replica exists in the cluster.
+	// Stability: Long-term
 	SolitarySegmentSize float64 `json:"solitarySegmentSize"`
 	// A flag indicating whether the node is considered up or down by the cluster coordinated. This is based on the `lastHeartbeat` field.
+	// Stability: Long-term
 	IsAvailable bool `json:"isAvailable"`
 	// The last time a heartbeat was received from the node.
+	// Stability: Long-term
 	LastHeartbeat time.Time `json:"lastHeartbeat"`
-	Zone          *string   `json:"zone"`
+	// Stability: Long-term
+	Zone *string `json:"zone"`
 }
 
 // GetId returns ClusterNodeNodesClusterNode.Id, and is useful for accessing the field via an interface.
@@ -1931,6 +2015,7 @@ func (v *CreateAggregateAlertCreateAggregateAlert) __premarshalJSON() (*__premar
 // CreateAggregateAlertResponse is returned by CreateAggregateAlert on success.
 type CreateAggregateAlertResponse struct {
 	// Create an aggregate alert.
+	// Stability: Long-term
 	CreateAggregateAlert CreateAggregateAlertCreateAggregateAlert `json:"createAggregateAlert"`
 }
 
@@ -2092,6 +2177,7 @@ func (v *CreateAlertCreateAlert) __premarshalJSON() (*__premarshalCreateAlertCre
 // CreateAlertResponse is returned by CreateAlert on success.
 type CreateAlertResponse struct {
 	// Create an alert.
+	// Stability: Long-term
 	CreateAlert CreateAlertCreateAlert `json:"createAlert"`
 }
 
@@ -2104,16 +2190,22 @@ func (v *CreateAlertResponse) GetCreateAlert() CreateAlertCreateAlert { return v
 // An email action.
 type CreateEmailActionCreateEmailAction struct {
 	// The id of the action.
+	// Stability: Long-term
 	Id string `json:"id"`
 	// The name of the action.
+	// Stability: Long-term
 	Name string `json:"name"`
 	// List of email addresses to send an email to.
+	// Stability: Long-term
 	Recipients []string `json:"recipients"`
 	// Subject of the email. Can be templated with values from the result.
+	// Stability: Long-term
 	SubjectTemplate *string `json:"subjectTemplate"`
 	// Body of the email. Can be templated with values from the result.
+	// Stability: Long-term
 	BodyTemplate *string `json:"bodyTemplate"`
 	// Defines whether the action should use the configured proxy to make web requests.
+	// Stability: Long-term
 	UseProxy bool `json:"useProxy"`
 }
 
@@ -2138,6 +2230,7 @@ func (v *CreateEmailActionCreateEmailAction) GetUseProxy() bool { return v.UsePr
 // CreateEmailActionResponse is returned by CreateEmailAction on success.
 type CreateEmailActionResponse struct {
 	// Create an email action.
+	// Stability: Long-term
 	CreateEmailAction CreateEmailActionCreateEmailAction `json:"createEmailAction"`
 }
 
@@ -2298,6 +2391,7 @@ func (v *CreateFilterAlertCreateFilterAlert) __premarshalJSON() (*__premarshalCr
 // CreateFilterAlertResponse is returned by CreateFilterAlert on success.
 type CreateFilterAlertResponse struct {
 	// Create a filter alert.
+	// Stability: Long-term
 	CreateFilterAlert CreateFilterAlertCreateFilterAlert `json:"createFilterAlert"`
 }
 
@@ -2312,10 +2406,13 @@ func (v *CreateFilterAlertResponse) GetCreateFilterAlert() CreateFilterAlertCrea
 // A LogScale repository action.
 type CreateHumioRepoActionCreateHumioRepoAction struct {
 	// The id of the action.
+	// Stability: Long-term
 	Id string `json:"id"`
 	// The name of the action.
+	// Stability: Long-term
 	Name string `json:"name"`
 	// Humio ingest token for the dataspace that the action should ingest into.
+	// Stability: Long-term
 	IngestToken string `json:"ingestToken"`
 }
 
@@ -2331,6 +2428,7 @@ func (v *CreateHumioRepoActionCreateHumioRepoAction) GetIngestToken() string { r
 // CreateHumioRepoActionResponse is returned by CreateHumioRepoAction on success.
 type CreateHumioRepoActionResponse struct {
 	// Create a LogScale repository action.
+	// Stability: Long-term
 	CreateHumioRepoAction CreateHumioRepoActionCreateHumioRepoAction `json:"createHumioRepoAction"`
 }
 
@@ -2345,14 +2443,19 @@ func (v *CreateHumioRepoActionResponse) GetCreateHumioRepoAction() CreateHumioRe
 // An OpsGenie action
 type CreateOpsGenieActionCreateOpsGenieAction struct {
 	// The id of the action.
+	// Stability: Long-term
 	Id string `json:"id"`
 	// The name of the action.
+	// Stability: Long-term
 	Name string `json:"name"`
 	// OpsGenie webhook url to send the request to.
+	// Stability: Long-term
 	ApiUrl string `json:"apiUrl"`
 	// Key to authenticate with OpsGenie.
+	// Stability: Long-term
 	GenieKey string `json:"genieKey"`
 	// Defines whether the action should use the configured proxy to make web requests.
+	// Stability: Long-term
 	UseProxy bool `json:"useProxy"`
 }
 
@@ -2374,6 +2477,7 @@ func (v *CreateOpsGenieActionCreateOpsGenieAction) GetUseProxy() bool { return v
 // CreateOpsGenieActionResponse is returned by CreateOpsGenieAction on success.
 type CreateOpsGenieActionResponse struct {
 	// Create an OpsGenie action.
+	// Stability: Long-term
 	CreateOpsGenieAction CreateOpsGenieActionCreateOpsGenieAction `json:"createOpsGenieAction"`
 }
 
@@ -2388,14 +2492,19 @@ func (v *CreateOpsGenieActionResponse) GetCreateOpsGenieAction() CreateOpsGenieA
 // A PagerDuty action.
 type CreatePagerDutyActionCreatePagerDutyAction struct {
 	// The id of the action.
+	// Stability: Long-term
 	Id string `json:"id"`
 	// The name of the action.
+	// Stability: Long-term
 	Name string `json:"name"`
 	// Severity level to give to the message.
+	// Stability: Long-term
 	Severity string `json:"severity"`
 	// Routing key to authenticate with PagerDuty.
+	// Stability: Long-term
 	RoutingKey string `json:"routingKey"`
 	// Defines whether the action should use the configured proxy to make web requests.
+	// Stability: Long-term
 	UseProxy bool `json:"useProxy"`
 }
 
@@ -2417,6 +2526,7 @@ func (v *CreatePagerDutyActionCreatePagerDutyAction) GetUseProxy() bool { return
 // CreatePagerDutyActionResponse is returned by CreatePagerDutyAction on success.
 type CreatePagerDutyActionResponse struct {
 	// Create a PagerDuty action.
+	// Stability: Long-term
 	CreatePagerDutyAction CreatePagerDutyActionCreatePagerDutyAction `json:"createPagerDutyAction"`
 }
 
@@ -2541,6 +2651,7 @@ func (v *CreateParserCreateParserV2Parser) __premarshalJSON() (*__premarshalCrea
 // CreateParserResponse is returned by CreateParser on success.
 type CreateParserResponse struct {
 	// Create a parser.
+	// Stability: Long-term
 	CreateParserV2 CreateParserCreateParserV2Parser `json:"createParserV2"`
 }
 
@@ -2551,6 +2662,7 @@ func (v *CreateParserResponse) GetCreateParserV2() CreateParserCreateParserV2Par
 
 // CreateRepositoryCreateRepositoryCreateRepositoryMutation includes the requested fields of the GraphQL type CreateRepositoryMutation.
 type CreateRepositoryCreateRepositoryCreateRepositoryMutation struct {
+	// Stability: Long-term
 	Repository CreateRepositoryCreateRepositoryCreateRepositoryMutationRepository `json:"repository"`
 }
 
@@ -2683,6 +2795,7 @@ func (v *CreateRepositoryCreateRepositoryCreateRepositoryMutationRepository) __p
 // CreateRepositoryResponse is returned by CreateRepository on success.
 type CreateRepositoryResponse struct {
 	// Create a new repository.
+	// Stability: Short-term
 	CreateRepository CreateRepositoryCreateRepositoryCreateRepositoryMutation `json:"createRepository"`
 }
 
@@ -2883,20 +2996,234 @@ func (v *CreateScheduledSearchResponse) GetCreateScheduledSearch() CreateSchedul
 	return v.CreateScheduledSearch
 }
 
+// CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch includes the requested fields of the GraphQL type ScheduledSearch.
+// The GraphQL type's documentation follows.
+//
+// Information about a scheduled search
+type CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch struct {
+	ScheduledSearchV2Details `json:"-"`
+}
+
+// GetId returns CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch.Id, and is useful for accessing the field via an interface.
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) GetId() string {
+	return v.ScheduledSearchV2Details.Id
+}
+
+// GetName returns CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch.Name, and is useful for accessing the field via an interface.
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) GetName() string {
+	return v.ScheduledSearchV2Details.Name
+}
+
+// GetDescription returns CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch.Description, and is useful for accessing the field via an interface.
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) GetDescription() *string {
+	return v.ScheduledSearchV2Details.Description
+}
+
+// GetQueryString returns CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch.QueryString, and is useful for accessing the field via an interface.
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) GetQueryString() string {
+	return v.ScheduledSearchV2Details.QueryString
+}
+
+// GetSearchIntervalSeconds returns CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch.SearchIntervalSeconds, and is useful for accessing the field via an interface.
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) GetSearchIntervalSeconds() int64 {
+	return v.ScheduledSearchV2Details.SearchIntervalSeconds
+}
+
+// GetSearchIntervalOffsetSeconds returns CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch.SearchIntervalOffsetSeconds, and is useful for accessing the field via an interface.
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) GetSearchIntervalOffsetSeconds() *int64 {
+	return v.ScheduledSearchV2Details.SearchIntervalOffsetSeconds
+}
+
+// GetMaxWaitTimeSeconds returns CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch.MaxWaitTimeSeconds, and is useful for accessing the field via an interface.
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) GetMaxWaitTimeSeconds() *int64 {
+	return v.ScheduledSearchV2Details.MaxWaitTimeSeconds
+}
+
+// GetTimeZone returns CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch.TimeZone, and is useful for accessing the field via an interface.
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) GetTimeZone() string {
+	return v.ScheduledSearchV2Details.TimeZone
+}
+
+// GetSchedule returns CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch.Schedule, and is useful for accessing the field via an interface.
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) GetSchedule() string {
+	return v.ScheduledSearchV2Details.Schedule
+}
+
+// GetBackfillLimitV2 returns CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch.BackfillLimitV2, and is useful for accessing the field via an interface.
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) GetBackfillLimitV2() *int {
+	return v.ScheduledSearchV2Details.BackfillLimitV2
+}
+
+// GetEnabled returns CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch.Enabled, and is useful for accessing the field via an interface.
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) GetEnabled() bool {
+	return v.ScheduledSearchV2Details.Enabled
+}
+
+// GetActionsV2 returns CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch.ActionsV2, and is useful for accessing the field via an interface.
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) GetActionsV2() []ScheduledSearchV2DetailsActionsV2Action {
+	return v.ScheduledSearchV2Details.ActionsV2
+}
+
+// GetLabels returns CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch.Labels, and is useful for accessing the field via an interface.
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) GetLabels() []string {
+	return v.ScheduledSearchV2Details.Labels
+}
+
+// GetQueryTimestampType returns CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch.QueryTimestampType, and is useful for accessing the field via an interface.
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) GetQueryTimestampType() QueryTimestampType {
+	return v.ScheduledSearchV2Details.QueryTimestampType
+}
+
+// GetQueryOwnership returns CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch.QueryOwnership, and is useful for accessing the field via an interface.
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) GetQueryOwnership() SharedQueryOwnershipType {
+	return v.ScheduledSearchV2Details.QueryOwnership
+}
+
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.ScheduledSearchV2Details)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalCreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch struct {
+	Id string `json:"id"`
+
+	Name string `json:"name"`
+
+	Description *string `json:"description"`
+
+	QueryString string `json:"queryString"`
+
+	SearchIntervalSeconds int64 `json:"searchIntervalSeconds"`
+
+	SearchIntervalOffsetSeconds *int64 `json:"searchIntervalOffsetSeconds"`
+
+	MaxWaitTimeSeconds *int64 `json:"maxWaitTimeSeconds"`
+
+	TimeZone string `json:"timeZone"`
+
+	Schedule string `json:"schedule"`
+
+	BackfillLimitV2 *int `json:"backfillLimitV2"`
+
+	Enabled bool `json:"enabled"`
+
+	ActionsV2 []json.RawMessage `json:"actionsV2"`
+
+	Labels []string `json:"labels"`
+
+	QueryTimestampType QueryTimestampType `json:"queryTimestampType"`
+
+	QueryOwnership json.RawMessage `json:"queryOwnership"`
+}
+
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch) __premarshalJSON() (*__premarshalCreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch, error) {
+	var retval __premarshalCreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch
+
+	retval.Id = v.ScheduledSearchV2Details.Id
+	retval.Name = v.ScheduledSearchV2Details.Name
+	retval.Description = v.ScheduledSearchV2Details.Description
+	retval.QueryString = v.ScheduledSearchV2Details.QueryString
+	retval.SearchIntervalSeconds = v.ScheduledSearchV2Details.SearchIntervalSeconds
+	retval.SearchIntervalOffsetSeconds = v.ScheduledSearchV2Details.SearchIntervalOffsetSeconds
+	retval.MaxWaitTimeSeconds = v.ScheduledSearchV2Details.MaxWaitTimeSeconds
+	retval.TimeZone = v.ScheduledSearchV2Details.TimeZone
+	retval.Schedule = v.ScheduledSearchV2Details.Schedule
+	retval.BackfillLimitV2 = v.ScheduledSearchV2Details.BackfillLimitV2
+	retval.Enabled = v.ScheduledSearchV2Details.Enabled
+	{
+
+		dst := &retval.ActionsV2
+		src := v.ScheduledSearchV2Details.ActionsV2
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalScheduledSearchV2DetailsActionsV2Action(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"unable to marshal CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch.ScheduledSearchV2Details.ActionsV2: %w", err)
+			}
+		}
+	}
+	retval.Labels = v.ScheduledSearchV2Details.Labels
+	retval.QueryTimestampType = v.ScheduledSearchV2Details.QueryTimestampType
+	{
+
+		dst := &retval.QueryOwnership
+		src := v.ScheduledSearchV2Details.QueryOwnership
+		var err error
+		*dst, err = __marshalSharedQueryOwnershipType(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch.ScheduledSearchV2Details.QueryOwnership: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
+// CreateScheduledSearchV2Response is returned by CreateScheduledSearchV2 on success.
+type CreateScheduledSearchV2Response struct {
+	// Create a scheduled search.
+	// Stability: Long-term
+	CreateScheduledSearchV2 CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch `json:"createScheduledSearchV2"`
+}
+
+// GetCreateScheduledSearchV2 returns CreateScheduledSearchV2Response.CreateScheduledSearchV2, and is useful for accessing the field via an interface.
+func (v *CreateScheduledSearchV2Response) GetCreateScheduledSearchV2() CreateScheduledSearchV2CreateScheduledSearchV2ScheduledSearch {
+	return v.CreateScheduledSearchV2
+}
+
 // CreateSlackActionCreateSlackAction includes the requested fields of the GraphQL type SlackAction.
 // The GraphQL type's documentation follows.
 //
 // A Slack action
 type CreateSlackActionCreateSlackAction struct {
 	// The id of the action.
+	// Stability: Long-term
 	Id string `json:"id"`
 	// The name of the action.
+	// Stability: Long-term
 	Name string `json:"name"`
 	// Fields to include within the Slack message. Can be templated with values from the result.
+	// Stability: Long-term
 	Fields []CreateSlackActionCreateSlackActionFieldsSlackFieldEntry `json:"fields"`
 	// Slack webhook url to send the request to.
+	// Stability: Long-term
 	Url string `json:"url"`
 	// Defines whether the action should use the configured proxy to make web requests.
+	// Stability: Long-term
 	UseProxy bool `json:"useProxy"`
 }
 
@@ -2923,8 +3250,10 @@ func (v *CreateSlackActionCreateSlackAction) GetUseProxy() bool { return v.UsePr
 // Field entry in a Slack message
 type CreateSlackActionCreateSlackActionFieldsSlackFieldEntry struct {
 	// Value of a Slack field.
+	// Stability: Long-term
 	Value string `json:"value"`
 	// Key of a Slack field.
+	// Stability: Long-term
 	FieldName string `json:"fieldName"`
 }
 
@@ -2939,6 +3268,7 @@ func (v *CreateSlackActionCreateSlackActionFieldsSlackFieldEntry) GetFieldName()
 // CreateSlackActionResponse is returned by CreateSlackAction on success.
 type CreateSlackActionResponse struct {
 	// Create a Slack action.
+	// Stability: Long-term
 	CreateSlackAction CreateSlackActionCreateSlackAction `json:"createSlackAction"`
 }
 
@@ -2953,16 +3283,22 @@ func (v *CreateSlackActionResponse) GetCreateSlackAction() CreateSlackActionCrea
 // A slack post-message action.
 type CreateSlackPostMessageActionCreateSlackPostMessageAction struct {
 	// The id of the action.
+	// Stability: Long-term
 	Id string `json:"id"`
 	// The name of the action.
+	// Stability: Long-term
 	Name string `json:"name"`
 	// Api token to authenticate with Slack.
+	// Stability: Long-term
 	ApiToken string `json:"apiToken"`
 	// List of Slack channels to message.
+	// Stability: Long-term
 	Channels []string `json:"channels"`
 	// Fields to include within the Slack message. Can be templated with values from the result.
+	// Stability: Long-term
 	Fields []CreateSlackPostMessageActionCreateSlackPostMessageActionFieldsSlackFieldEntry `json:"fields"`
 	// Defines whether the action should use the configured proxy to make web requests.
+	// Stability: Long-term
 	UseProxy bool `json:"useProxy"`
 }
 
@@ -2998,8 +3334,10 @@ func (v *CreateSlackPostMessageActionCreateSlackPostMessageAction) GetUseProxy()
 // Field entry in a Slack message
 type CreateSlackPostMessageActionCreateSlackPostMessageActionFieldsSlackFieldEntry struct {
 	// Value of a Slack field.
+	// Stability: Long-term
 	Value string `json:"value"`
 	// Key of a Slack field.
+	// Stability: Long-term
 	FieldName string `json:"fieldName"`
 }
 
@@ -3016,6 +3354,7 @@ func (v *CreateSlackPostMessageActionCreateSlackPostMessageActionFieldsSlackFiel
 // CreateSlackPostMessageActionResponse is returned by CreateSlackPostMessageAction on success.
 type CreateSlackPostMessageActionResponse struct {
 	// Create a post message Slack action.
+	// Stability: Long-term
 	CreateSlackPostMessageAction CreateSlackPostMessageActionCreateSlackPostMessageAction `json:"createSlackPostMessageAction"`
 }
 
@@ -3030,10 +3369,13 @@ func (v *CreateSlackPostMessageActionResponse) GetCreateSlackPostMessageAction()
 // An upload file action.
 type CreateUploadFileActionCreateUploadFileAction struct {
 	// The id of the action.
+	// Stability: Long-term
 	Id string `json:"id"`
 	// The name of the action.
+	// Stability: Long-term
 	Name string `json:"name"`
 	// File name for the uploaded file.
+	// Stability: Long-term
 	FileName string `json:"fileName"`
 }
 
@@ -3049,6 +3391,7 @@ func (v *CreateUploadFileActionCreateUploadFileAction) GetFileName() string { re
 // CreateUploadFileActionResponse is returned by CreateUploadFileAction on success.
 type CreateUploadFileActionResponse struct {
 	// Create an upload file action.
+	// Stability: Long-term
 	CreateUploadFileAction CreateUploadFileActionCreateUploadFileAction `json:"createUploadFileAction"`
 }
 
@@ -3063,14 +3406,19 @@ func (v *CreateUploadFileActionResponse) GetCreateUploadFileAction() CreateUploa
 // A VictorOps action.
 type CreateVictorOpsActionCreateVictorOpsAction struct {
 	// The id of the action.
+	// Stability: Long-term
 	Id string `json:"id"`
 	// The name of the action.
+	// Stability: Long-term
 	Name string `json:"name"`
 	// Type of the VictorOps message to make.
+	// Stability: Long-term
 	MessageType string `json:"messageType"`
 	// VictorOps webhook url to send the request to.
+	// Stability: Long-term
 	NotifyUrl string `json:"notifyUrl"`
 	// Defines whether the action should use the configured proxy to make web requests.
+	// Stability: Long-term
 	UseProxy bool `json:"useProxy"`
 }
 
@@ -3092,6 +3440,7 @@ func (v *CreateVictorOpsActionCreateVictorOpsAction) GetUseProxy() bool { return
 // CreateVictorOpsActionResponse is returned by CreateVictorOpsAction on success.
 type CreateVictorOpsActionResponse struct {
 	// Create a VictorOps action.
+	// Stability: Long-term
 	CreateVictorOpsAction CreateVictorOpsActionCreateVictorOpsAction `json:"createVictorOpsAction"`
 }
 
@@ -3114,6 +3463,7 @@ func (v *CreateViewCreateView) GetTypename() *string { return v.Typename }
 // CreateViewResponse is returned by CreateView on success.
 type CreateViewResponse struct {
 	// Create a new view.
+	// Stability: Long-term
 	CreateView CreateViewCreateView `json:"createView"`
 }
 
@@ -3126,20 +3476,28 @@ func (v *CreateViewResponse) GetCreateView() CreateViewCreateView { return v.Cre
 // A webhook action
 type CreateWebhookActionCreateWebhookAction struct {
 	// The id of the action.
+	// Stability: Long-term
 	Id string `json:"id"`
 	// The name of the action.
+	// Stability: Long-term
 	Name string `json:"name"`
 	// Url to send the http(s) request to.
+	// Stability: Long-term
 	Url string `json:"url"`
 	// Method to use for the request.
+	// Stability: Long-term
 	Method string `json:"method"`
 	// Headers of the http(s) request.
+	// Stability: Long-term
 	Headers []CreateWebhookActionCreateWebhookActionHeadersHttpHeaderEntry `json:"headers"`
 	// Body of the http(s) request. Can be templated with values from the result.
+	// Stability: Long-term
 	BodyTemplate string `json:"bodyTemplate"`
 	// Flag indicating whether SSL should be ignored for the request.
+	// Stability: Long-term
 	IgnoreSSL bool `json:"ignoreSSL"`
 	// Defines whether the action should use the configured proxy to make web requests.
+	// Stability: Long-term
 	UseProxy bool `json:"useProxy"`
 }
 
@@ -3175,8 +3533,10 @@ func (v *CreateWebhookActionCreateWebhookAction) GetUseProxy() bool { return v.U
 // A http request header.
 type CreateWebhookActionCreateWebhookActionHeadersHttpHeaderEntry struct {
 	// Value of a http(s) header.
+	// Stability: Long-term
 	Value string `json:"value"`
 	// Key of a http(s) header.
+	// Stability: Long-term
 	Header string `json:"header"`
 }
 
@@ -3193,6 +3553,7 @@ func (v *CreateWebhookActionCreateWebhookActionHeadersHttpHeaderEntry) GetHeader
 // CreateWebhookActionResponse is returned by CreateWebhookAction on success.
 type CreateWebhookActionResponse struct {
 	// Create a webhook action.
+	// Stability: Long-term
 	CreateWebhookAction CreateWebhookActionCreateWebhookAction `json:"createWebhookAction"`
 }
 
@@ -3204,6 +3565,7 @@ func (v *CreateWebhookActionResponse) GetCreateWebhookAction() CreateWebhookActi
 // DeleteActionByIDResponse is returned by DeleteActionByID on success.
 type DeleteActionByIDResponse struct {
 	// Delete an action.
+	// Stability: Long-term
 	DeleteAction bool `json:"deleteAction"`
 }
 
@@ -3213,6 +3575,7 @@ func (v *DeleteActionByIDResponse) GetDeleteAction() bool { return v.DeleteActio
 // DeleteAggregateAlertResponse is returned by DeleteAggregateAlert on success.
 type DeleteAggregateAlertResponse struct {
 	// Delete an aggregate alert.
+	// Stability: Long-term
 	DeleteAggregateAlert bool `json:"deleteAggregateAlert"`
 }
 
@@ -3222,6 +3585,7 @@ func (v *DeleteAggregateAlertResponse) GetDeleteAggregateAlert() bool { return v
 // DeleteAlertResponse is returned by DeleteAlert on success.
 type DeleteAlertResponse struct {
 	// Delete an alert.
+	// Stability: Long-term
 	DeleteAlert bool `json:"deleteAlert"`
 }
 
@@ -3231,6 +3595,7 @@ func (v *DeleteAlertResponse) GetDeleteAlert() bool { return v.DeleteAlert }
 // DeleteFilterAlertResponse is returned by DeleteFilterAlert on success.
 type DeleteFilterAlertResponse struct {
 	// Delete a filter alert.
+	// Stability: Long-term
 	DeleteFilterAlert bool `json:"deleteFilterAlert"`
 }
 
@@ -3248,6 +3613,7 @@ func (v *DeleteParserByIDDeleteParserBooleanResultType) GetTypename() *string { 
 // DeleteParserByIDResponse is returned by DeleteParserByID on success.
 type DeleteParserByIDResponse struct {
 	// Delete a parser.
+	// Stability: Long-term
 	DeleteParser DeleteParserByIDDeleteParserBooleanResultType `json:"deleteParser"`
 }
 
@@ -3259,11 +3625,24 @@ func (v *DeleteParserByIDResponse) GetDeleteParser() DeleteParserByIDDeleteParse
 // DeleteScheduledSearchByIDResponse is returned by DeleteScheduledSearchByID on success.
 type DeleteScheduledSearchByIDResponse struct {
 	// Delete a scheduled search.
+	// Stability: Long-term
 	DeleteScheduledSearch bool `json:"deleteScheduledSearch"`
 }
 
 // GetDeleteScheduledSearch returns DeleteScheduledSearchByIDResponse.DeleteScheduledSearch, and is useful for accessing the field via an interface.
 func (v *DeleteScheduledSearchByIDResponse) GetDeleteScheduledSearch() bool {
+	return v.DeleteScheduledSearch
+}
+
+// DeleteScheduledSearchV2ByIDResponse is returned by DeleteScheduledSearchV2ByID on success.
+type DeleteScheduledSearchV2ByIDResponse struct {
+	// Delete a scheduled search.
+	// Stability: Long-term
+	DeleteScheduledSearch bool `json:"deleteScheduledSearch"`
+}
+
+// GetDeleteScheduledSearch returns DeleteScheduledSearchV2ByIDResponse.DeleteScheduledSearch, and is useful for accessing the field via an interface.
+func (v *DeleteScheduledSearchV2ByIDResponse) GetDeleteScheduledSearch() bool {
 	return v.DeleteScheduledSearch
 }
 
@@ -3280,6 +3659,7 @@ func (v *DeleteSearchDomainDeleteSearchDomainBooleanResultType) GetTypename() *s
 // DeleteSearchDomainResponse is returned by DeleteSearchDomain on success.
 type DeleteSearchDomainResponse struct {
 	// Delete a repository or view.
+	// Stability: Long-term
 	DeleteSearchDomain DeleteSearchDomainDeleteSearchDomainBooleanResultType `json:"deleteSearchDomain"`
 }
 
@@ -3291,6 +3671,7 @@ func (v *DeleteSearchDomainResponse) GetDeleteSearchDomain() DeleteSearchDomainD
 // DisableFeatureFlagForOrganizationResponse is returned by DisableFeatureFlagForOrganization on success.
 type DisableFeatureFlagForOrganizationResponse struct {
 	// Disable a feature for a specific organization.
+	// Stability: Short-term
 	DisableFeatureForOrg bool `json:"disableFeatureForOrg"`
 }
 
@@ -3302,6 +3683,7 @@ func (v *DisableFeatureFlagForOrganizationResponse) GetDisableFeatureForOrg() bo
 // DisableFeatureFlagForUserResponse is returned by DisableFeatureFlagForUser on success.
 type DisableFeatureFlagForUserResponse struct {
 	// Disable a feature for a specific user.
+	// Stability: Short-term
 	DisableFeatureForUser bool `json:"disableFeatureForUser"`
 }
 
@@ -3313,6 +3695,7 @@ func (v *DisableFeatureFlagForUserResponse) GetDisableFeatureForUser() bool {
 // DisableFeatureFlagGloballyResponse is returned by DisableFeatureFlagGlobally on success.
 type DisableFeatureFlagGloballyResponse struct {
 	// Disable a feature.
+	// Stability: Short-term
 	DisableFeature bool `json:"disableFeature"`
 }
 
@@ -3322,6 +3705,7 @@ func (v *DisableFeatureFlagGloballyResponse) GetDisableFeature() bool { return v
 // DisableS3ArchivingResponse is returned by DisableS3Archiving on success.
 type DisableS3ArchivingResponse struct {
 	// Disables the archiving job for the repository.
+	// Stability: Short-term
 	S3DisableArchiving DisableS3ArchivingS3DisableArchivingBooleanResultType `json:"s3DisableArchiving"`
 }
 
@@ -3343,6 +3727,7 @@ func (v *DisableS3ArchivingS3DisableArchivingBooleanResultType) GetTypename() *s
 // EnableFeatureFlagForOrganizationResponse is returned by EnableFeatureFlagForOrganization on success.
 type EnableFeatureFlagForOrganizationResponse struct {
 	// Enable a feature for a specific organization.
+	// Stability: Short-term
 	EnableFeatureForOrg bool `json:"enableFeatureForOrg"`
 }
 
@@ -3354,6 +3739,7 @@ func (v *EnableFeatureFlagForOrganizationResponse) GetEnableFeatureForOrg() bool
 // EnableFeatureFlagForUserResponse is returned by EnableFeatureFlagForUser on success.
 type EnableFeatureFlagForUserResponse struct {
 	// Enable a feature for a specific user.
+	// Stability: Short-term
 	EnableFeatureForUser bool `json:"enableFeatureForUser"`
 }
 
@@ -3365,6 +3751,7 @@ func (v *EnableFeatureFlagForUserResponse) GetEnableFeatureForUser() bool {
 // EnableFeatureFlagGloballyResponse is returned by EnableFeatureFlagGlobally on success.
 type EnableFeatureFlagGloballyResponse struct {
 	// Enable a feature.
+	// Stability: Short-term
 	EnableFeature bool `json:"enableFeature"`
 }
 
@@ -3374,6 +3761,7 @@ func (v *EnableFeatureFlagGloballyResponse) GetEnableFeature() bool { return v.E
 // EnableS3ArchivingResponse is returned by EnableS3Archiving on success.
 type EnableS3ArchivingResponse struct {
 	// Enables the archiving job for the repository.
+	// Stability: Short-term
 	S3EnableArchiving EnableS3ArchivingS3EnableArchivingBooleanResultType `json:"s3EnableArchiving"`
 }
 
@@ -3396,86 +3784,193 @@ func (v *EnableS3ArchivingS3EnableArchivingBooleanResultType) GetTypename() *str
 type FeatureFlag string
 
 const (
-	// [PREVIEW: This functionality is still under development and can change without warning.] Export data to bucket storage.
+	// Export data to bucket storage.
+	// Stability: Preview
 	FeatureFlagExporttobucket FeatureFlag = "ExportToBucket"
-	// [PREVIEW: This functionality is still under development and can change without warning.] Enable repeating queries. Can be used instead of live queries for functions having limitations around live queries.
+	// Enable repeating queries. Can be used instead of live queries for functions having limitations around live queries.
+	// Stability: Preview
 	FeatureFlagRepeatingqueries FeatureFlag = "RepeatingQueries"
-	// [PREVIEW: This functionality is still under development and can change without warning.] Enable custom ingest tokens not generated by LogScale.
+	// Enable custom ingest tokens not generated by LogScale.
+	// Stability: Preview
 	FeatureFlagCustomingesttokens FeatureFlag = "CustomIngestTokens"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable permission tokens.
-	FeatureFlagPermissiontokens FeatureFlag = "PermissionTokens"
-	// [PREVIEW: This functionality is still under development and can change without warning.] Assign default roles for groups.
-	FeatureFlagDefaultrolesforgroups FeatureFlag = "DefaultRolesForGroups"
-	// [PREVIEW: This functionality is still under development and can change without warning.] Use new organization limits.
+	// Use new organization limits.
+	// Stability: Preview
 	FeatureFlagNeworganizationlimits FeatureFlag = "NewOrganizationLimits"
-	// [PREVIEW: This functionality is still under development and can change without warning.] Authenticate cookies server-side.
-	FeatureFlagCookieauthserverside FeatureFlag = "CookieAuthServerSide"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable ArrayFunctions in query language.
+	// Enable ArrayFunctions in query language.
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
 	FeatureFlagArrayfunctions FeatureFlag = "ArrayFunctions"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable geography functions in query language.
+	// Enable geography functions in query language.
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
 	FeatureFlagGeographyfunctions FeatureFlag = "GeographyFunctions"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Prioritize newer over older segments.
+	// Prioritize newer over older segments.
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
 	FeatureFlagCachepolicies FeatureFlag = "CachePolicies"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable searching across LogScale clusters.
+	// Enable searching across LogScale clusters.
+	// Stability: Preview
 	FeatureFlagMulticlustersearch FeatureFlag = "MultiClusterSearch"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable subdomains for current cluster.
+	// Enable subdomains for current cluster.
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
 	FeatureFlagSubdomainfororganizations FeatureFlag = "SubdomainForOrganizations"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable Humio Managed repositories. The customer is not permitted to change certain configurations in a LogScale Managed repository.
+	// Enable Humio Managed repositories. The customer is not permitted to change certain configurations in a LogScale Managed repository.
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
 	FeatureFlagManagedrepositories FeatureFlag = "ManagedRepositories"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Allow users to configure FDR feeds for managed repositories
+	// Allow users to configure FDR feeds for managed repositories
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
 	FeatureFlagManagedrepositoriesallowfdrconfig FeatureFlag = "ManagedRepositoriesAllowFDRConfig"
-	// [PREVIEW: This functionality is still under development and can change without warning.] The UsagePage shows data from ingestAfterFieldRemovalSize instead of segmentWriteBytes
+	// The UsagePage shows data from ingestAfterFieldRemovalSize instead of segmentWriteBytes
+	// Stability: Preview
 	FeatureFlagUsagepageusingingestafterfieldremovalsize FeatureFlag = "UsagePageUsingIngestAfterFieldRemovalSize"
-	// [PREVIEW: This functionality is still under development and can change without warning.] Enable falcon data connector
+	// Enable falcon data connector
+	// Stability: Preview
 	FeatureFlagFalcondataconnector FeatureFlag = "FalconDataConnector"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Flag for testing, does nothing
+	// Flag for testing, does nothing
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
 	FeatureFlagSleepfunction FeatureFlag = "SleepFunction"
-	// [PREVIEW: This functionality is still under development and can change without warning.] Enable login bridge
+	// Enable login bridge
+	// Stability: Preview
 	FeatureFlagLoginbridge FeatureFlag = "LoginBridge"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables download of macos installer for logcollector through fleet management
+	// Enables download of macos installer for logcollector through fleet management
+	// Stability: Preview
 	FeatureFlagMacosinstallerforlogcollector FeatureFlag = "MacosInstallerForLogCollector"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables UsageJob to log average usage as part of usage log
-	FeatureFlagLogaverageusage FeatureFlag = "LogAverageUsage"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables ephemeral hosts support for fleet management
+	// Enables ephemeral hosts support for fleet management
+	// Stability: Preview
 	FeatureFlagFleetephemeralhosts FeatureFlag = "FleetEphemeralHosts"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables fleet management collector metrics
+	// Prevents the archiving logic from splitting segments into multiple archived files based on their tag groups
+	// Stability: Preview
+	FeatureFlagDontsplitsegmentsforarchiving FeatureFlag = "DontSplitSegmentsForArchiving"
+	// Enables fleet management collector metrics
+	// Stability: Preview
 	FeatureFlagFleetcollectormetrics FeatureFlag = "FleetCollectorMetrics"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] No currentHosts writes for segments in buckets
+	// No currentHosts writes for segments in buckets
+	// Stability: Preview
 	FeatureFlagNocurrentsforbucketsegments FeatureFlag = "NoCurrentsForBucketSegments"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Pre-merge mini-segments
+	// Force a refresh of ClusterManagementStats cache before calculating UnregisterNodeBlockers in clusterUnregisterNode mutation
+	// Stability: Preview
+	FeatureFlagRefreshclustermanagementstatsinunregisternode FeatureFlag = "RefreshClusterManagementStatsInUnregisterNode"
+	// Pre-merge mini-segments
+	// Stability: Preview
 	FeatureFlagPremergeminisegments FeatureFlag = "PreMergeMiniSegments"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Use a new segment file format on write - not readable by older versions
+	// Use new store for Autosharding rules
+	// Stability: Preview
+	FeatureFlagNewautoshardrulestore FeatureFlag = "NewAutoshardRuleStore"
+	// Use a new segment file format on write - not readable by older versions
+	// Stability: Preview
 	FeatureFlagWritenewsegmentfileformat FeatureFlag = "WriteNewSegmentFileFormat"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables fleet management collector debug logging
+	// When using the new segment file format on write, also do the old solely for comparison
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
+	FeatureFlagMeasurenewsegmentfileformat FeatureFlag = "MeasureNewSegmentFileFormat"
+	// Enables fleet management collector debug logging
+	// Stability: Preview
 	FeatureFlagFleetcollectordebuglogging FeatureFlag = "FleetCollectorDebugLogging"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables LogScale Collector remote updates
+	// Resolve field names during codegen rather than for every event
+	// Stability: Preview
+	FeatureFlagResolvefieldscodegen FeatureFlag = "ResolveFieldsCodeGen"
+	// Enables LogScale Collector remote updates
+	// Stability: Preview
 	FeatureFlagFleetremoteupdates FeatureFlag = "FleetRemoteUpdates"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables alternate query merge target handling
+	// Enables alternate query merge target handling
+	// Stability: Preview
 	FeatureFlagAlternatequerymergetargethandling FeatureFlag = "AlternateQueryMergeTargetHandling"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables query optimizations for fleet management
-	FeatureFlagFleetusestaticqueries FeatureFlag = "FleetUseStaticQueries"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables labels for fleet management
+	// Allow digesters to start without having all the minis for the current merge target. Requires the AlternateQueryMergeTargetHandling feature flag to be enabled
+	// Stability: Preview
+	FeatureFlagDigestersdontneedmergetargetminis FeatureFlag = "DigestersDontNeedMergeTargetMinis"
+	// Enables labels for fleet management
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
 	FeatureFlagFleetlabels FeatureFlag = "FleetLabels"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables Field Aliasing
+	// Segment rebalancer handles mini segments. Can only take effect when the AlternateQueryMergeTargetHandling and DigestersDontNeedMergeTargetMinis feature flags are also enabled
+	// Stability: Preview
+	FeatureFlagSegmentrebalancerhandlesminis FeatureFlag = "SegmentRebalancerHandlesMinis"
+	// Enables dashboards on fleet overview page
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
+	FeatureFlagFleetoverviewdashboards FeatureFlag = "FleetOverviewDashboards"
+	// Enables archiving for Google Cloud Storage
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
+	FeatureFlagGooglecloudarchiving FeatureFlag = "GoogleCloudArchiving"
+	// Enables TablePage UI on fleet management pages.
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
+	FeatureFlagFleettablepageui FeatureFlag = "FleetTablePageUI"
+	// Disables periodic ingestOffset pushing for datasources in favor of alternate handling
+	// Stability: Preview
+	FeatureFlagReplaceperiodicingestoffsetpushing FeatureFlag = "ReplacePeriodicIngestOffsetPushing"
+	// Lets the cluster know that non-evicted nodes undergoing a graceful shutdown should be considered alive for 5 minutes with regards to segment rebalancing
+	// Stability: Preview
+	FeatureFlagSetconsideredaliveuntilongracefulshutdown FeatureFlag = "SetConsideredAliveUntilOnGracefulShutdown"
+	// Enables Field Aliasing
+	// Stability: Preview
 	FeatureFlagFieldaliasing FeatureFlag = "FieldAliasing"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] External Functions
+	// External Functions
+	// THIS FUNCTIONALITY IS RESTRICTED: Enabling this functionality should not be done in any production environment.
+	// Stability: Preview
 	FeatureFlagExternalfunctions FeatureFlag = "ExternalFunctions"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable the LogScale Query Assistant
+	// Enable the LogScale Query Assistant
+	// THIS FUNCTIONALITY IS RESTRICTED: Enabling this functionality should not be done in any production environment.
+	// Stability: Preview
 	FeatureFlagQueryassistant FeatureFlag = "QueryAssistant"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable Flight Control support in cluster
+	// Enable Flight Control support in cluster
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
 	FeatureFlagFlightcontrol FeatureFlag = "FlightControl"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable organization level security policies. For instance the ability to only enable certain action types.
-	FeatureFlagOrganizationsecuritypolicies FeatureFlag = "OrganizationSecurityPolicies"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables a limit on query backtracking
+	// Enables a limit on query backtracking
+	// Stability: Preview
 	FeatureFlagQuerybacktrackinglimit FeatureFlag = "QueryBacktrackingLimit"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Adds a derived #repo.cid tag when searching in views or dataspaces within an organization with an associated CID
+	// Adds a derived #repo.cid tag when searching in views or dataspaces within an organization with an associated CID
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
 	FeatureFlagDerivedcidtag FeatureFlag = "DerivedCidTag"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Live tables
+	// Live tables
+	// Stability: Preview
 	FeatureFlagLivetables FeatureFlag = "LiveTables"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables the MITRE Detection Annotation function
+	// Enables graph queries
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
+	FeatureFlagGraphqueries FeatureFlag = "GraphQueries"
+	// Enables the MITRE Detection Annotation function
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
 	FeatureFlagMitredetectionannotation FeatureFlag = "MitreDetectionAnnotation"
-	// [PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables having multiple role bindings for a single view in the same group. This feature flag does nothing until min version is at least 1.150.0
+	// Enables having multiple role bindings for a single view in the same group. This feature can only be enabled when min version is at least 1.150.0
+	// Stability: Preview
 	FeatureFlagMultipleviewrolebindings FeatureFlag = "MultipleViewRoleBindings"
+	// When enabled, queries exceeding the AggregatorOutputRowLimit will get cancelled. When disabled, queries will continue to run, but a log is produced whenever the limit is exceeded.
+	// Stability: Preview
+	FeatureFlagCancelqueriesexceedingaggregateoutputrowlimit FeatureFlag = "CancelQueriesExceedingAggregateOutputRowLimit"
+	// Enables mapping one group to more than one LogScale group with the same lookup name during group synchronization.
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
+	FeatureFlagOnetomanygroupsynchronization FeatureFlag = "OneToManyGroupSynchronization"
+	// Enables support specifying the query time interval using the query function setTimeInterval()
+	// Stability: Preview
+	FeatureFlagTimeintervalinquery FeatureFlag = "TimeIntervalInQuery"
+	// Enables LLM parser generation
+	// THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+	// Stability: Preview
+	FeatureFlagLlmparsergeneration FeatureFlag = "LlmParserGeneration"
+	// Enables the external data source sync job to sync entity data
+	// THIS FUNCTIONALITY IS RESTRICTED: Enabling this functionality should not be done in any production environment.
+	// Stability: Preview
+	FeatureFlagExternaldatasourcesyncforentity FeatureFlag = "ExternalDataSourceSyncForEntity"
+	// Enables the external data source sync job to sync identity data
+	// THIS FUNCTIONALITY IS RESTRICTED: Enabling this functionality should not be done in any production environment.
+	// Stability: Preview
+	FeatureFlagExternaldatasourcesyncforidentity FeatureFlag = "ExternalDataSourceSyncForIdentity"
+	// Use the new query coordination partition logic.
+	// Stability: Preview
+	FeatureFlagUsenewquerycoordinationpartitions FeatureFlag = "UseNewQueryCoordinationPartitions"
+	// Use the new sort, head, tail, and table datastructure
+	// Stability: Preview
+	FeatureFlagSortnewdatastructure FeatureFlag = "SortNewDatastructure"
 )
 
 // Asserts that a given field has an expected value after having been parsed.
@@ -3498,24 +3993,34 @@ func (v *FieldHasValueInput) GetExpectedValue() string { return v.ExpectedValue 
 // A filter alert.
 type FilterAlertDetails struct {
 	// Id of the filter alert.
+	// Stability: Long-term
 	Id string `json:"id"`
 	// Name of the filter alert.
+	// Stability: Long-term
 	Name string `json:"name"`
 	// Description of the filter alert.
+	// Stability: Long-term
 	Description *string `json:"description"`
 	// LogScale query to execute.
+	// Stability: Long-term
 	QueryString string `json:"queryString"`
 	// Throttle time in seconds.
+	// Stability: Long-term
 	ThrottleTimeSeconds *int64 `json:"throttleTimeSeconds"`
 	// A field to throttle on. Can only be set if throttleTimeSeconds is set.
+	// Stability: Long-term
 	ThrottleField *string `json:"throttleField"`
 	// List of ids for actions to fire on query result.
+	// Stability: Long-term
 	Actions []FilterAlertDetailsActionsAction `json:"-"`
 	// Labels attached to the filter alert.
+	// Stability: Long-term
 	Labels []string `json:"labels"`
 	// Flag indicating whether the filter alert is enabled.
+	// Stability: Long-term
 	Enabled bool `json:"enabled"`
 	// Ownership of the query run by this alert
+	// Stability: Long-term
 	QueryOwnership SharedQueryOwnershipType `json:"-"`
 }
 
@@ -4001,6 +4506,7 @@ func (v *FilterAlertDetailsActionsWebhookAction) GetName() string { return v.Nam
 
 // GetActionByIDResponse is returned by GetActionByID on success.
 type GetActionByIDResponse struct {
+	// Stability: Long-term
 	SearchDomain GetActionByIDSearchDomain `json:"-"`
 }
 
@@ -5410,6 +5916,7 @@ func (v *GetActionByIDSearchDomainView) __premarshalJSON() (*__premarshalGetActi
 
 // GetAggregateAlertByIDResponse is returned by GetAggregateAlertByID on success.
 type GetAggregateAlertByIDResponse struct {
+	// Stability: Long-term
 	SearchDomain GetAggregateAlertByIDSearchDomain `json:"-"`
 }
 
@@ -5784,17 +6291,27 @@ func (v *GetAggregateAlertByIDSearchDomainView) GetAggregateAlert() GetAggregate
 //
 // Information about the LogScale cluster.
 type GetClusterCluster struct {
-	ClusterNode                         `json:"-"`
-	ClusterInfoAgeSeconds               float64                                            `json:"clusterInfoAgeSeconds"`
-	UnderReplicatedSegmentSize          float64                                            `json:"underReplicatedSegmentSize"`
-	OverReplicatedSegmentSize           float64                                            `json:"overReplicatedSegmentSize"`
-	MissingSegmentSize                  float64                                            `json:"missingSegmentSize"`
-	ProperlyReplicatedSegmentSize       float64                                            `json:"properlyReplicatedSegmentSize"`
-	TargetUnderReplicatedSegmentSize    float64                                            `json:"targetUnderReplicatedSegmentSize"`
-	TargetOverReplicatedSegmentSize     float64                                            `json:"targetOverReplicatedSegmentSize"`
-	TargetMissingSegmentSize            float64                                            `json:"targetMissingSegmentSize"`
-	TargetProperlyReplicatedSegmentSize float64                                            `json:"targetProperlyReplicatedSegmentSize"`
-	IngestPartitions                    []GetClusterClusterIngestPartitionsIngestPartition `json:"ingestPartitions"`
+	ClusterNode `json:"-"`
+	// Stability: Long-term
+	ClusterInfoAgeSeconds float64 `json:"clusterInfoAgeSeconds"`
+	// Stability: Long-term
+	UnderReplicatedSegmentSize float64 `json:"underReplicatedSegmentSize"`
+	// Stability: Long-term
+	OverReplicatedSegmentSize float64 `json:"overReplicatedSegmentSize"`
+	// Stability: Long-term
+	MissingSegmentSize float64 `json:"missingSegmentSize"`
+	// Stability: Long-term
+	ProperlyReplicatedSegmentSize float64 `json:"properlyReplicatedSegmentSize"`
+	// Stability: Long-term
+	TargetUnderReplicatedSegmentSize float64 `json:"targetUnderReplicatedSegmentSize"`
+	// Stability: Long-term
+	TargetOverReplicatedSegmentSize float64 `json:"targetOverReplicatedSegmentSize"`
+	// Stability: Long-term
+	TargetMissingSegmentSize float64 `json:"targetMissingSegmentSize"`
+	// Stability: Long-term
+	TargetProperlyReplicatedSegmentSize float64 `json:"targetProperlyReplicatedSegmentSize"`
+	// Stability: Long-term
+	IngestPartitions []GetClusterClusterIngestPartitionsIngestPartition `json:"ingestPartitions"`
 }
 
 // GetClusterInfoAgeSeconds returns GetClusterCluster.ClusterInfoAgeSeconds, and is useful for accessing the field via an interface.
@@ -5923,8 +6440,10 @@ func (v *GetClusterCluster) __premarshalJSON() (*__premarshalGetClusterCluster, 
 //
 // A cluster ingest partition. It assigns cluster nodes with the responsibility of ingesting data.
 type GetClusterClusterIngestPartitionsIngestPartition struct {
+	// Stability: Long-term
 	Id int `json:"id"`
 	// The ids of the node responsible executing real-time queries for the partition and writing events to time series. The list is ordered so that the first node is the primary node and the rest are followers ready to take over if the primary fails.
+	// Stability: Long-term
 	NodeIds []int `json:"nodeIds"`
 }
 
@@ -5937,6 +6456,7 @@ func (v *GetClusterClusterIngestPartitionsIngestPartition) GetNodeIds() []int { 
 // GetClusterResponse is returned by GetCluster on success.
 type GetClusterResponse struct {
 	// This is used to retrieve information about a cluster.
+	// Stability: Long-term
 	Cluster GetClusterCluster `json:"cluster"`
 }
 
@@ -5945,6 +6465,7 @@ func (v *GetClusterResponse) GetCluster() GetClusterCluster { return v.Cluster }
 
 // GetFilterAlertByIDResponse is returned by GetFilterAlertByID on success.
 type GetFilterAlertByIDResponse struct {
+	// Stability: Long-term
 	SearchDomain GetFilterAlertByIDSearchDomain `json:"-"`
 }
 
@@ -6385,10 +6906,13 @@ type GetLicenseInstalledLicenseOnPremLicense struct {
 	// Represents information about the LogScale instance.
 	IssuedAt time.Time `json:"issuedAt"`
 	// license id.
+	// Stability: Long-term
 	Uid string `json:"uid"`
 	// The name of the entity the license was issued to.
+	// Stability: Long-term
 	Owner string `json:"owner"`
 	// The maximum number of user accounts allowed in LogScale. Unlimited if undefined.
+	// Stability: Long-term
 	MaxUsers *int `json:"maxUsers"`
 }
 
@@ -6434,6 +6958,7 @@ func (v *GetLicenseInstalledLicenseTrialLicense) GetIssuedAt() time.Time { retur
 // GetLicenseResponse is returned by GetLicense on success.
 type GetLicenseResponse struct {
 	// This returns information about the license for the LogScale instance, if any license installed.
+	// Stability: Long-term
 	InstalledLicense *GetLicenseInstalledLicense `json:"-"`
 }
 
@@ -6514,6 +7039,7 @@ func (v *GetLicenseResponse) __premarshalJSON() (*__premarshalGetLicenseResponse
 // A repository stores ingested data, configures parsers and data retention policies.
 type GetParserByIDRepository struct {
 	// A parser on the repository.
+	// Stability: Long-term
 	Parser *GetParserByIDRepositoryParser `json:"parser"`
 }
 
@@ -6630,6 +7156,7 @@ func (v *GetParserByIDRepositoryParser) __premarshalJSON() (*__premarshalGetPars
 // GetParserByIDResponse is returned by GetParserByID on success.
 type GetParserByIDResponse struct {
 	// Lookup a given repository by name.
+	// Stability: Long-term
 	Repository GetParserByIDRepository `json:"repository"`
 }
 
@@ -6642,6 +7169,7 @@ func (v *GetParserByIDResponse) GetRepository() GetParserByIDRepository { return
 // A repository stores ingested data, configures parsers and data retention policies.
 type GetParserYAMLByNameRepository struct {
 	// A parser on the repository.
+	// Stability: Long-term
 	Parser *GetParserYAMLByNameRepositoryParser `json:"parser"`
 }
 
@@ -6656,8 +7184,10 @@ func (v *GetParserYAMLByNameRepository) GetParser() *GetParserYAMLByNameReposito
 // A configured parser for incoming data.
 type GetParserYAMLByNameRepositoryParser struct {
 	// Name of the parser.
+	// Stability: Long-term
 	Name string `json:"name"`
 	// A template that can be used to recreate the parser.
+	// Stability: Long-term
 	YamlTemplate string `json:"yamlTemplate"`
 }
 
@@ -6670,6 +7200,7 @@ func (v *GetParserYAMLByNameRepositoryParser) GetYamlTemplate() string { return 
 // GetParserYAMLByNameResponse is returned by GetParserYAMLByName on success.
 type GetParserYAMLByNameResponse struct {
 	// Lookup a given repository by name.
+	// Stability: Long-term
 	Repository GetParserYAMLByNameRepository `json:"repository"`
 }
 
@@ -6796,6 +7327,7 @@ func (v *GetRepositoryRepository) __premarshalJSON() (*__premarshalGetRepository
 // GetRepositoryResponse is returned by GetRepository on success.
 type GetRepositoryResponse struct {
 	// Lookup a given repository by name.
+	// Stability: Long-term
 	Repository GetRepositoryRepository `json:"repository"`
 }
 
@@ -6805,6 +7337,7 @@ func (v *GetRepositoryResponse) GetRepository() GetRepositoryRepository { return
 // GetRoleByIDResponse is returned by GetRoleByID on success.
 type GetRoleByIDResponse struct {
 	// A given role.
+	// Stability: Long-term
 	Role GetRoleByIDRole `json:"role"`
 }
 
@@ -6893,6 +7426,7 @@ func (v *GetRoleByIDRole) __premarshalJSON() (*__premarshalGetRoleByIDRole, erro
 
 // GetSearchDomainResponse is returned by GetSearchDomain on success.
 type GetSearchDomainResponse struct {
+	// Stability: Long-term
 	SearchDomain GetSearchDomainSearchDomain `json:"-"`
 }
 
@@ -7102,9 +7636,10 @@ type GetSearchDomainSearchDomainView struct {
 	// Common interface for Repositories and Views.
 	Description *string `json:"description"`
 	// Common interface for Repositories and Views.
-	AutomaticSearch bool                                                       `json:"automaticSearch"`
-	Connections     []GetSearchDomainSearchDomainViewConnectionsViewConnection `json:"connections"`
-	Typename        *string                                                    `json:"__typename"`
+	AutomaticSearch bool `json:"automaticSearch"`
+	// Stability: Long-term
+	Connections []GetSearchDomainSearchDomainViewConnectionsViewConnection `json:"connections"`
+	Typename    *string                                                    `json:"__typename"`
 }
 
 // GetId returns GetSearchDomainSearchDomainView.Id, and is useful for accessing the field via an interface.
@@ -7133,8 +7668,10 @@ func (v *GetSearchDomainSearchDomainView) GetTypename() *string { return v.Typen
 // Represents the connection between a view and an underlying repository.
 type GetSearchDomainSearchDomainViewConnectionsViewConnection struct {
 	// The underlying repository
+	// Stability: Long-term
 	Repository GetSearchDomainSearchDomainViewConnectionsViewConnectionRepository `json:"repository"`
 	// The filter applied to all results from the repository.
+	// Stability: Long-term
 	Filter string `json:"filter"`
 }
 
@@ -7153,6 +7690,7 @@ func (v *GetSearchDomainSearchDomainViewConnectionsViewConnection) GetFilter() s
 //
 // A repository stores ingested data, configures parsers and data retention policies.
 type GetSearchDomainSearchDomainViewConnectionsViewConnectionRepository struct {
+	// Stability: Long-term
 	Name string `json:"name"`
 }
 
@@ -7166,9 +7704,12 @@ func (v *GetSearchDomainSearchDomainViewConnectionsViewConnectionRepository) Get
 //
 // Feature flags with details
 type GetSupportedFeatureFlagsFeatureFlagsFeatureFlagV2 struct {
-	Flag         FeatureFlag `json:"flag"`
-	Experimental bool        `json:"experimental"`
-	Description  string      `json:"description"`
+	// Stability: Preview
+	Flag FeatureFlag `json:"flag"`
+	// Stability: Preview
+	Experimental bool `json:"experimental"`
+	// Stability: Preview
+	Description string `json:"description"`
 }
 
 // GetFlag returns GetSupportedFeatureFlagsFeatureFlagsFeatureFlagV2.Flag, and is useful for accessing the field via an interface.
@@ -7186,7 +7727,8 @@ func (v *GetSupportedFeatureFlagsFeatureFlagsFeatureFlagV2) GetDescription() str
 
 // GetSupportedFeatureFlagsResponse is returned by GetSupportedFeatureFlags on success.
 type GetSupportedFeatureFlagsResponse struct {
-	// [PREVIEW: All flags should be considered as beta features. Enabling features that are marked as experimental is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] List feature flags depending on filters and context
+	// List feature flags depending on filters and context
+	// Stability: Preview
 	FeatureFlags []GetSupportedFeatureFlagsFeatureFlagsFeatureFlagV2 `json:"featureFlags"`
 }
 
@@ -7198,6 +7740,7 @@ func (v *GetSupportedFeatureFlagsResponse) GetFeatureFlags() []GetSupportedFeatu
 // GetUsernameResponse is returned by GetUsername on success.
 type GetUsernameResponse struct {
 	// The currently authenticated user's account.
+	// Stability: Long-term
 	Viewer GetUsernameViewerAccount `json:"viewer"`
 }
 
@@ -7209,6 +7752,7 @@ func (v *GetUsernameResponse) GetViewer() GetUsernameViewerAccount { return v.Vi
 //
 // A user account.
 type GetUsernameViewerAccount struct {
+	// Stability: Long-term
 	Username string `json:"username"`
 }
 
@@ -7218,6 +7762,7 @@ func (v *GetUsernameViewerAccount) GetUsername() string { return v.Username }
 // GetUsersByUsernameResponse is returned by GetUsersByUsername on success.
 type GetUsersByUsernameResponse struct {
 	// Requires manage cluster permission; Returns all users in the system.
+	// Stability: Long-term
 	Users []GetUsersByUsernameUsersUser `json:"users"`
 }
 
@@ -7346,8 +7891,11 @@ func (v *HttpHeaderEntryInput) GetValue() string { return v.Value }
 //
 // An API ingest token used for sending data to LogScale.
 type IngestTokenDetails struct {
-	Name   string                    `json:"name"`
-	Token  string                    `json:"token"`
+	// Stability: Long-term
+	Name string `json:"name"`
+	// Stability: Long-term
+	Token string `json:"token"`
+	// Stability: Long-term
 	Parser *IngestTokenDetailsParser `json:"parser"`
 }
 
@@ -7366,6 +7914,7 @@ func (v *IngestTokenDetails) GetParser() *IngestTokenDetailsParser { return v.Pa
 // A configured parser for incoming data.
 type IngestTokenDetailsParser struct {
 	// Name of the parser.
+	// Stability: Long-term
 	Name string `json:"name"`
 }
 
@@ -7385,6 +7934,7 @@ const (
 
 // LegacyCreateParserCreateParserCreateParserMutation includes the requested fields of the GraphQL type CreateParserMutation.
 type LegacyCreateParserCreateParserCreateParserMutation struct {
+	// Stability: Long-term
 	Parser LegacyCreateParserCreateParserCreateParserMutationParser `json:"parser"`
 }
 
@@ -7552,6 +8102,7 @@ func (v *LegacyDeleteParserByIDResponse) GetRemoveParser() LegacyDeleteParserByI
 // A repository stores ingested data, configures parsers and data retention policies.
 type LegacyGetParserRepository struct {
 	// A parser on the repository.
+	// Stability: Long-term
 	Parser *LegacyGetParserRepositoryParser `json:"parser"`
 }
 
@@ -7564,8 +8115,10 @@ func (v *LegacyGetParserRepository) GetParser() *LegacyGetParserRepositoryParser
 // A configured parser for incoming data.
 type LegacyGetParserRepositoryParser struct {
 	// The id of the parser.
+	// Stability: Long-term
 	Id string `json:"id"`
 	// Name of the parser.
+	// Stability: Long-term
 	Name string `json:"name"`
 	// The source code of the parser.
 	SourceCode string `json:"sourceCode"`
@@ -7593,6 +8146,7 @@ func (v *LegacyGetParserRepositoryParser) GetTagFields() []string { return v.Tag
 // LegacyGetParserResponse is returned by LegacyGetParser on success.
 type LegacyGetParserResponse struct {
 	// Lookup a given repository by name.
+	// Stability: Long-term
 	Repository LegacyGetParserRepository `json:"repository"`
 }
 
@@ -7601,6 +8155,7 @@ func (v *LegacyGetParserResponse) GetRepository() LegacyGetParserRepository { re
 
 // ListActionsResponse is returned by ListActions on success.
 type ListActionsResponse struct {
+	// Stability: Long-term
 	SearchDomain ListActionsSearchDomain `json:"-"`
 }
 
@@ -9036,6 +9591,7 @@ func (v *ListActionsSearchDomainView) __premarshalJSON() (*__premarshalListActio
 
 // ListAggregateAlertsResponse is returned by ListAggregateAlerts on success.
 type ListAggregateAlertsResponse struct {
+	// Stability: Long-term
 	SearchDomain ListAggregateAlertsSearchDomain `json:"-"`
 }
 
@@ -9407,6 +9963,7 @@ func (v *ListAggregateAlertsSearchDomainView) GetAggregateAlerts() []ListAggrega
 
 // ListAlertsResponse is returned by ListAlerts on success.
 type ListAlertsResponse struct {
+	// Stability: Long-term
 	SearchDomain ListAlertsSearchDomain `json:"-"`
 }
 
@@ -9805,6 +10362,7 @@ func (v *ListClusterNodesCluster) __premarshalJSON() (*__premarshalListClusterNo
 // ListClusterNodesResponse is returned by ListClusterNodes on success.
 type ListClusterNodesResponse struct {
 	// This is used to retrieve information about a cluster.
+	// Stability: Long-term
 	Cluster ListClusterNodesCluster `json:"cluster"`
 }
 
@@ -9813,6 +10371,7 @@ func (v *ListClusterNodesResponse) GetCluster() ListClusterNodesCluster { return
 
 // ListFilesResponse is returned by ListFiles on success.
 type ListFilesResponse struct {
+	// Stability: Long-term
 	SearchDomain ListFilesSearchDomain `json:"-"`
 }
 
@@ -9966,7 +10525,9 @@ func __marshalListFilesSearchDomain(v *ListFilesSearchDomain) ([]byte, error) {
 //
 // A file upload to LogScale for use with the `match` query function. You can see them under the Files page in the UI.
 type ListFilesSearchDomainFilesFile struct {
-	ContentHash string                                    `json:"contentHash"`
+	// Stability: Long-term
+	ContentHash string `json:"contentHash"`
+	// Stability: Long-term
 	NameAndPath ListFilesSearchDomainFilesFileNameAndPath `json:"nameAndPath"`
 }
 
@@ -9980,6 +10541,7 @@ func (v *ListFilesSearchDomainFilesFile) GetNameAndPath() ListFilesSearchDomainF
 
 // ListFilesSearchDomainFilesFileNameAndPath includes the requested fields of the GraphQL type FileNameAndPath.
 type ListFilesSearchDomainFilesFileNameAndPath struct {
+	// Stability: Long-term
 	Name string `json:"name"`
 }
 
@@ -10020,6 +10582,7 @@ func (v *ListFilesSearchDomainView) GetFiles() []ListFilesSearchDomainFilesFile 
 
 // ListFilterAlertsResponse is returned by ListFilterAlerts on success.
 type ListFilterAlertsResponse struct {
+	// Stability: Long-term
 	SearchDomain ListFilterAlertsSearchDomain `json:"-"`
 }
 
@@ -10369,6 +10932,7 @@ func (v *ListFilterAlertsSearchDomainView) GetFilterAlerts() []ListFilterAlertsS
 //
 // A page of groups in an organization.
 type ListGroupsGroupsPageGroupPage struct {
+	// Stability: Long-term
 	Page []ListGroupsGroupsPageGroupPagePageGroup `json:"page"`
 }
 
@@ -10382,7 +10946,9 @@ func (v *ListGroupsGroupsPageGroupPage) GetPage() []ListGroupsGroupsPageGroupPag
 //
 // A group.
 type ListGroupsGroupsPageGroupPagePageGroup struct {
-	Id          string `json:"id"`
+	// Stability: Long-term
+	Id string `json:"id"`
+	// Stability: Long-term
 	DisplayName string `json:"displayName"`
 }
 
@@ -10395,6 +10961,7 @@ func (v *ListGroupsGroupsPageGroupPagePageGroup) GetDisplayName() string { retur
 // ListGroupsResponse is returned by ListGroups on success.
 type ListGroupsResponse struct {
 	// All defined groups in an organization.
+	// Stability: Long-term
 	GroupsPage ListGroupsGroupsPageGroupPage `json:"groupsPage"`
 }
 
@@ -10406,6 +10973,7 @@ func (v *ListGroupsResponse) GetGroupsPage() ListGroupsGroupsPageGroupPage { ret
 //
 // A repository stores ingested data, configures parsers and data retention policies.
 type ListIngestTokensRepository struct {
+	// Stability: Long-term
 	IngestTokens []ListIngestTokensRepositoryIngestTokensIngestToken `json:"ingestTokens"`
 }
 
@@ -10490,6 +11058,7 @@ func (v *ListIngestTokensRepositoryIngestTokensIngestToken) __premarshalJSON() (
 // ListIngestTokensResponse is returned by ListIngestTokens on success.
 type ListIngestTokensResponse struct {
 	// Lookup a given repository by name.
+	// Stability: Long-term
 	Repository ListIngestTokensRepository `json:"repository"`
 }
 
@@ -10498,6 +11067,7 @@ func (v *ListIngestTokensResponse) GetRepository() ListIngestTokensRepository { 
 
 // ListInstalledPackagesResponse is returned by ListInstalledPackages on success.
 type ListInstalledPackagesResponse struct {
+	// Stability: Long-term
 	SearchDomain ListInstalledPackagesSearchDomain `json:"-"`
 }
 
@@ -10655,11 +11225,16 @@ func __marshalListInstalledPackagesSearchDomain(v *ListInstalledPackagesSearchDo
 //
 // A package installation.
 type ListInstalledPackagesSearchDomainInstalledPackagesPackageInstallation struct {
-	Id          string                                                                                           `json:"id"`
+	// Stability: Long-term
+	Id string `json:"id"`
+	// Stability: Long-term
 	InstalledBy ListInstalledPackagesSearchDomainInstalledPackagesPackageInstallationInstalledByUserAndTimestamp `json:"installedBy"`
-	UpdatedBy   ListInstalledPackagesSearchDomainInstalledPackagesPackageInstallationUpdatedByUserAndTimestamp   `json:"updatedBy"`
-	Source      PackageInstallationSourceType                                                                    `json:"source"`
+	// Stability: Long-term
+	UpdatedBy ListInstalledPackagesSearchDomainInstalledPackagesPackageInstallationUpdatedByUserAndTimestamp `json:"updatedBy"`
+	// Stability: Long-term
+	Source PackageInstallationSourceType `json:"source"`
 	// Finds updates on a package. It also looks for updates on packages that were installed manually, in case e.g. test versions of a package have been distributed prior to the full release.
+	// Stability: Long-term
 	AvailableUpdate *string `json:"availableUpdate"`
 }
 
@@ -10690,7 +11265,9 @@ func (v *ListInstalledPackagesSearchDomainInstalledPackagesPackageInstallation) 
 
 // ListInstalledPackagesSearchDomainInstalledPackagesPackageInstallationInstalledByUserAndTimestamp includes the requested fields of the GraphQL type UserAndTimestamp.
 type ListInstalledPackagesSearchDomainInstalledPackagesPackageInstallationInstalledByUserAndTimestamp struct {
-	Username  string    `json:"username"`
+	// Stability: Long-term
+	Username string `json:"username"`
+	// Stability: Long-term
 	Timestamp time.Time `json:"timestamp"`
 }
 
@@ -10706,7 +11283,9 @@ func (v *ListInstalledPackagesSearchDomainInstalledPackagesPackageInstallationIn
 
 // ListInstalledPackagesSearchDomainInstalledPackagesPackageInstallationUpdatedByUserAndTimestamp includes the requested fields of the GraphQL type UserAndTimestamp.
 type ListInstalledPackagesSearchDomainInstalledPackagesPackageInstallationUpdatedByUserAndTimestamp struct {
-	Username  string    `json:"username"`
+	// Stability: Long-term
+	Username string `json:"username"`
+	// Stability: Long-term
 	Timestamp time.Time `json:"timestamp"`
 }
 
@@ -10762,6 +11341,7 @@ func (v *ListInstalledPackagesSearchDomainView) GetInstalledPackages() []ListIns
 // A repository stores ingested data, configures parsers and data retention policies.
 type ListParsersRepository struct {
 	// Saved parsers.
+	// Stability: Long-term
 	Parsers []ListParsersRepositoryParsersParser `json:"parsers"`
 }
 
@@ -10774,10 +11354,13 @@ func (v *ListParsersRepository) GetParsers() []ListParsersRepositoryParsersParse
 // A configured parser for incoming data.
 type ListParsersRepositoryParsersParser struct {
 	// The id of the parser.
+	// Stability: Long-term
 	Id string `json:"id"`
 	// Name of the parser.
+	// Stability: Long-term
 	Name string `json:"name"`
 	// True if the parser is one of LogScale's built-in parsers.
+	// Stability: Long-term
 	IsBuiltIn bool `json:"isBuiltIn"`
 }
 
@@ -10793,6 +11376,7 @@ func (v *ListParsersRepositoryParsersParser) GetIsBuiltIn() bool { return v.IsBu
 // ListParsersResponse is returned by ListParsers on success.
 type ListParsersResponse struct {
 	// Lookup a given repository by name.
+	// Stability: Long-term
 	Repository ListParsersRepository `json:"repository"`
 }
 
@@ -10804,9 +11388,12 @@ func (v *ListParsersResponse) GetRepository() ListParsersRepository { return v.R
 //
 // A repository stores ingested data, configures parsers and data retention policies.
 type ListRepositoriesRepositoriesRepository struct {
-	Id   string `json:"id"`
+	// Stability: Long-term
+	Id string `json:"id"`
+	// Stability: Long-term
 	Name string `json:"name"`
 	// Total size of data. Size is measured as the size after compression.
+	// Stability: Long-term
 	CompressedByteSize int64 `json:"compressedByteSize"`
 }
 
@@ -10823,6 +11410,7 @@ func (v *ListRepositoriesRepositoriesRepository) GetCompressedByteSize() int64 {
 
 // ListRepositoriesResponse is returned by ListRepositories on success.
 type ListRepositoriesResponse struct {
+	// Stability: Long-term
 	Repositories []ListRepositoriesRepositoriesRepository `json:"repositories"`
 }
 
@@ -10834,6 +11422,7 @@ func (v *ListRepositoriesResponse) GetRepositories() []ListRepositoriesRepositor
 // ListRolesResponse is returned by ListRoles on success.
 type ListRolesResponse struct {
 	// All defined roles.
+	// Stability: Long-term
 	Roles []ListRolesRolesRole `json:"roles"`
 }
 
@@ -10922,6 +11511,7 @@ func (v *ListRolesRolesRole) __premarshalJSON() (*__premarshalListRolesRolesRole
 
 // ListScheduledSearchesResponse is returned by ListScheduledSearches on success.
 type ListScheduledSearchesResponse struct {
+	// Stability: Long-term
 	SearchDomain ListScheduledSearchesSearchDomain `json:"-"`
 }
 
@@ -11291,8 +11881,397 @@ func (v *ListScheduledSearchesSearchDomainView) GetScheduledSearches() []ListSch
 	return v.ScheduledSearches
 }
 
+// ListScheduledSearchesV2Response is returned by ListScheduledSearchesV2 on success.
+type ListScheduledSearchesV2Response struct {
+	// Stability: Long-term
+	SearchDomain ListScheduledSearchesV2SearchDomain `json:"-"`
+}
+
+// GetSearchDomain returns ListScheduledSearchesV2Response.SearchDomain, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2Response) GetSearchDomain() ListScheduledSearchesV2SearchDomain {
+	return v.SearchDomain
+}
+
+func (v *ListScheduledSearchesV2Response) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*ListScheduledSearchesV2Response
+		SearchDomain json.RawMessage `json:"searchDomain"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.ListScheduledSearchesV2Response = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.SearchDomain
+		src := firstPass.SearchDomain
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalListScheduledSearchesV2SearchDomain(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal ListScheduledSearchesV2Response.SearchDomain: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalListScheduledSearchesV2Response struct {
+	SearchDomain json.RawMessage `json:"searchDomain"`
+}
+
+func (v *ListScheduledSearchesV2Response) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *ListScheduledSearchesV2Response) __premarshalJSON() (*__premarshalListScheduledSearchesV2Response, error) {
+	var retval __premarshalListScheduledSearchesV2Response
+
+	{
+
+		dst := &retval.SearchDomain
+		src := v.SearchDomain
+		var err error
+		*dst, err = __marshalListScheduledSearchesV2SearchDomain(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal ListScheduledSearchesV2Response.SearchDomain: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
+// ListScheduledSearchesV2SearchDomain includes the requested fields of the GraphQL interface SearchDomain.
+//
+// ListScheduledSearchesV2SearchDomain is implemented by the following types:
+// ListScheduledSearchesV2SearchDomainRepository
+// ListScheduledSearchesV2SearchDomainView
+// The GraphQL type's documentation follows.
+//
+// Common interface for Repositories and Views.
+type ListScheduledSearchesV2SearchDomain interface {
+	implementsGraphQLInterfaceListScheduledSearchesV2SearchDomain()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+	// GetScheduledSearches returns the interface-field "scheduledSearches" from its implementation.
+	// The GraphQL interface field's documentation follows.
+	//
+	// Common interface for Repositories and Views.
+	GetScheduledSearches() []ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch
+}
+
+func (v *ListScheduledSearchesV2SearchDomainRepository) implementsGraphQLInterfaceListScheduledSearchesV2SearchDomain() {
+}
+func (v *ListScheduledSearchesV2SearchDomainView) implementsGraphQLInterfaceListScheduledSearchesV2SearchDomain() {
+}
+
+func __unmarshalListScheduledSearchesV2SearchDomain(b []byte, v *ListScheduledSearchesV2SearchDomain) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "Repository":
+		*v = new(ListScheduledSearchesV2SearchDomainRepository)
+		return json.Unmarshal(b, *v)
+	case "View":
+		*v = new(ListScheduledSearchesV2SearchDomainView)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing SearchDomain.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for ListScheduledSearchesV2SearchDomain: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalListScheduledSearchesV2SearchDomain(v *ListScheduledSearchesV2SearchDomain) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *ListScheduledSearchesV2SearchDomainRepository:
+		typename = "Repository"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ListScheduledSearchesV2SearchDomainRepository
+		}{typename, v}
+		return json.Marshal(result)
+	case *ListScheduledSearchesV2SearchDomainView:
+		typename = "View"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ListScheduledSearchesV2SearchDomainView
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for ListScheduledSearchesV2SearchDomain: "%T"`, v)
+	}
+}
+
+// ListScheduledSearchesV2SearchDomainRepository includes the requested fields of the GraphQL type Repository.
+// The GraphQL type's documentation follows.
+//
+// A repository stores ingested data, configures parsers and data retention policies.
+type ListScheduledSearchesV2SearchDomainRepository struct {
+	Typename *string `json:"__typename"`
+	// Common interface for Repositories and Views.
+	ScheduledSearches []ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch `json:"scheduledSearches"`
+}
+
+// GetTypename returns ListScheduledSearchesV2SearchDomainRepository.Typename, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainRepository) GetTypename() *string { return v.Typename }
+
+// GetScheduledSearches returns ListScheduledSearchesV2SearchDomainRepository.ScheduledSearches, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainRepository) GetScheduledSearches() []ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch {
+	return v.ScheduledSearches
+}
+
+// ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch includes the requested fields of the GraphQL type ScheduledSearch.
+// The GraphQL type's documentation follows.
+//
+// Information about a scheduled search
+type ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch struct {
+	ScheduledSearchV2Details `json:"-"`
+}
+
+// GetId returns ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch.Id, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) GetId() string {
+	return v.ScheduledSearchV2Details.Id
+}
+
+// GetName returns ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch.Name, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) GetName() string {
+	return v.ScheduledSearchV2Details.Name
+}
+
+// GetDescription returns ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch.Description, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) GetDescription() *string {
+	return v.ScheduledSearchV2Details.Description
+}
+
+// GetQueryString returns ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch.QueryString, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) GetQueryString() string {
+	return v.ScheduledSearchV2Details.QueryString
+}
+
+// GetSearchIntervalSeconds returns ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch.SearchIntervalSeconds, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) GetSearchIntervalSeconds() int64 {
+	return v.ScheduledSearchV2Details.SearchIntervalSeconds
+}
+
+// GetSearchIntervalOffsetSeconds returns ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch.SearchIntervalOffsetSeconds, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) GetSearchIntervalOffsetSeconds() *int64 {
+	return v.ScheduledSearchV2Details.SearchIntervalOffsetSeconds
+}
+
+// GetMaxWaitTimeSeconds returns ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch.MaxWaitTimeSeconds, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) GetMaxWaitTimeSeconds() *int64 {
+	return v.ScheduledSearchV2Details.MaxWaitTimeSeconds
+}
+
+// GetTimeZone returns ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch.TimeZone, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) GetTimeZone() string {
+	return v.ScheduledSearchV2Details.TimeZone
+}
+
+// GetSchedule returns ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch.Schedule, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) GetSchedule() string {
+	return v.ScheduledSearchV2Details.Schedule
+}
+
+// GetBackfillLimitV2 returns ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch.BackfillLimitV2, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) GetBackfillLimitV2() *int {
+	return v.ScheduledSearchV2Details.BackfillLimitV2
+}
+
+// GetEnabled returns ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch.Enabled, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) GetEnabled() bool {
+	return v.ScheduledSearchV2Details.Enabled
+}
+
+// GetActionsV2 returns ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch.ActionsV2, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) GetActionsV2() []ScheduledSearchV2DetailsActionsV2Action {
+	return v.ScheduledSearchV2Details.ActionsV2
+}
+
+// GetLabels returns ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch.Labels, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) GetLabels() []string {
+	return v.ScheduledSearchV2Details.Labels
+}
+
+// GetQueryTimestampType returns ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch.QueryTimestampType, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) GetQueryTimestampType() QueryTimestampType {
+	return v.ScheduledSearchV2Details.QueryTimestampType
+}
+
+// GetQueryOwnership returns ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch.QueryOwnership, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) GetQueryOwnership() SharedQueryOwnershipType {
+	return v.ScheduledSearchV2Details.QueryOwnership
+}
+
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.ScheduledSearchV2Details)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch struct {
+	Id string `json:"id"`
+
+	Name string `json:"name"`
+
+	Description *string `json:"description"`
+
+	QueryString string `json:"queryString"`
+
+	SearchIntervalSeconds int64 `json:"searchIntervalSeconds"`
+
+	SearchIntervalOffsetSeconds *int64 `json:"searchIntervalOffsetSeconds"`
+
+	MaxWaitTimeSeconds *int64 `json:"maxWaitTimeSeconds"`
+
+	TimeZone string `json:"timeZone"`
+
+	Schedule string `json:"schedule"`
+
+	BackfillLimitV2 *int `json:"backfillLimitV2"`
+
+	Enabled bool `json:"enabled"`
+
+	ActionsV2 []json.RawMessage `json:"actionsV2"`
+
+	Labels []string `json:"labels"`
+
+	QueryTimestampType QueryTimestampType `json:"queryTimestampType"`
+
+	QueryOwnership json.RawMessage `json:"queryOwnership"`
+}
+
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch) __premarshalJSON() (*__premarshalListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch, error) {
+	var retval __premarshalListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch
+
+	retval.Id = v.ScheduledSearchV2Details.Id
+	retval.Name = v.ScheduledSearchV2Details.Name
+	retval.Description = v.ScheduledSearchV2Details.Description
+	retval.QueryString = v.ScheduledSearchV2Details.QueryString
+	retval.SearchIntervalSeconds = v.ScheduledSearchV2Details.SearchIntervalSeconds
+	retval.SearchIntervalOffsetSeconds = v.ScheduledSearchV2Details.SearchIntervalOffsetSeconds
+	retval.MaxWaitTimeSeconds = v.ScheduledSearchV2Details.MaxWaitTimeSeconds
+	retval.TimeZone = v.ScheduledSearchV2Details.TimeZone
+	retval.Schedule = v.ScheduledSearchV2Details.Schedule
+	retval.BackfillLimitV2 = v.ScheduledSearchV2Details.BackfillLimitV2
+	retval.Enabled = v.ScheduledSearchV2Details.Enabled
+	{
+
+		dst := &retval.ActionsV2
+		src := v.ScheduledSearchV2Details.ActionsV2
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalScheduledSearchV2DetailsActionsV2Action(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"unable to marshal ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch.ScheduledSearchV2Details.ActionsV2: %w", err)
+			}
+		}
+	}
+	retval.Labels = v.ScheduledSearchV2Details.Labels
+	retval.QueryTimestampType = v.ScheduledSearchV2Details.QueryTimestampType
+	{
+
+		dst := &retval.QueryOwnership
+		src := v.ScheduledSearchV2Details.QueryOwnership
+		var err error
+		*dst, err = __marshalSharedQueryOwnershipType(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch.ScheduledSearchV2Details.QueryOwnership: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
+// ListScheduledSearchesV2SearchDomainView includes the requested fields of the GraphQL type View.
+// The GraphQL type's documentation follows.
+//
+// Represents information about a view, pulling data from one or several repositories.
+type ListScheduledSearchesV2SearchDomainView struct {
+	Typename *string `json:"__typename"`
+	// Common interface for Repositories and Views.
+	ScheduledSearches []ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch `json:"scheduledSearches"`
+}
+
+// GetTypename returns ListScheduledSearchesV2SearchDomainView.Typename, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainView) GetTypename() *string { return v.Typename }
+
+// GetScheduledSearches returns ListScheduledSearchesV2SearchDomainView.ScheduledSearches, and is useful for accessing the field via an interface.
+func (v *ListScheduledSearchesV2SearchDomainView) GetScheduledSearches() []ListScheduledSearchesV2SearchDomainScheduledSearchesScheduledSearch {
+	return v.ScheduledSearches
+}
+
 // ListSearchDomainsResponse is returned by ListSearchDomains on success.
 type ListSearchDomainsResponse struct {
+	// Stability: Long-term
 	SearchDomains []ListSearchDomainsSearchDomainsSearchDomain `json:"-"`
 }
 
@@ -11509,6 +12488,7 @@ func (v *ListSearchDomainsSearchDomainsView) GetAutomaticSearch() bool { return 
 // ListUsersResponse is returned by ListUsers on success.
 type ListUsersResponse struct {
 	// Requires manage cluster permission; Returns all users in the system.
+	// Stability: Long-term
 	Users []ListUsersUsersUser `json:"users"`
 }
 
@@ -11650,8 +12630,10 @@ const (
 type PackageInstallationSourceType string
 
 const (
+	// Stability: Long-term
 	PackageInstallationSourceTypeHumiohub PackageInstallationSourceType = "HumioHub"
-	PackageInstallationSourceTypeZipfile  PackageInstallationSourceType = "ZipFile"
+	// Stability: Long-term
+	PackageInstallationSourceTypeZipfile PackageInstallationSourceType = "ZipFile"
 )
 
 // ParserDetails includes the GraphQL fields of Parser requested by the fragment ParserDetails.
@@ -11660,22 +12642,31 @@ const (
 // A configured parser for incoming data.
 type ParserDetails struct {
 	// The id of the parser.
+	// Stability: Long-term
 	Id string `json:"id"`
 	// Name of the parser.
+	// Stability: Long-term
 	Name string `json:"name"`
 	// The full name of the parser including package information if part of an application.
+	// Stability: Long-term
 	DisplayName string `json:"displayName"`
 	// The description of the parser.
+	// Stability: Long-term
 	Description *string `json:"description"`
 	// True if the parser is one of LogScale's built-in parsers.
+	// Stability: Long-term
 	IsBuiltIn bool `json:"isBuiltIn"`
 	// The parser script that is executed for every incoming event.
+	// Stability: Long-term
 	Script string `json:"script"`
 	// Fields that are used as tags.
+	// Stability: Long-term
 	FieldsToTag []string `json:"fieldsToTag"`
 	// A list of fields that will be removed from the event before it's parsed. These fields will not be included when calculating usage.
+	// Stability: Long-term
 	FieldsToBeRemovedBeforeParsing []string `json:"fieldsToBeRemovedBeforeParsing"`
 	// Test cases that can be used to help verify that the parser works as expected.
+	// Stability: Long-term
 	TestCases []ParserDetailsTestCasesParserTestCase `json:"testCases"`
 }
 
@@ -11714,8 +12705,10 @@ func (v *ParserDetails) GetTestCases() []ParserDetailsTestCasesParserTestCase { 
 // A test case for a parser.
 type ParserDetailsTestCasesParserTestCase struct {
 	// The event to parse and test on.
+	// Stability: Long-term
 	Event ParserDetailsTestCasesParserTestCaseEventParserTestEvent `json:"event"`
 	// Assertions on the shape of the test case output events. The list consists of key-value pairs to be treated as a map-construct, where the index of the output event is the key, and the assertions are the value.
+	// Stability: Long-term
 	OutputAssertions []ParserDetailsTestCasesParserTestCaseOutputAssertionsParserTestCaseAssertionsForOutput `json:"outputAssertions"`
 }
 
@@ -11735,6 +12728,7 @@ func (v *ParserDetailsTestCasesParserTestCase) GetOutputAssertions() []ParserDet
 // An event for a parser to parse during testing.
 type ParserDetailsTestCasesParserTestCaseEventParserTestEvent struct {
 	// The contents of the `@rawstring` field when the event begins parsing.
+	// Stability: Long-term
 	RawString string `json:"rawString"`
 }
 
@@ -11749,8 +12743,10 @@ func (v *ParserDetailsTestCasesParserTestCaseEventParserTestEvent) GetRawString(
 // Assertions on the shape of the given output event. It is a key-value pair, where the index of the output event is the key, and the assertions are the value.
 type ParserDetailsTestCasesParserTestCaseOutputAssertionsParserTestCaseAssertionsForOutput struct {
 	// Assertions on the shape of a given test case output event.
+	// Stability: Long-term
 	Assertions ParserDetailsTestCasesParserTestCaseOutputAssertionsParserTestCaseAssertionsForOutputAssertionsParserTestCaseOutputAssertions `json:"assertions"`
 	// The index of the output event which the assertions should apply to.
+	// Stability: Long-term
 	OutputEventIndex int `json:"outputEventIndex"`
 }
 
@@ -11770,8 +12766,10 @@ func (v *ParserDetailsTestCasesParserTestCaseOutputAssertionsParserTestCaseAsser
 // Assertions on the shape of a given test case output event.
 type ParserDetailsTestCasesParserTestCaseOutputAssertionsParserTestCaseAssertionsForOutputAssertionsParserTestCaseOutputAssertions struct {
 	// Names of fields and their expected value on the output event. These are key-value pairs, and should be treated as a map-construct.
+	// Stability: Long-term
 	FieldsHaveValues []ParserDetailsTestCasesParserTestCaseOutputAssertionsParserTestCaseAssertionsForOutputAssertionsParserTestCaseOutputAssertionsFieldsHaveValuesFieldHasValue `json:"fieldsHaveValues"`
 	// Names of fields which should not be present on the output event.
+	// Stability: Long-term
 	FieldsNotPresent []string `json:"fieldsNotPresent"`
 }
 
@@ -11791,8 +12789,10 @@ func (v *ParserDetailsTestCasesParserTestCaseOutputAssertionsParserTestCaseAsser
 // An assertion that an event output from a parser test case has an expected value for a given field.
 type ParserDetailsTestCasesParserTestCaseOutputAssertionsParserTestCaseAssertionsForOutputAssertionsParserTestCaseOutputAssertionsFieldsHaveValuesFieldHasValue struct {
 	// Field to assert on.
+	// Stability: Long-term
 	FieldName string `json:"fieldName"`
 	// Value expected to be contained in the field.
+	// Stability: Long-term
 	ExpectedValue string `json:"expectedValue"`
 }
 
@@ -11874,14 +12874,29 @@ const (
 	PermissionChangetriggersandactions Permission = "ChangeTriggersAndActions"
 	// Permission to administer alerts and scheduled searches
 	PermissionChangetriggers Permission = "ChangeTriggers"
+	PermissionCreatetriggers Permission = "CreateTriggers"
+	PermissionUpdatetriggers Permission = "UpdateTriggers"
+	PermissionDeletetriggers Permission = "DeleteTriggers"
 	// Permission to administer actions
 	PermissionChangeactions                     Permission = "ChangeActions"
+	PermissionCreateactions                     Permission = "CreateActions"
+	PermissionUpdateactions                     Permission = "UpdateActions"
+	PermissionDeleteactions                     Permission = "DeleteActions"
 	PermissionChangedashboards                  Permission = "ChangeDashboards"
+	PermissionCreatedashboards                  Permission = "CreateDashboards"
+	PermissionUpdatedashboards                  Permission = "UpdateDashboards"
+	PermissionDeletedashboards                  Permission = "DeleteDashboards"
 	PermissionChangedashboardreadonlytoken      Permission = "ChangeDashboardReadonlyToken"
 	PermissionChangefiles                       Permission = "ChangeFiles"
+	PermissionCreatefiles                       Permission = "CreateFiles"
+	PermissionUpdatefiles                       Permission = "UpdateFiles"
+	PermissionDeletefiles                       Permission = "DeleteFiles"
 	PermissionChangeinteractions                Permission = "ChangeInteractions"
 	PermissionChangeparsers                     Permission = "ChangeParsers"
 	PermissionChangesavedqueries                Permission = "ChangeSavedQueries"
+	PermissionCreatesavedqueries                Permission = "CreateSavedQueries"
+	PermissionUpdatesavedqueries                Permission = "UpdateSavedQueries"
+	PermissionDeletesavedqueries                Permission = "DeleteSavedQueries"
 	PermissionConnectview                       Permission = "ConnectView"
 	PermissionChangedatadeletionpermissions     Permission = "ChangeDataDeletionPermissions"
 	PermissionChangeretention                   Permission = "ChangeRetention"
@@ -11904,6 +12919,9 @@ const (
 	PermissionReadexternalfunctions             Permission = "ReadExternalFunctions"
 	PermissionChangeingestfeeds                 Permission = "ChangeIngestFeeds"
 	PermissionChangescheduledreports            Permission = "ChangeScheduledReports"
+	PermissionCreatescheduledreports            Permission = "CreateScheduledReports"
+	PermissionUpdatescheduledreports            Permission = "UpdateScheduledReports"
+	PermissionDeletescheduledreports            Permission = "DeleteScheduledReports"
 )
 
 // QueryOwnership includes the GraphQL fields of QueryOwnership requested by the fragment QueryOwnership.
@@ -12038,6 +13056,7 @@ func (v *RemoveFileRemoveFileBooleanResultType) GetTypename() *string { return v
 // RemoveFileResponse is returned by RemoveFile on success.
 type RemoveFileResponse struct {
 	// Remove file
+	// Stability: Long-term
 	RemoveFile RemoveFileRemoveFileBooleanResultType `json:"removeFile"`
 }
 
@@ -12059,6 +13078,7 @@ func (v *RemoveIngestTokenRemoveIngestTokenBooleanResultType) GetTypename() *str
 // RemoveIngestTokenResponse is returned by RemoveIngestToken on success.
 type RemoveIngestTokenResponse struct {
 	// Remove an Ingest Token.
+	// Stability: Long-term
 	RemoveIngestToken RemoveIngestTokenRemoveIngestTokenBooleanResultType `json:"removeIngestToken"`
 }
 
@@ -12080,6 +13100,7 @@ func (v *RemoveUserFromGroupRemoveUsersFromGroupRemoveUsersFromGroupMutation) Ge
 // RemoveUserFromGroupResponse is returned by RemoveUserFromGroup on success.
 type RemoveUserFromGroupResponse struct {
 	// Removes users from an existing group.
+	// Stability: Long-term
 	RemoveUsersFromGroup RemoveUserFromGroupRemoveUsersFromGroupRemoveUsersFromGroupMutation `json:"removeUsersFromGroup"`
 }
 
@@ -12090,6 +13111,7 @@ func (v *RemoveUserFromGroupResponse) GetRemoveUsersFromGroup() RemoveUserFromGr
 
 // RemoveUserRemoveUserRemoveUserMutation includes the requested fields of the GraphQL type RemoveUserMutation.
 type RemoveUserRemoveUserRemoveUserMutation struct {
+	// Stability: Long-term
 	User RemoveUserRemoveUserRemoveUserMutationUser `json:"user"`
 }
 
@@ -12216,6 +13238,7 @@ func (v *RemoveUserRemoveUserRemoveUserMutationUser) __premarshalJSON() (*__prem
 // RemoveUserResponse is returned by RemoveUser on success.
 type RemoveUserResponse struct {
 	// Remove a user.
+	// Stability: Long-term
 	RemoveUser RemoveUserRemoveUserRemoveUserMutation `json:"removeUser"`
 }
 
@@ -12229,19 +13252,28 @@ func (v *RemoveUserResponse) GetRemoveUser() RemoveUserRemoveUserRemoveUserMutat
 //
 // A repository stores ingested data, configures parsers and data retention policies.
 type RepositoryDetails struct {
-	Id          string  `json:"id"`
-	Name        string  `json:"name"`
+	// Stability: Long-term
+	Id string `json:"id"`
+	// Stability: Long-term
+	Name string `json:"name"`
+	// Stability: Long-term
 	Description *string `json:"description"`
 	// The maximum time (in days) to keep data. Data old than this will be deleted.
+	// Stability: Long-term
 	TimeBasedRetention *float64 `json:"timeBasedRetention"`
 	// Retention (in Gigabytes) based on the size of data when it arrives to LogScale, that is before parsing and compression. LogScale will keep `at most` this amount of data.
+	// Stability: Long-term
 	IngestSizeBasedRetention *float64 `json:"ingestSizeBasedRetention"`
 	// Retention (in Gigabytes) based on the size of data when in storage, that is, after parsing and compression. LogScale will keep `at least` this amount of data, but as close to this number as possible.
+	// Stability: Long-term
 	StorageSizeBasedRetention *float64 `json:"storageSizeBasedRetention"`
 	// Total size of data. Size is measured as the size after compression.
+	// Stability: Long-term
 	CompressedByteSize int64 `json:"compressedByteSize"`
-	AutomaticSearch    bool  `json:"automaticSearch"`
+	// Stability: Long-term
+	AutomaticSearch bool `json:"automaticSearch"`
 	// Configuration for S3 archiving. E.g. bucket name and region.
+	// Stability: Long-term
 	S3ArchivingConfiguration *RepositoryDetailsS3ArchivingConfigurationS3Configuration `json:"s3ArchivingConfiguration"`
 }
 
@@ -12282,12 +13314,16 @@ func (v *RepositoryDetails) GetS3ArchivingConfiguration() *RepositoryDetailsS3Ar
 // Configuration for S3 archiving. E.g. bucket name and region.
 type RepositoryDetailsS3ArchivingConfigurationS3Configuration struct {
 	// S3 bucket name for storing archived data. Example: acme-bucket.
+	// Stability: Short-term
 	Bucket string `json:"bucket"`
 	// The region the S3 bucket belongs to. Example: eu-central-1.
+	// Stability: Short-term
 	Region string `json:"region"`
 	// Whether the archiving has been disabled.
+	// Stability: Short-term
 	Disabled *bool `json:"disabled"`
 	// The format to store the archived data in on S3.
+	// Stability: Short-term
 	Format *S3ArchivingFormat `json:"format"`
 }
 
@@ -12313,11 +13349,16 @@ func (v *RepositoryDetailsS3ArchivingConfigurationS3Configuration) GetFormat() *
 
 // RoleDetails includes the GraphQL fields of Role requested by the fragment RoleDetails.
 type RoleDetails struct {
-	Id                      string                   `json:"id"`
-	DisplayName             string                   `json:"displayName"`
-	ViewPermissions         []Permission             `json:"viewPermissions"`
+	// Stability: Long-term
+	Id string `json:"id"`
+	// Stability: Long-term
+	DisplayName string `json:"displayName"`
+	// Stability: Long-term
+	ViewPermissions []Permission `json:"viewPermissions"`
+	// Stability: Long-term
 	OrganizationPermissions []OrganizationPermission `json:"organizationPermissions"`
-	SystemPermissions       []SystemPermission       `json:"systemPermissions"`
+	// Stability: Long-term
+	SystemPermissions []SystemPermission `json:"systemPermissions"`
 }
 
 // GetId returns RoleDetails.Id, and is useful for accessing the field via an interface.
@@ -12340,13 +13381,14 @@ func (v *RoleDetails) GetSystemPermissions() []SystemPermission { return v.Syste
 // RotateTokenByIDResponse is returned by RotateTokenByID on success.
 type RotateTokenByIDResponse struct {
 	// Rotate a token
+	// Stability: Long-term
 	RotateToken string `json:"rotateToken"`
 }
 
 // GetRotateToken returns RotateTokenByIDResponse.RotateToken, and is useful for accessing the field via an interface.
 func (v *RotateTokenByIDResponse) GetRotateToken() string { return v.RotateToken }
 
-// The format to store archived segments in on AWS S3.
+// The format to store archived segments in AWS S3.
 type S3ArchivingFormat string
 
 const (
@@ -12360,30 +13402,40 @@ const (
 // Information about a scheduled search
 type ScheduledSearchDetails struct {
 	// Id of the scheduled search.
+	// Stability: Long-term
 	Id string `json:"id"`
 	// Name of the scheduled search.
+	// Stability: Long-term
 	Name string `json:"name"`
 	// Description of the scheduled search.
+	// Stability: Long-term
 	Description *string `json:"description"`
 	// LogScale query to execute.
+	// Stability: Long-term
 	QueryString string `json:"queryString"`
 	// Start of the relative time interval for the query.
 	Start string `json:"start"`
 	// End of the relative time interval for the query.
 	End string `json:"end"`
 	// Time zone of the schedule. Currently this field only supports UTC offsets like 'UTC', 'UTC-01' or 'UTC+12:45'.
+	// Stability: Long-term
 	TimeZone string `json:"timeZone"`
 	// Cron pattern describing the schedule to execute the query on.
+	// Stability: Long-term
 	Schedule string `json:"schedule"`
-	// User-defined limit, which caps the number of missed searches to backfill, e.g. in the event of a shutdown.
+	// User-defined limit, which caps the number of missed searches to backfill, e.g. in the event of a shutdown. If the 'queryTimestampType' is IngestTimestamp this field is not used, but due to backwards compatibility a value of 0 is returned.
 	BackfillLimit int `json:"backfillLimit"`
 	// Flag indicating whether the scheduled search is enabled.
+	// Stability: Long-term
 	Enabled bool `json:"enabled"`
 	// List of actions to fire on query result.
+	// Stability: Long-term
 	ActionsV2 []ScheduledSearchDetailsActionsV2Action `json:"-"`
 	// Labels added to the scheduled search.
+	// Stability: Long-term
 	Labels []string `json:"labels"`
 	// Ownership of the query run by this scheduled search
+	// Stability: Long-term
 	QueryOwnership SharedQueryOwnershipType `json:"-"`
 }
 
@@ -12891,9 +13943,582 @@ func (v *ScheduledSearchDetailsActionsV2WebhookAction) GetTypename() *string { r
 // GetName returns ScheduledSearchDetailsActionsV2WebhookAction.Name, and is useful for accessing the field via an interface.
 func (v *ScheduledSearchDetailsActionsV2WebhookAction) GetName() string { return v.Name }
 
+// ScheduledSearchV2Details includes the GraphQL fields of ScheduledSearch requested by the fragment ScheduledSearchV2Details.
+// The GraphQL type's documentation follows.
+//
+// Information about a scheduled search
+type ScheduledSearchV2Details struct {
+	// Id of the scheduled search.
+	// Stability: Long-term
+	Id string `json:"id"`
+	// Name of the scheduled search.
+	// Stability: Long-term
+	Name string `json:"name"`
+	// Description of the scheduled search.
+	// Stability: Long-term
+	Description *string `json:"description"`
+	// LogScale query to execute.
+	// Stability: Long-term
+	QueryString string `json:"queryString"`
+	// Search interval in seconds.
+	// Stability: Long-term
+	SearchIntervalSeconds int64 `json:"searchIntervalSeconds"`
+	// Offset of the search interval in seconds. Only present when 'queryTimestampType' is EventTimestamp.
+	// Stability: Long-term
+	SearchIntervalOffsetSeconds *int64 `json:"searchIntervalOffsetSeconds"`
+	// Maximum number of seconds to wait for ingest delay. Only present when 'queryTimestampType' is IngestTimestamp.
+	// Stability: Long-term
+	MaxWaitTimeSeconds *int64 `json:"maxWaitTimeSeconds"`
+	// Time zone of the schedule. Currently this field only supports UTC offsets like 'UTC', 'UTC-01' or 'UTC+12:45'.
+	// Stability: Long-term
+	TimeZone string `json:"timeZone"`
+	// Cron pattern describing the schedule to execute the query on.
+	// Stability: Long-term
+	Schedule string `json:"schedule"`
+	// User-defined limit, which caps the number of missed searches to backfill, e.g. in the event of a shutdown. Only present when 'queryTimestampType' is EventTimestamp.
+	// Stability: Long-term
+	BackfillLimitV2 *int `json:"backfillLimitV2"`
+	// Flag indicating whether the scheduled search is enabled.
+	// Stability: Long-term
+	Enabled bool `json:"enabled"`
+	// List of actions to fire on query result.
+	// Stability: Long-term
+	ActionsV2 []ScheduledSearchV2DetailsActionsV2Action `json:"-"`
+	// Labels added to the scheduled search.
+	// Stability: Long-term
+	Labels []string `json:"labels"`
+	// Timestamp type to use for the query.
+	// Stability: Long-term
+	QueryTimestampType QueryTimestampType `json:"queryTimestampType"`
+	// Ownership of the query run by this scheduled search
+	// Stability: Long-term
+	QueryOwnership SharedQueryOwnershipType `json:"-"`
+}
+
+// GetId returns ScheduledSearchV2Details.Id, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2Details) GetId() string { return v.Id }
+
+// GetName returns ScheduledSearchV2Details.Name, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2Details) GetName() string { return v.Name }
+
+// GetDescription returns ScheduledSearchV2Details.Description, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2Details) GetDescription() *string { return v.Description }
+
+// GetQueryString returns ScheduledSearchV2Details.QueryString, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2Details) GetQueryString() string { return v.QueryString }
+
+// GetSearchIntervalSeconds returns ScheduledSearchV2Details.SearchIntervalSeconds, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2Details) GetSearchIntervalSeconds() int64 { return v.SearchIntervalSeconds }
+
+// GetSearchIntervalOffsetSeconds returns ScheduledSearchV2Details.SearchIntervalOffsetSeconds, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2Details) GetSearchIntervalOffsetSeconds() *int64 {
+	return v.SearchIntervalOffsetSeconds
+}
+
+// GetMaxWaitTimeSeconds returns ScheduledSearchV2Details.MaxWaitTimeSeconds, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2Details) GetMaxWaitTimeSeconds() *int64 { return v.MaxWaitTimeSeconds }
+
+// GetTimeZone returns ScheduledSearchV2Details.TimeZone, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2Details) GetTimeZone() string { return v.TimeZone }
+
+// GetSchedule returns ScheduledSearchV2Details.Schedule, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2Details) GetSchedule() string { return v.Schedule }
+
+// GetBackfillLimitV2 returns ScheduledSearchV2Details.BackfillLimitV2, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2Details) GetBackfillLimitV2() *int { return v.BackfillLimitV2 }
+
+// GetEnabled returns ScheduledSearchV2Details.Enabled, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2Details) GetEnabled() bool { return v.Enabled }
+
+// GetActionsV2 returns ScheduledSearchV2Details.ActionsV2, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2Details) GetActionsV2() []ScheduledSearchV2DetailsActionsV2Action {
+	return v.ActionsV2
+}
+
+// GetLabels returns ScheduledSearchV2Details.Labels, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2Details) GetLabels() []string { return v.Labels }
+
+// GetQueryTimestampType returns ScheduledSearchV2Details.QueryTimestampType, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2Details) GetQueryTimestampType() QueryTimestampType {
+	return v.QueryTimestampType
+}
+
+// GetQueryOwnership returns ScheduledSearchV2Details.QueryOwnership, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2Details) GetQueryOwnership() SharedQueryOwnershipType {
+	return v.QueryOwnership
+}
+
+func (v *ScheduledSearchV2Details) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*ScheduledSearchV2Details
+		ActionsV2      []json.RawMessage `json:"actionsV2"`
+		QueryOwnership json.RawMessage   `json:"queryOwnership"`
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.ScheduledSearchV2Details = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	{
+		dst := &v.ActionsV2
+		src := firstPass.ActionsV2
+		*dst = make(
+			[]ScheduledSearchV2DetailsActionsV2Action,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			if len(src) != 0 && string(src) != "null" {
+				err = __unmarshalScheduledSearchV2DetailsActionsV2Action(
+					src, dst)
+				if err != nil {
+					return fmt.Errorf(
+						"unable to unmarshal ScheduledSearchV2Details.ActionsV2: %w", err)
+				}
+			}
+		}
+	}
+
+	{
+		dst := &v.QueryOwnership
+		src := firstPass.QueryOwnership
+		if len(src) != 0 && string(src) != "null" {
+			err = __unmarshalSharedQueryOwnershipType(
+				src, dst)
+			if err != nil {
+				return fmt.Errorf(
+					"unable to unmarshal ScheduledSearchV2Details.QueryOwnership: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+type __premarshalScheduledSearchV2Details struct {
+	Id string `json:"id"`
+
+	Name string `json:"name"`
+
+	Description *string `json:"description"`
+
+	QueryString string `json:"queryString"`
+
+	SearchIntervalSeconds int64 `json:"searchIntervalSeconds"`
+
+	SearchIntervalOffsetSeconds *int64 `json:"searchIntervalOffsetSeconds"`
+
+	MaxWaitTimeSeconds *int64 `json:"maxWaitTimeSeconds"`
+
+	TimeZone string `json:"timeZone"`
+
+	Schedule string `json:"schedule"`
+
+	BackfillLimitV2 *int `json:"backfillLimitV2"`
+
+	Enabled bool `json:"enabled"`
+
+	ActionsV2 []json.RawMessage `json:"actionsV2"`
+
+	Labels []string `json:"labels"`
+
+	QueryTimestampType QueryTimestampType `json:"queryTimestampType"`
+
+	QueryOwnership json.RawMessage `json:"queryOwnership"`
+}
+
+func (v *ScheduledSearchV2Details) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *ScheduledSearchV2Details) __premarshalJSON() (*__premarshalScheduledSearchV2Details, error) {
+	var retval __premarshalScheduledSearchV2Details
+
+	retval.Id = v.Id
+	retval.Name = v.Name
+	retval.Description = v.Description
+	retval.QueryString = v.QueryString
+	retval.SearchIntervalSeconds = v.SearchIntervalSeconds
+	retval.SearchIntervalOffsetSeconds = v.SearchIntervalOffsetSeconds
+	retval.MaxWaitTimeSeconds = v.MaxWaitTimeSeconds
+	retval.TimeZone = v.TimeZone
+	retval.Schedule = v.Schedule
+	retval.BackfillLimitV2 = v.BackfillLimitV2
+	retval.Enabled = v.Enabled
+	{
+
+		dst := &retval.ActionsV2
+		src := v.ActionsV2
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalScheduledSearchV2DetailsActionsV2Action(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"unable to marshal ScheduledSearchV2Details.ActionsV2: %w", err)
+			}
+		}
+	}
+	retval.Labels = v.Labels
+	retval.QueryTimestampType = v.QueryTimestampType
+	{
+
+		dst := &retval.QueryOwnership
+		src := v.QueryOwnership
+		var err error
+		*dst, err = __marshalSharedQueryOwnershipType(
+			&src)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to marshal ScheduledSearchV2Details.QueryOwnership: %w", err)
+		}
+	}
+	return &retval, nil
+}
+
+// ScheduledSearchV2DetailsActionsV2Action includes the requested fields of the GraphQL interface Action.
+//
+// ScheduledSearchV2DetailsActionsV2Action is implemented by the following types:
+// ScheduledSearchV2DetailsActionsV2EmailAction
+// ScheduledSearchV2DetailsActionsV2HumioRepoAction
+// ScheduledSearchV2DetailsActionsV2OpsGenieAction
+// ScheduledSearchV2DetailsActionsV2PagerDutyAction
+// ScheduledSearchV2DetailsActionsV2SlackAction
+// ScheduledSearchV2DetailsActionsV2SlackPostMessageAction
+// ScheduledSearchV2DetailsActionsV2UploadFileAction
+// ScheduledSearchV2DetailsActionsV2VictorOpsAction
+// ScheduledSearchV2DetailsActionsV2WebhookAction
+// The GraphQL type's documentation follows.
+//
+// An action that can be invoked from a trigger.
+type ScheduledSearchV2DetailsActionsV2Action interface {
+	implementsGraphQLInterfaceScheduledSearchV2DetailsActionsV2Action()
+	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
+	GetTypename() *string
+	// GetName returns the interface-field "name" from its implementation.
+	// The GraphQL interface field's documentation follows.
+	//
+	// An action that can be invoked from a trigger.
+	GetName() string
+}
+
+func (v *ScheduledSearchV2DetailsActionsV2EmailAction) implementsGraphQLInterfaceScheduledSearchV2DetailsActionsV2Action() {
+}
+func (v *ScheduledSearchV2DetailsActionsV2HumioRepoAction) implementsGraphQLInterfaceScheduledSearchV2DetailsActionsV2Action() {
+}
+func (v *ScheduledSearchV2DetailsActionsV2OpsGenieAction) implementsGraphQLInterfaceScheduledSearchV2DetailsActionsV2Action() {
+}
+func (v *ScheduledSearchV2DetailsActionsV2PagerDutyAction) implementsGraphQLInterfaceScheduledSearchV2DetailsActionsV2Action() {
+}
+func (v *ScheduledSearchV2DetailsActionsV2SlackAction) implementsGraphQLInterfaceScheduledSearchV2DetailsActionsV2Action() {
+}
+func (v *ScheduledSearchV2DetailsActionsV2SlackPostMessageAction) implementsGraphQLInterfaceScheduledSearchV2DetailsActionsV2Action() {
+}
+func (v *ScheduledSearchV2DetailsActionsV2UploadFileAction) implementsGraphQLInterfaceScheduledSearchV2DetailsActionsV2Action() {
+}
+func (v *ScheduledSearchV2DetailsActionsV2VictorOpsAction) implementsGraphQLInterfaceScheduledSearchV2DetailsActionsV2Action() {
+}
+func (v *ScheduledSearchV2DetailsActionsV2WebhookAction) implementsGraphQLInterfaceScheduledSearchV2DetailsActionsV2Action() {
+}
+
+func __unmarshalScheduledSearchV2DetailsActionsV2Action(b []byte, v *ScheduledSearchV2DetailsActionsV2Action) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var tn struct {
+		TypeName string `json:"__typename"`
+	}
+	err := json.Unmarshal(b, &tn)
+	if err != nil {
+		return err
+	}
+
+	switch tn.TypeName {
+	case "EmailAction":
+		*v = new(ScheduledSearchV2DetailsActionsV2EmailAction)
+		return json.Unmarshal(b, *v)
+	case "HumioRepoAction":
+		*v = new(ScheduledSearchV2DetailsActionsV2HumioRepoAction)
+		return json.Unmarshal(b, *v)
+	case "OpsGenieAction":
+		*v = new(ScheduledSearchV2DetailsActionsV2OpsGenieAction)
+		return json.Unmarshal(b, *v)
+	case "PagerDutyAction":
+		*v = new(ScheduledSearchV2DetailsActionsV2PagerDutyAction)
+		return json.Unmarshal(b, *v)
+	case "SlackAction":
+		*v = new(ScheduledSearchV2DetailsActionsV2SlackAction)
+		return json.Unmarshal(b, *v)
+	case "SlackPostMessageAction":
+		*v = new(ScheduledSearchV2DetailsActionsV2SlackPostMessageAction)
+		return json.Unmarshal(b, *v)
+	case "UploadFileAction":
+		*v = new(ScheduledSearchV2DetailsActionsV2UploadFileAction)
+		return json.Unmarshal(b, *v)
+	case "VictorOpsAction":
+		*v = new(ScheduledSearchV2DetailsActionsV2VictorOpsAction)
+		return json.Unmarshal(b, *v)
+	case "WebhookAction":
+		*v = new(ScheduledSearchV2DetailsActionsV2WebhookAction)
+		return json.Unmarshal(b, *v)
+	case "":
+		return fmt.Errorf(
+			"response was missing Action.__typename")
+	default:
+		return fmt.Errorf(
+			`unexpected concrete type for ScheduledSearchV2DetailsActionsV2Action: "%v"`, tn.TypeName)
+	}
+}
+
+func __marshalScheduledSearchV2DetailsActionsV2Action(v *ScheduledSearchV2DetailsActionsV2Action) ([]byte, error) {
+
+	var typename string
+	switch v := (*v).(type) {
+	case *ScheduledSearchV2DetailsActionsV2EmailAction:
+		typename = "EmailAction"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ScheduledSearchV2DetailsActionsV2EmailAction
+		}{typename, v}
+		return json.Marshal(result)
+	case *ScheduledSearchV2DetailsActionsV2HumioRepoAction:
+		typename = "HumioRepoAction"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ScheduledSearchV2DetailsActionsV2HumioRepoAction
+		}{typename, v}
+		return json.Marshal(result)
+	case *ScheduledSearchV2DetailsActionsV2OpsGenieAction:
+		typename = "OpsGenieAction"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ScheduledSearchV2DetailsActionsV2OpsGenieAction
+		}{typename, v}
+		return json.Marshal(result)
+	case *ScheduledSearchV2DetailsActionsV2PagerDutyAction:
+		typename = "PagerDutyAction"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ScheduledSearchV2DetailsActionsV2PagerDutyAction
+		}{typename, v}
+		return json.Marshal(result)
+	case *ScheduledSearchV2DetailsActionsV2SlackAction:
+		typename = "SlackAction"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ScheduledSearchV2DetailsActionsV2SlackAction
+		}{typename, v}
+		return json.Marshal(result)
+	case *ScheduledSearchV2DetailsActionsV2SlackPostMessageAction:
+		typename = "SlackPostMessageAction"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ScheduledSearchV2DetailsActionsV2SlackPostMessageAction
+		}{typename, v}
+		return json.Marshal(result)
+	case *ScheduledSearchV2DetailsActionsV2UploadFileAction:
+		typename = "UploadFileAction"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ScheduledSearchV2DetailsActionsV2UploadFileAction
+		}{typename, v}
+		return json.Marshal(result)
+	case *ScheduledSearchV2DetailsActionsV2VictorOpsAction:
+		typename = "VictorOpsAction"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ScheduledSearchV2DetailsActionsV2VictorOpsAction
+		}{typename, v}
+		return json.Marshal(result)
+	case *ScheduledSearchV2DetailsActionsV2WebhookAction:
+		typename = "WebhookAction"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*ScheduledSearchV2DetailsActionsV2WebhookAction
+		}{typename, v}
+		return json.Marshal(result)
+	case nil:
+		return []byte("null"), nil
+	default:
+		return nil, fmt.Errorf(
+			`unexpected concrete type for ScheduledSearchV2DetailsActionsV2Action: "%T"`, v)
+	}
+}
+
+// ScheduledSearchV2DetailsActionsV2EmailAction includes the requested fields of the GraphQL type EmailAction.
+// The GraphQL type's documentation follows.
+//
+// An email action.
+type ScheduledSearchV2DetailsActionsV2EmailAction struct {
+	Typename *string `json:"__typename"`
+	// An action that can be invoked from a trigger.
+	Name string `json:"name"`
+}
+
+// GetTypename returns ScheduledSearchV2DetailsActionsV2EmailAction.Typename, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2EmailAction) GetTypename() *string { return v.Typename }
+
+// GetName returns ScheduledSearchV2DetailsActionsV2EmailAction.Name, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2EmailAction) GetName() string { return v.Name }
+
+// ScheduledSearchV2DetailsActionsV2HumioRepoAction includes the requested fields of the GraphQL type HumioRepoAction.
+// The GraphQL type's documentation follows.
+//
+// A LogScale repository action.
+type ScheduledSearchV2DetailsActionsV2HumioRepoAction struct {
+	Typename *string `json:"__typename"`
+	// An action that can be invoked from a trigger.
+	Name string `json:"name"`
+}
+
+// GetTypename returns ScheduledSearchV2DetailsActionsV2HumioRepoAction.Typename, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2HumioRepoAction) GetTypename() *string { return v.Typename }
+
+// GetName returns ScheduledSearchV2DetailsActionsV2HumioRepoAction.Name, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2HumioRepoAction) GetName() string { return v.Name }
+
+// ScheduledSearchV2DetailsActionsV2OpsGenieAction includes the requested fields of the GraphQL type OpsGenieAction.
+// The GraphQL type's documentation follows.
+//
+// An OpsGenie action
+type ScheduledSearchV2DetailsActionsV2OpsGenieAction struct {
+	Typename *string `json:"__typename"`
+	// An action that can be invoked from a trigger.
+	Name string `json:"name"`
+}
+
+// GetTypename returns ScheduledSearchV2DetailsActionsV2OpsGenieAction.Typename, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2OpsGenieAction) GetTypename() *string { return v.Typename }
+
+// GetName returns ScheduledSearchV2DetailsActionsV2OpsGenieAction.Name, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2OpsGenieAction) GetName() string { return v.Name }
+
+// ScheduledSearchV2DetailsActionsV2PagerDutyAction includes the requested fields of the GraphQL type PagerDutyAction.
+// The GraphQL type's documentation follows.
+//
+// A PagerDuty action.
+type ScheduledSearchV2DetailsActionsV2PagerDutyAction struct {
+	Typename *string `json:"__typename"`
+	// An action that can be invoked from a trigger.
+	Name string `json:"name"`
+}
+
+// GetTypename returns ScheduledSearchV2DetailsActionsV2PagerDutyAction.Typename, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2PagerDutyAction) GetTypename() *string { return v.Typename }
+
+// GetName returns ScheduledSearchV2DetailsActionsV2PagerDutyAction.Name, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2PagerDutyAction) GetName() string { return v.Name }
+
+// ScheduledSearchV2DetailsActionsV2SlackAction includes the requested fields of the GraphQL type SlackAction.
+// The GraphQL type's documentation follows.
+//
+// A Slack action
+type ScheduledSearchV2DetailsActionsV2SlackAction struct {
+	Typename *string `json:"__typename"`
+	// An action that can be invoked from a trigger.
+	Name string `json:"name"`
+}
+
+// GetTypename returns ScheduledSearchV2DetailsActionsV2SlackAction.Typename, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2SlackAction) GetTypename() *string { return v.Typename }
+
+// GetName returns ScheduledSearchV2DetailsActionsV2SlackAction.Name, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2SlackAction) GetName() string { return v.Name }
+
+// ScheduledSearchV2DetailsActionsV2SlackPostMessageAction includes the requested fields of the GraphQL type SlackPostMessageAction.
+// The GraphQL type's documentation follows.
+//
+// A slack post-message action.
+type ScheduledSearchV2DetailsActionsV2SlackPostMessageAction struct {
+	Typename *string `json:"__typename"`
+	// An action that can be invoked from a trigger.
+	Name string `json:"name"`
+}
+
+// GetTypename returns ScheduledSearchV2DetailsActionsV2SlackPostMessageAction.Typename, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2SlackPostMessageAction) GetTypename() *string {
+	return v.Typename
+}
+
+// GetName returns ScheduledSearchV2DetailsActionsV2SlackPostMessageAction.Name, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2SlackPostMessageAction) GetName() string { return v.Name }
+
+// ScheduledSearchV2DetailsActionsV2UploadFileAction includes the requested fields of the GraphQL type UploadFileAction.
+// The GraphQL type's documentation follows.
+//
+// An upload file action.
+type ScheduledSearchV2DetailsActionsV2UploadFileAction struct {
+	Typename *string `json:"__typename"`
+	// An action that can be invoked from a trigger.
+	Name string `json:"name"`
+}
+
+// GetTypename returns ScheduledSearchV2DetailsActionsV2UploadFileAction.Typename, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2UploadFileAction) GetTypename() *string { return v.Typename }
+
+// GetName returns ScheduledSearchV2DetailsActionsV2UploadFileAction.Name, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2UploadFileAction) GetName() string { return v.Name }
+
+// ScheduledSearchV2DetailsActionsV2VictorOpsAction includes the requested fields of the GraphQL type VictorOpsAction.
+// The GraphQL type's documentation follows.
+//
+// A VictorOps action.
+type ScheduledSearchV2DetailsActionsV2VictorOpsAction struct {
+	Typename *string `json:"__typename"`
+	// An action that can be invoked from a trigger.
+	Name string `json:"name"`
+}
+
+// GetTypename returns ScheduledSearchV2DetailsActionsV2VictorOpsAction.Typename, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2VictorOpsAction) GetTypename() *string { return v.Typename }
+
+// GetName returns ScheduledSearchV2DetailsActionsV2VictorOpsAction.Name, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2VictorOpsAction) GetName() string { return v.Name }
+
+// ScheduledSearchV2DetailsActionsV2WebhookAction includes the requested fields of the GraphQL type WebhookAction.
+// The GraphQL type's documentation follows.
+//
+// A webhook action
+type ScheduledSearchV2DetailsActionsV2WebhookAction struct {
+	Typename *string `json:"__typename"`
+	// An action that can be invoked from a trigger.
+	Name string `json:"name"`
+}
+
+// GetTypename returns ScheduledSearchV2DetailsActionsV2WebhookAction.Typename, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2WebhookAction) GetTypename() *string { return v.Typename }
+
+// GetName returns ScheduledSearchV2DetailsActionsV2WebhookAction.Name, and is useful for accessing the field via an interface.
+func (v *ScheduledSearchV2DetailsActionsV2WebhookAction) GetName() string { return v.Name }
+
 // SetAutomaticSearchingResponse is returned by SetAutomaticSearching on success.
 type SetAutomaticSearchingResponse struct {
 	// Automatically search when arriving at the search page
+	// Stability: Long-term
 	SetAutomaticSearching SetAutomaticSearchingSetAutomaticSearching `json:"setAutomaticSearching"`
 }
 
@@ -13172,6 +14797,7 @@ const (
 // UnassignParserToIngestTokenResponse is returned by UnassignParserToIngestToken on success.
 type UnassignParserToIngestTokenResponse struct {
 	// Un-associates a token with its currently assigned parser.
+	// Stability: Long-term
 	UnassignIngestToken UnassignParserToIngestTokenUnassignIngestTokenUnassignIngestTokenMutation `json:"unassignIngestToken"`
 }
 
@@ -13193,6 +14819,7 @@ func (v *UnassignParserToIngestTokenUnassignIngestTokenUnassignIngestTokenMutati
 // UninstallPackageResponse is returned by UninstallPackage on success.
 type UninstallPackageResponse struct {
 	// Uninstalls a package from a specific view.
+	// Stability: Long-term
 	UninstallPackage UninstallPackageUninstallPackageBooleanResultType `json:"uninstallPackage"`
 }
 
@@ -13222,6 +14849,7 @@ func (v *UnregisterClusterNodeClusterUnregisterNodeUnregisterNodeMutation) GetTy
 // UnregisterClusterNodeResponse is returned by UnregisterClusterNode on success.
 type UnregisterClusterNodeResponse struct {
 	// Unregisters a node from the cluster.
+	// Stability: Long-term
 	ClusterUnregisterNode UnregisterClusterNodeClusterUnregisterNodeUnregisterNodeMutation `json:"clusterUnregisterNode"`
 }
 
@@ -13232,6 +14860,7 @@ func (v *UnregisterClusterNodeResponse) GetClusterUnregisterNode() UnregisterClu
 
 // UpdateDescriptionForSearchDomainResponse is returned by UpdateDescriptionForSearchDomain on success.
 type UpdateDescriptionForSearchDomainResponse struct {
+	// Stability: Long-term
 	UpdateDescriptionForSearchDomain UpdateDescriptionForSearchDomainUpdateDescriptionForSearchDomainUpdateDescriptionMutation `json:"updateDescriptionForSearchDomain"`
 }
 
@@ -13253,6 +14882,7 @@ func (v *UpdateDescriptionForSearchDomainUpdateDescriptionForSearchDomainUpdateD
 // UpdateIngestBasedRetentionResponse is returned by UpdateIngestBasedRetention on success.
 type UpdateIngestBasedRetentionResponse struct {
 	// Update the retention policy of a repository.
+	// Stability: Long-term
 	UpdateRetention UpdateIngestBasedRetentionUpdateRetentionUpdateRetentionMutation `json:"updateRetention"`
 }
 
@@ -13274,6 +14904,7 @@ func (v *UpdateIngestBasedRetentionUpdateRetentionUpdateRetentionMutation) GetTy
 // UpdateLicenseKeyResponse is returned by UpdateLicenseKey on success.
 type UpdateLicenseKeyResponse struct {
 	// Update the license key for the LogScale cluster. If there is an existing license on this cluster this operation requires permission to manage cluster.
+	// Stability: Long-term
 	UpdateLicenseKey UpdateLicenseKeyUpdateLicenseKeyLicense `json:"-"`
 }
 
@@ -13446,6 +15077,7 @@ func (v *UpdateLicenseKeyUpdateLicenseKeyTrialLicense) GetTypename() *string { r
 // UpdateS3ArchivingConfigurationResponse is returned by UpdateS3ArchivingConfiguration on success.
 type UpdateS3ArchivingConfigurationResponse struct {
 	// Configures S3 archiving for a repository. E.g. bucket and region.
+	// Stability: Short-term
 	S3ConfigureArchiving UpdateS3ArchivingConfigurationS3ConfigureArchivingBooleanResultType `json:"s3ConfigureArchiving"`
 }
 
@@ -13467,6 +15099,7 @@ func (v *UpdateS3ArchivingConfigurationS3ConfigureArchivingBooleanResultType) Ge
 // UpdateStorageBasedRetentionResponse is returned by UpdateStorageBasedRetention on success.
 type UpdateStorageBasedRetentionResponse struct {
 	// Update the retention policy of a repository.
+	// Stability: Long-term
 	UpdateRetention UpdateStorageBasedRetentionUpdateRetentionUpdateRetentionMutation `json:"updateRetention"`
 }
 
@@ -13488,6 +15121,7 @@ func (v *UpdateStorageBasedRetentionUpdateRetentionUpdateRetentionMutation) GetT
 // UpdateTimeBasedRetentionResponse is returned by UpdateTimeBasedRetention on success.
 type UpdateTimeBasedRetentionResponse struct {
 	// Update the retention policy of a repository.
+	// Stability: Long-term
 	UpdateRetention UpdateTimeBasedRetentionUpdateRetentionUpdateRetentionMutation `json:"updateRetention"`
 }
 
@@ -13509,6 +15143,7 @@ func (v *UpdateTimeBasedRetentionUpdateRetentionUpdateRetentionMutation) GetType
 // UpdateUserResponse is returned by UpdateUser on success.
 type UpdateUserResponse struct {
 	// Updates a user. Requires Root Permission.
+	// Stability: Long-term
 	UpdateUser UpdateUserUpdateUserUpdateUserMutation `json:"updateUser"`
 }
 
@@ -13528,6 +15163,7 @@ func (v *UpdateUserUpdateUserUpdateUserMutation) GetTypename() *string { return 
 // UpdateViewConnectionsResponse is returned by UpdateViewConnections on success.
 type UpdateViewConnectionsResponse struct {
 	// Update a view.
+	// Stability: Long-term
 	UpdateView UpdateViewConnectionsUpdateView `json:"updateView"`
 }
 
@@ -13541,6 +15177,7 @@ func (v *UpdateViewConnectionsResponse) GetUpdateView() UpdateViewConnectionsUpd
 //
 // Represents information about a view, pulling data from one or several repositories.
 type UpdateViewConnectionsUpdateView struct {
+	// Stability: Long-term
 	Name string `json:"name"`
 }
 
@@ -13552,15 +15189,24 @@ func (v *UpdateViewConnectionsUpdateView) GetName() string { return v.Name }
 //
 // A user profile.
 type UserDetails struct {
-	Id          string    `json:"id"`
-	Username    string    `json:"username"`
-	FullName    *string   `json:"fullName"`
-	Email       *string   `json:"email"`
-	Company     *string   `json:"company"`
-	CountryCode *string   `json:"countryCode"`
-	Picture     *string   `json:"picture"`
-	IsRoot      bool      `json:"isRoot"`
-	CreatedAt   time.Time `json:"createdAt"`
+	// Stability: Long-term
+	Id string `json:"id"`
+	// Stability: Long-term
+	Username string `json:"username"`
+	// Stability: Long-term
+	FullName *string `json:"fullName"`
+	// Stability: Long-term
+	Email *string `json:"email"`
+	// Stability: Long-term
+	Company *string `json:"company"`
+	// Stability: Long-term
+	CountryCode *string `json:"countryCode"`
+	// Stability: Long-term
+	Picture *string `json:"picture"`
+	// Stability: Long-term
+	IsRoot bool `json:"isRoot"`
+	// Stability: Long-term
+	CreatedAt time.Time `json:"createdAt"`
 }
 
 // GetId returns UserDetails.Id, and is useful for accessing the field via an interface.
@@ -14051,6 +15697,82 @@ func (v *__CreateScheduledSearchInput) GetQueryOwnershipType() *QueryOwnershipTy
 	return v.QueryOwnershipType
 }
 
+// __CreateScheduledSearchV2Input is used internally by genqlient
+type __CreateScheduledSearchV2Input struct {
+	SearchDomainName            string             `json:"SearchDomainName"`
+	Name                        string             `json:"Name"`
+	Description                 *string            `json:"Description"`
+	QueryString                 string             `json:"QueryString"`
+	SearchIntervalSeconds       int64              `json:"SearchIntervalSeconds"`
+	SearchIntervalOffsetSeconds *int64             `json:"SearchIntervalOffsetSeconds"`
+	MaxWaitTimeSeconds          *int64             `json:"MaxWaitTimeSeconds"`
+	Schedule                    string             `json:"Schedule"`
+	TimeZone                    string             `json:"TimeZone"`
+	BackfillLimit               *int               `json:"BackfillLimit"`
+	Enabled                     bool               `json:"Enabled"`
+	ActionIdsOrNames            []string           `json:"ActionIdsOrNames"`
+	RunAsUserID                 *string            `json:"RunAsUserID"`
+	Labels                      []string           `json:"Labels"`
+	QueryTimestampType          QueryTimestampType `json:"QueryTimestampType"`
+	QueryOwnershipType          QueryOwnershipType `json:"QueryOwnershipType"`
+}
+
+// GetSearchDomainName returns __CreateScheduledSearchV2Input.SearchDomainName, and is useful for accessing the field via an interface.
+func (v *__CreateScheduledSearchV2Input) GetSearchDomainName() string { return v.SearchDomainName }
+
+// GetName returns __CreateScheduledSearchV2Input.Name, and is useful for accessing the field via an interface.
+func (v *__CreateScheduledSearchV2Input) GetName() string { return v.Name }
+
+// GetDescription returns __CreateScheduledSearchV2Input.Description, and is useful for accessing the field via an interface.
+func (v *__CreateScheduledSearchV2Input) GetDescription() *string { return v.Description }
+
+// GetQueryString returns __CreateScheduledSearchV2Input.QueryString, and is useful for accessing the field via an interface.
+func (v *__CreateScheduledSearchV2Input) GetQueryString() string { return v.QueryString }
+
+// GetSearchIntervalSeconds returns __CreateScheduledSearchV2Input.SearchIntervalSeconds, and is useful for accessing the field via an interface.
+func (v *__CreateScheduledSearchV2Input) GetSearchIntervalSeconds() int64 {
+	return v.SearchIntervalSeconds
+}
+
+// GetSearchIntervalOffsetSeconds returns __CreateScheduledSearchV2Input.SearchIntervalOffsetSeconds, and is useful for accessing the field via an interface.
+func (v *__CreateScheduledSearchV2Input) GetSearchIntervalOffsetSeconds() *int64 {
+	return v.SearchIntervalOffsetSeconds
+}
+
+// GetMaxWaitTimeSeconds returns __CreateScheduledSearchV2Input.MaxWaitTimeSeconds, and is useful for accessing the field via an interface.
+func (v *__CreateScheduledSearchV2Input) GetMaxWaitTimeSeconds() *int64 { return v.MaxWaitTimeSeconds }
+
+// GetSchedule returns __CreateScheduledSearchV2Input.Schedule, and is useful for accessing the field via an interface.
+func (v *__CreateScheduledSearchV2Input) GetSchedule() string { return v.Schedule }
+
+// GetTimeZone returns __CreateScheduledSearchV2Input.TimeZone, and is useful for accessing the field via an interface.
+func (v *__CreateScheduledSearchV2Input) GetTimeZone() string { return v.TimeZone }
+
+// GetBackfillLimit returns __CreateScheduledSearchV2Input.BackfillLimit, and is useful for accessing the field via an interface.
+func (v *__CreateScheduledSearchV2Input) GetBackfillLimit() *int { return v.BackfillLimit }
+
+// GetEnabled returns __CreateScheduledSearchV2Input.Enabled, and is useful for accessing the field via an interface.
+func (v *__CreateScheduledSearchV2Input) GetEnabled() bool { return v.Enabled }
+
+// GetActionIdsOrNames returns __CreateScheduledSearchV2Input.ActionIdsOrNames, and is useful for accessing the field via an interface.
+func (v *__CreateScheduledSearchV2Input) GetActionIdsOrNames() []string { return v.ActionIdsOrNames }
+
+// GetRunAsUserID returns __CreateScheduledSearchV2Input.RunAsUserID, and is useful for accessing the field via an interface.
+func (v *__CreateScheduledSearchV2Input) GetRunAsUserID() *string { return v.RunAsUserID }
+
+// GetLabels returns __CreateScheduledSearchV2Input.Labels, and is useful for accessing the field via an interface.
+func (v *__CreateScheduledSearchV2Input) GetLabels() []string { return v.Labels }
+
+// GetQueryTimestampType returns __CreateScheduledSearchV2Input.QueryTimestampType, and is useful for accessing the field via an interface.
+func (v *__CreateScheduledSearchV2Input) GetQueryTimestampType() QueryTimestampType {
+	return v.QueryTimestampType
+}
+
+// GetQueryOwnershipType returns __CreateScheduledSearchV2Input.QueryOwnershipType, and is useful for accessing the field via an interface.
+func (v *__CreateScheduledSearchV2Input) GetQueryOwnershipType() QueryOwnershipType {
+	return v.QueryOwnershipType
+}
+
 // __CreateSlackActionInput is used internally by genqlient
 type __CreateSlackActionInput struct {
 	SearchDomainName string                 `json:"SearchDomainName"`
@@ -14266,6 +15988,20 @@ func (v *__DeleteScheduledSearchByIDInput) GetSearchDomainName() string { return
 
 // GetScheduledSearchID returns __DeleteScheduledSearchByIDInput.ScheduledSearchID, and is useful for accessing the field via an interface.
 func (v *__DeleteScheduledSearchByIDInput) GetScheduledSearchID() string { return v.ScheduledSearchID }
+
+// __DeleteScheduledSearchV2ByIDInput is used internally by genqlient
+type __DeleteScheduledSearchV2ByIDInput struct {
+	SearchDomainName  string `json:"SearchDomainName"`
+	ScheduledSearchID string `json:"ScheduledSearchID"`
+}
+
+// GetSearchDomainName returns __DeleteScheduledSearchV2ByIDInput.SearchDomainName, and is useful for accessing the field via an interface.
+func (v *__DeleteScheduledSearchV2ByIDInput) GetSearchDomainName() string { return v.SearchDomainName }
+
+// GetScheduledSearchID returns __DeleteScheduledSearchV2ByIDInput.ScheduledSearchID, and is useful for accessing the field via an interface.
+func (v *__DeleteScheduledSearchV2ByIDInput) GetScheduledSearchID() string {
+	return v.ScheduledSearchID
+}
 
 // __DeleteSearchDomainInput is used internally by genqlient
 type __DeleteSearchDomainInput struct {
@@ -14576,6 +16312,14 @@ type __ListScheduledSearchesInput struct {
 
 // GetSearchDomainName returns __ListScheduledSearchesInput.SearchDomainName, and is useful for accessing the field via an interface.
 func (v *__ListScheduledSearchesInput) GetSearchDomainName() string { return v.SearchDomainName }
+
+// __ListScheduledSearchesV2Input is used internally by genqlient
+type __ListScheduledSearchesV2Input struct {
+	SearchDomainName string `json:"SearchDomainName"`
+}
+
+// GetSearchDomainName returns __ListScheduledSearchesV2Input.SearchDomainName, and is useful for accessing the field via an interface.
+func (v *__ListScheduledSearchesV2Input) GetSearchDomainName() string { return v.SearchDomainName }
 
 // __RemoveFileInput is used internally by genqlient
 type __RemoveFileInput struct {
@@ -15617,6 +17361,97 @@ func CreateScheduledSearch(
 	return &data_, err_
 }
 
+// The query or mutation executed by CreateScheduledSearchV2.
+const CreateScheduledSearchV2_Operation = `
+mutation CreateScheduledSearchV2 ($SearchDomainName: String!, $Name: String!, $Description: String, $QueryString: String!, $SearchIntervalSeconds: Long!, $SearchIntervalOffsetSeconds: Long, $MaxWaitTimeSeconds: Long, $Schedule: String!, $TimeZone: String!, $BackfillLimit: Int, $Enabled: Boolean!, $ActionIdsOrNames: [String!]!, $RunAsUserID: String, $Labels: [String!]!, $QueryTimestampType: QueryTimestampType!, $QueryOwnershipType: QueryOwnershipType!) {
+	createScheduledSearchV2(input: {viewName:$SearchDomainName,name:$Name,description:$Description,queryString:$QueryString,searchIntervalSeconds:$SearchIntervalSeconds,searchIntervalOffsetSeconds:$SearchIntervalOffsetSeconds,maxWaitTimeSeconds:$MaxWaitTimeSeconds,schedule:$Schedule,timeZone:$TimeZone,backfillLimit:$BackfillLimit,enabled:$Enabled,actionIdsOrNames:$ActionIdsOrNames,runAsUserId:$RunAsUserID,labels:$Labels,queryTimestampType:$QueryTimestampType,queryOwnershipType:$QueryOwnershipType}) {
+		... ScheduledSearchV2Details
+	}
+}
+fragment ScheduledSearchV2Details on ScheduledSearch {
+	id
+	name
+	description
+	queryString
+	searchIntervalSeconds
+	searchIntervalOffsetSeconds
+	maxWaitTimeSeconds
+	timeZone
+	schedule
+	backfillLimitV2
+	enabled
+	actionsV2 {
+		__typename
+		name
+	}
+	labels
+	queryTimestampType
+	queryOwnership {
+		__typename
+		... QueryOwnership
+	}
+}
+fragment QueryOwnership on QueryOwnership {
+	id
+}
+`
+
+func CreateScheduledSearchV2(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	SearchDomainName string,
+	Name string,
+	Description *string,
+	QueryString string,
+	SearchIntervalSeconds int64,
+	SearchIntervalOffsetSeconds *int64,
+	MaxWaitTimeSeconds *int64,
+	Schedule string,
+	TimeZone string,
+	BackfillLimit *int,
+	Enabled bool,
+	ActionIdsOrNames []string,
+	RunAsUserID *string,
+	Labels []string,
+	QueryTimestampType QueryTimestampType,
+	QueryOwnershipType QueryOwnershipType,
+) (*CreateScheduledSearchV2Response, error) {
+	req_ := &graphql.Request{
+		OpName: "CreateScheduledSearchV2",
+		Query:  CreateScheduledSearchV2_Operation,
+		Variables: &__CreateScheduledSearchV2Input{
+			SearchDomainName:            SearchDomainName,
+			Name:                        Name,
+			Description:                 Description,
+			QueryString:                 QueryString,
+			SearchIntervalSeconds:       SearchIntervalSeconds,
+			SearchIntervalOffsetSeconds: SearchIntervalOffsetSeconds,
+			MaxWaitTimeSeconds:          MaxWaitTimeSeconds,
+			Schedule:                    Schedule,
+			TimeZone:                    TimeZone,
+			BackfillLimit:               BackfillLimit,
+			Enabled:                     Enabled,
+			ActionIdsOrNames:            ActionIdsOrNames,
+			RunAsUserID:                 RunAsUserID,
+			Labels:                      Labels,
+			QueryTimestampType:          QueryTimestampType,
+			QueryOwnershipType:          QueryOwnershipType,
+		},
+	}
+	var err_ error
+
+	var data_ CreateScheduledSearchV2Response
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
 // The query or mutation executed by CreateSlackAction.
 const CreateSlackAction_Operation = `
 mutation CreateSlackAction ($SearchDomainName: String!, $ActionName: String!, $Fields: [SlackFieldEntryInput!]!, $Url: String!, $UseProxy: Boolean!) {
@@ -16107,6 +17942,41 @@ func DeleteScheduledSearchByID(
 	var err_ error
 
 	var data_ DeleteScheduledSearchByIDResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by DeleteScheduledSearchV2ByID.
+const DeleteScheduledSearchV2ByID_Operation = `
+mutation DeleteScheduledSearchV2ByID ($SearchDomainName: String!, $ScheduledSearchID: String!) {
+	deleteScheduledSearch(input: {viewName:$SearchDomainName,id:$ScheduledSearchID})
+}
+`
+
+func DeleteScheduledSearchV2ByID(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	SearchDomainName string,
+	ScheduledSearchID string,
+) (*DeleteScheduledSearchV2ByIDResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "DeleteScheduledSearchV2ByID",
+		Query:  DeleteScheduledSearchV2ByID_Operation,
+		Variables: &__DeleteScheduledSearchV2ByIDInput{
+			SearchDomainName:  SearchDomainName,
+			ScheduledSearchID: ScheduledSearchID,
+		},
+	}
+	var err_ error
+
+	var data_ DeleteScheduledSearchV2ByIDResponse
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(
@@ -17932,6 +19802,70 @@ func ListScheduledSearches(
 	var err_ error
 
 	var data_ ListScheduledSearchesResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by ListScheduledSearchesV2.
+const ListScheduledSearchesV2_Operation = `
+query ListScheduledSearchesV2 ($SearchDomainName: String!) {
+	searchDomain(name: $SearchDomainName) {
+		__typename
+		scheduledSearches {
+			... ScheduledSearchV2Details
+		}
+	}
+}
+fragment ScheduledSearchV2Details on ScheduledSearch {
+	id
+	name
+	description
+	queryString
+	searchIntervalSeconds
+	searchIntervalOffsetSeconds
+	maxWaitTimeSeconds
+	timeZone
+	schedule
+	backfillLimitV2
+	enabled
+	actionsV2 {
+		__typename
+		name
+	}
+	labels
+	queryTimestampType
+	queryOwnership {
+		__typename
+		... QueryOwnership
+	}
+}
+fragment QueryOwnership on QueryOwnership {
+	id
+}
+`
+
+func ListScheduledSearchesV2(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	SearchDomainName string,
+) (*ListScheduledSearchesV2Response, error) {
+	req_ := &graphql.Request{
+		OpName: "ListScheduledSearchesV2",
+		Query:  ListScheduledSearchesV2_Operation,
+		Variables: &__ListScheduledSearchesV2Input{
+			SearchDomainName: SearchDomainName,
+		},
+	}
+	var err_ error
+
+	var data_ ListScheduledSearchesV2Response
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(

--- a/internal/api/humiographql/schema/_schema.graphql
+++ b/internal/api/humiographql/schema/_schema.graphql
@@ -28,9 +28,12 @@ Explains why this element was deprecated, usually also including a suggestion fo
 	reason: String
 ) on ENUM_VALUE | FIELD_DEFINITION
 
-directive @preview(
-	reason: String!
-) on ENUM_VALUE | FIELD_DEFINITION
+"""
+Marks the stability level of the field or enum value.
+"""
+directive @stability(
+	level: StabilityLevel!
+) on ENUM_VALUE | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 """
 Data for updating action security policies
@@ -82,6 +85,20 @@ Data for updating action security policies
 	webhookActionUrlAllowList: [String!]
 }
 
+input ActorInput {
+	actorType: ActorType!
+	actorId: String!
+}
+
+"""
+The different types of actors that can be assigned permissions.
+"""
+enum ActorType {
+	User
+	Group
+	Token
+}
+
 """
 Data for adding a label to an alert
 """
@@ -101,20 +118,28 @@ Data for adding a label to an alert
 }
 
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field addFieldAliasMapping
+Input object for field addFieldAliasMapping
 """
 input AddAliasMappingInput {
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field addFieldAliasMapping
+Input object for field addFieldAliasMapping
 """
 	schemaId: String!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field addFieldAliasMapping
+Input object for field addFieldAliasMapping
 """
 	aliasMapping: AliasMappingInput!
 }
 
+input AddCrossOrganizationViewConnectionFiltersInput {
+	name: String!
+	connections: [CrossOrganizationViewConnectionInputModel!]!
+}
+
 type AddGroupMutation {
+"""
+Stability: Long-term
+"""
 	group: Group!
 }
 
@@ -190,6 +215,9 @@ input AddLimitV2Input {
 }
 
 type AddRecentQuery {
+"""
+Stability: Long-term
+"""
 	recentQueries: [RecentQuery!]!
 }
 
@@ -215,6 +243,9 @@ input AddRoleInput {
 }
 
 type AddRoleMutation {
+"""
+Stability: Long-term
+"""
 	role: Role!
 }
 
@@ -252,6 +283,9 @@ input AddStarToFieldInput {
 }
 
 type AddStarToFieldMutation {
+"""
+Stability: Long-term
+"""
 	starredFields: [String!]!
 }
 
@@ -343,6 +377,9 @@ input AddUsersToGroupInput {
 }
 
 type AddUsersToGroupMutation {
+"""
+Stability: Long-term
+"""
 	group: Group!
 }
 
@@ -352,23 +389,23 @@ input AliasInfoInput {
 }
 
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for creating a new alias mapping.
+Input object for creating a new alias mapping.
 """
 input AliasMappingInput {
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for creating a new alias mapping.
+Input object for creating a new alias mapping.
 """
 	name: String!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for creating a new alias mapping.
+Input object for creating a new alias mapping.
 """
 	tags: [TagsInput!]!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for creating a new alias mapping.
+Input object for creating a new alias mapping.
 """
 	aliases: [AliasInfoInput!]!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for creating a new alias mapping.
+Input object for creating a new alias mapping.
 """
 	originalFieldsToKeep: [String!]
 }
@@ -458,6 +495,24 @@ input AnalyticsUserAgent {
 	os: AnalyticsOS!
 }
 
+"""
+The type of archiving to reset. Defaults to RepoOnly
+"""
+enum ArchivalKind {
+"""
+Reset only the repo archiving
+"""
+	RepoOnly
+"""
+Reset only the cluster wide archiving
+"""
+	ClusterWideOnly
+"""
+Reset all the the archiving types
+"""
+	All
+}
+
 input ArgumentInput {
 	key: String!
 	value: String!
@@ -468,11 +523,13 @@ A gap in th array. Null values represent missing bounds
 """
 type ArrayGap {
 """
-[PREVIEW: API under active development] Array gap starts at this index (inclusive)
+Array gap starts at this index (inclusive)
+Stability: Preview
 """
 	startsAtIndex: Int!
 """
-[PREVIEW: API under active development] Array gap ends at this index (exclusive)
+Array gap ends at this index (exclusive)
+Stability: Preview
 """
 	endsAtIndex: Int!
 }
@@ -482,11 +539,13 @@ Array gaps identified for a given prefix
 """
 type ArrayWithGap {
 """
-[PREVIEW: API under active development] Prefix that represents a field up until the point at which a gap was identified. For instance, the field `a[0].b[1]` would give the prefix `a[0].b` as the gap occurs when indexing `b` with `1`. For `a[1].b[0]` we would get the prefix `a`.
+Prefix that represents a field up until the point at which a gap was identified. For instance, the field `a[0].b[1]` would give the prefix `a[0].b` as the gap occurs when indexing `b` with `1`. For `a[1].b[0]` we would get the prefix `a`.
+Stability: Preview
 """
 	lastValidPrefix: String!
 """
-[PREVIEW: API under active development] Gaps identified for array prefix
+Gaps identified for array prefix
+Stability: Preview
 """
 	gaps: [ArrayGap!]!
 }
@@ -502,24 +561,9 @@ This occurs when an assertion was set to run on some output event that wasn't pr
 type AssertionOnFieldWasOrphaned {
 """
 Field being asserted on.
+Stability: Long-term
 """
 	fieldName: String!
-}
-
-input AssignAssetPermissionsToGroupInputType {
-	groupId: String!
-	assetId: String!
-	assetType: AssetPermissionsAssetType!
-	searchDomainId: String
-	assetPermissions: [AssetPermissionInputEnum!]!
-}
-
-input AssignAssetPermissionsToUserInputType {
-	userId: String!
-	assetId: String!
-	assetType: AssetPermissionsAssetType!
-	searchDomainId: String
-	assetPermissions: [AssetPermissionInputEnum!]!
 }
 
 input AssignOrganizationManagementRoleToGroupInput {
@@ -529,6 +573,9 @@ input AssignOrganizationManagementRoleToGroupInput {
 }
 
 type AssignOrganizationManagementRoleToGroupMutation {
+"""
+Stability: Long-term
+"""
 	group: GroupOrganizationManagementRole!
 }
 
@@ -538,6 +585,9 @@ input AssignOrganizationRoleToGroupInput {
 }
 
 type AssignOrganizationRoleToGroupMutation {
+"""
+Stability: Long-term
+"""
 	group: GroupOrganizationRole!
 }
 
@@ -567,6 +617,9 @@ input AssignRoleToGroupInput {
 }
 
 type AssignRoleToGroupMutation {
+"""
+Stability: Long-term
+"""
 	group: SearchDomainRole!
 }
 
@@ -576,6 +629,9 @@ input AssignSystemRoleToGroupInput {
 }
 
 type AssignSystemRoleToGroupMutation {
+"""
+Stability: Long-term
+"""
 	group: GroupSystemRole!
 }
 
@@ -588,12 +644,25 @@ input AssignUserRolesInSearchDomainInput {
 Authentication through Auth0.
 """
 type Auth0Authentication implements AuthenticationMethod{
+"""
+Stability: Long-term
+"""
 	auth0Domain: String!
+"""
+Stability: Long-term
+"""
 	clientId: String!
+"""
+Stability: Long-term
+"""
 	allowSignup: Boolean!
+"""
+Stability: Long-term
+"""
 	redirectUrl: String!
 """
 The display name of the authentication method.
+Stability: Long-term
 """
 	name: String!
 }
@@ -613,6 +682,9 @@ Payload for specifying targets for batch updating query ownership
 }
 
 type BlockIngestMutation {
+"""
+Stability: Short-term
+"""
 	repository: Repository!
 }
 
@@ -621,6 +693,9 @@ input BlockIngestOnOrgInput {
 }
 
 type BooleanResultType {
+"""
+Stability: Long-term
+"""
 	result: Boolean!
 }
 
@@ -628,6 +703,9 @@ type BooleanResultType {
 By proxy authentication. Authentication is provided by proxy.
 """
 type ByProxyAuthentication implements AuthenticationMethod{
+"""
+Stability: Long-term
+"""
 	name: String!
 }
 
@@ -800,10 +878,16 @@ input ConflictResolutionConfiguration {
 }
 
 type CopyDashboardMutation {
+"""
+Stability: Long-term
+"""
 	dashboard: Dashboard!
 }
 
 type CreateActionFromPackageTemplateMutation {
+"""
+Stability: Long-term
+"""
 	action: Action!
 }
 
@@ -942,6 +1026,9 @@ Data for creating an alert
 }
 
 type CreateAlertFromPackageTemplateMutation {
+"""
+Stability: Long-term
+"""
 	alert: Alert!
 }
 
@@ -1009,12 +1096,20 @@ Data for creating an ingest feed that uses AWS S3 and SQS
 	compression: IngestFeedCompression!
 }
 
+input CreateCrossOrgViewInput {
+	name: String!
+	connections: [CrossOrganizationViewConnectionInputModel!]!
+}
+
 input CreateCustomLinkInteractionInput {
 	path: String!
 	customLinkInteractionInput: CustomLinkInteractionInput!
 }
 
 type CreateDashboardFromPackageTemplateMutation {
+"""
+Stability: Long-term
+"""
 	dashboard: Dashboard!
 }
 
@@ -1048,6 +1143,7 @@ input CreateDashboardInput {
 	parameters: [ParameterInput!]
 	description: String
 	updateFrequency: DashboardUpdateFrequencyInput
+	series: [SeriesConfigInput!]
 }
 
 input CreateDashboardLinkInteractionInput {
@@ -1056,6 +1152,9 @@ input CreateDashboardLinkInteractionInput {
 }
 
 type CreateDashboardMutation {
+"""
+Stability: Long-term
+"""
 	dashboard: Dashboard!
 }
 
@@ -1155,6 +1254,11 @@ Data for creating an FDR feed
 Data for creating an FDR feed
 """
 	enabled: Boolean
+}
+
+input CreateFieldAliasSchemaFromTemplateInput {
+	yamlTemplate: String!
+	name: String!
 }
 
 input CreateFieldAliasSchemaInput {
@@ -1376,6 +1480,29 @@ input CreateOrganizationPermissionTokenInput {
 	permissions: [OrganizationPermission!]!
 }
 
+input CreateOrganizationPermissionsTokenV2Input {
+	name: String!
+	expireAt: Long
+	ipFilterId: String
+	organizationPermissions: [OrganizationPermission!]!
+}
+
+"""
+The organization permissions token and its associated metadata.
+"""
+type CreateOrganizationPermissionsTokenV2Output {
+"""
+The organization permissions token.
+Stability: Long-term
+"""
+	token: String!
+"""
+Metadata about the token.
+Stability: Long-term
+"""
+	tokenMetadata: OrganizationPermissionsToken!
+}
+
 """
 Data for creating a PagerDuty action.
 """
@@ -1403,6 +1530,9 @@ Data for creating a PagerDuty action.
 }
 
 type CreateParserFromPackageTemplateMutation {
+"""
+Stability: Long-term
+"""
 	parser: Parser!
 }
 
@@ -1473,12 +1603,31 @@ Input for creating a parser.
 }
 
 type CreateParserMutation {
+"""
+Stability: Long-term
+"""
 	parser: Parser!
 }
 
 input CreatePersonalUserTokenInput {
 	expireAt: Long
 	ipFilterId: String
+}
+
+"""
+The personal user token and its associated metadata.
+"""
+type CreatePersonalUserTokenV2Output {
+"""
+The personal user token.
+Stability: Long-term
+"""
+	token: String!
+"""
+Metadata about the token.
+Stability: Long-term
+"""
+	tokenMetadata: PersonalUserToken!
 }
 
 """
@@ -1538,10 +1687,16 @@ Data for creating a remote cluster connection
 }
 
 type CreateRepositoryMutation {
+"""
+Stability: Long-term
+"""
 	repository: Repository!
 }
 
 type CreateSavedQueryFromPackageTemplateMutation {
+"""
+Stability: Long-term
+"""
 	savedQuery: SavedQuery!
 }
 
@@ -1561,6 +1716,9 @@ input CreateSavedQueryInput {
 }
 
 type CreateSavedQueryPayload {
+"""
+Stability: Long-term
+"""
 	savedQuery: SavedQuery!
 }
 
@@ -1780,6 +1938,76 @@ Data for creating a scheduled search from a yaml template.
 	yamlTemplate: YAML!
 }
 
+"""
+Data for creating a scheduled search
+"""
+input CreateScheduledSearchV2 {
+"""
+Data for creating a scheduled search
+"""
+	viewName: String!
+"""
+Data for creating a scheduled search
+"""
+	name: String!
+"""
+Data for creating a scheduled search
+"""
+	description: String
+"""
+Data for creating a scheduled search
+"""
+	queryString: String!
+"""
+Data for creating a scheduled search
+"""
+	searchIntervalSeconds: Long!
+"""
+Data for creating a scheduled search
+"""
+	searchIntervalOffsetSeconds: Long
+"""
+Data for creating a scheduled search
+"""
+	maxWaitTimeSeconds: Long
+"""
+Data for creating a scheduled search
+"""
+	schedule: String!
+"""
+Data for creating a scheduled search
+"""
+	timeZone: String!
+"""
+Data for creating a scheduled search
+"""
+	backfillLimit: Int
+"""
+Data for creating a scheduled search
+"""
+	enabled: Boolean
+"""
+Data for creating a scheduled search
+"""
+	actionIdsOrNames: [String!]!
+"""
+Data for creating a scheduled search
+"""
+	labels: [String!]
+"""
+Data for creating a scheduled search
+"""
+	runAsUserId: String
+"""
+Data for creating a scheduled search
+"""
+	queryOwnershipType: QueryOwnershipType!
+"""
+Data for creating a scheduled search
+"""
+	queryTimestampType: QueryTimestampType!
+}
+
 input CreateSearchLinkInteractionInput {
 	path: String!
 	searchLinkInteractionInput: SearchLinkInteractionInput!
@@ -1816,6 +2044,29 @@ input CreateSystemPermissionTokenInput {
 	expireAt: Long
 	ipFilterId: String
 	permissions: [SystemPermission!]!
+}
+
+input CreateSystemPermissionTokenV2Input {
+	name: String!
+	expireAt: Long
+	ipFilterId: String
+	systemPermissions: [SystemPermission!]!
+}
+
+"""
+The system permissions token and its associated metadata.
+"""
+type CreateSystemPermissionsTokenV2Output {
+"""
+The system permissions token.
+Stability: Long-term
+"""
+	token: String!
+"""
+Metadata about the token.
+Stability: Long-term
+"""
+	tokenMetadata: SystemPermissionsToken!
 }
 
 """
@@ -1870,6 +2121,31 @@ input CreateViewPermissionsTokenInput {
 	permissions: [Permission!]!
 }
 
+input CreateViewPermissionsTokenV2Input {
+	name: String!
+	expireAt: Long
+	ipFilterId: String
+	viewIds: [String!]!
+	viewPermissions: [Permission!]!
+	assetPermissionAssignments: [ViewPermissionsTokenAssetPermissionAssignmentInput!]
+}
+
+"""
+The view permissions token and its associated metadata.
+"""
+type CreateViewPermissionsTokenV2Output {
+"""
+The view permissions token.
+Stability: Long-term
+"""
+	token: String!
+"""
+Metadata about the token.
+Stability: Long-term
+"""
+	tokenMetadata: ViewPermissionsToken!
+}
+
 """
 Data for creating a webhook action.
 """
@@ -1906,6 +2182,12 @@ Data for creating a webhook action.
 Data for creating a webhook action.
 """
 	useProxy: Boolean!
+}
+
+input CrossOrganizationViewConnectionInputModel {
+	repoName: String!
+	filter: String!
+	organizationId: String!
 }
 
 input CustomLinkInteractionInput {
@@ -2017,6 +2299,9 @@ The data for deleting a dashboard
 }
 
 type DeleteDashboardMutation {
+"""
+Stability: Long-term
+"""
 	dashboard: Dashboard!
 }
 
@@ -2185,6 +2470,11 @@ input DisableFieldAliasSchemaOnViewInput {
 	schemaId: String!
 }
 
+input DisableFieldAliasSchemaOnViewsInput {
+	schemaId: String!
+	viewNames: [String!]!
+}
+
 """
 Data for disabling a filter alert
 """
@@ -2248,57 +2538,78 @@ An email action.
 type EmailAction implements Action{
 """
 List of email addresses to send an email to.
+Stability: Long-term
 """
 	recipients: [String!]!
 """
 Subject of the email. Can be templated with values from the result.
+Stability: Long-term
 """
 	subjectTemplate: String
 """
 Body of the email. Can be templated with values from the result.
+Stability: Long-term
 """
 	bodyTemplate: String
 """
 Defines whether the action should use the configured proxy to make web requests.
+Stability: Long-term
 """
 	useProxy: Boolean!
 """
-Whether the result set should be be attached as a CSV file.
+Whether the result set should be attached as a CSV file.
+Stability: Long-term
 """
 	attachCsv: Boolean!
 """
 The name of the action.
+Stability: Long-term
 """
 	name: String!
 """
 The display name of the action.
+Stability: Long-term
 """
 	displayName: String!
 """
 The id of the action.
+Stability: Long-term
 """
 	id: String!
 """
 A template that can be used to recreate the action.
+Stability: Long-term
 """
 	yamlTemplate: YAML!
+"""
+Stability: Long-term
+"""
 	packageId: VersionedPackageSpecifier
 """
-The package if any which the action is part of.
+The package, if any, which the action is part of.
+Stability: Long-term
 """
 	package: PackageInstallation
 """
 False if this type of action is disabled because of a security policy, true otherwise
+Stability: Long-term
 """
 	isAllowedToRun: Boolean!
 """
 True if this action is used by triggers, where the query is run by the organization. If true, then the OrganizationOwnedQueries permission is required to edit the action.
+Stability: Long-term
 """
 	requiresOrganizationOwnedQueriesPermissionToEdit: Boolean!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Allowed asset actions
+Allowed asset actions
+Stability: Preview
 """
 	allowedActions: [AssetAction!]!
+"""
+The resource identifier for this action.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 """
@@ -2427,8 +2738,17 @@ input EnforceSubdomainsInput {
 Information about an enrolled collector
 """
 type EnrolledCollector {
+"""
+Stability: Short-term
+"""
 	id: String!
+"""
+Stability: Short-term
+"""
 	configId: String
+"""
+Stability: Short-term
+"""
 	machineId: String!
 }
 
@@ -2436,6 +2756,9 @@ type EnrolledCollector {
 Enterprise only authentication.
 """
 type EnterpriseOnlyAuthentication implements AuthenticationMethod{
+"""
+Stability: Long-term
+"""
 	name: String!
 }
 
@@ -2445,10 +2768,12 @@ A single field in an event with a name and a value
 type EventField {
 """
 The name of the field
+Stability: Long-term
 """
 	fieldName: String!
 """
 The value of the field
+Stability: Long-term
 """
 	value: String!
 }
@@ -2459,10 +2784,12 @@ A single field in an event with a key and a value
 type Field {
 """
 The key of the field
+Stability: Long-term
 """
 	key: String!
 """
 The value of the field
+Stability: Long-term
 """
 	value: String!
 }
@@ -2479,6 +2806,7 @@ Assertion results can be uniquely identified by the output event index and the f
 type FieldHadConflictingAssertions {
 """
 Field being asserted on.
+Stability: Long-term
 """
 	fieldName: String!
 }
@@ -2489,14 +2817,17 @@ An assertion was made that a field had some value, and this assertion failed due
 type FieldHadUnexpectedValue {
 """
 Field being asserted on.
+Stability: Long-term
 """
 	fieldName: String!
 """
 Value that was asserted to be contained in the field.
+Stability: Long-term
 """
 	expectedValue: String!
 """
 The actual value of the field. Note that this is null in the case where the field wasn't present at all.
+Stability: Long-term
 """
 	actualValue: String
 }
@@ -2527,10 +2858,12 @@ An assertion was made that a field should not be present, and this assertion fai
 type FieldUnexpectedlyPresent {
 """
 Field being asserted on.
+Stability: Long-term
 """
 	fieldName: String!
 """
 The value that the field contained.
+Stability: Long-term
 """
 	actualValue: String!
 }
@@ -2541,63 +2874,72 @@ A dashboard parameter where suggestions are taken from uploaded files.
 type FileDashboardParameter implements DashboardParameter{
 """
 The name of the file to perform lookups in.
+Stability: Long-term
 """
 	fileName: String!
 """
 The column where the value of suggestions are taken from,
+Stability: Long-term
 """
 	valueColumn: String!
 """
 The column where the label of suggestions are taken from,
+Stability: Long-term
 """
 	labelColumn: String
 """
 Fields and values, where an entry in a file must match one of the given values for each field.
+Stability: Long-term
 """
 	valueFilters: [FileParameterValueFilter!]!
 """
 Regex patterns used to block parameter input.
+Stability: Long-term
 """
 	invalidInputPatterns: [String!]
 """
 Message when parameter input is blocked.
+Stability: Long-term
 """
 	invalidInputMessage: String
 """
 The ID of the parameter.
+Stability: Long-term
 """
 	id: String!
 """
 The label or 'name' displayed next to the input for the variable to make it more human-readable.
+Stability: Long-term
 """
 	label: String!
 """
 The value assigned to the parameter on dashboard load, if no other value is specified.
+Stability: Long-term
 """
 	defaultValueV2: String
 """
 A number that determines the order in which parameters are displayed on a dashboard. If null, the parameter is ordered after other parameters in alphanumerical order.
+Stability: Long-term
 """
 	order: Int
 """
 A number that determines the width of a parameter.
+Stability: Long-term
 """
 	width: Int
-"""
-[PREVIEW: The multi-value parameters feature is still in development.] A flag indicating whether the parameter supports having multiple values
-"""
-	isMultiParam: Boolean
-"""
-[PREVIEW: The multi-value parameters feature is still in development.] The value assigned to the multi-value parameter on dashboard load, if no other value is specified. This replaces defaultValue whenever isMultiParam is true
-"""
-	defaultMultiValues: [String!]
 }
 
 """
 A filter to reduce entries from files down to those with a matching value in the field.
 """
 type FileParameterValueFilter {
+"""
+Stability: Long-term
+"""
 	field: String!
+"""
+Stability: Long-term
+"""
 	values: [String!]!
 }
 
@@ -2611,47 +2953,59 @@ input FilterInput {
 A dashboard parameter with a fixed list of values to select from.
 """
 type FixedListDashboardParameter implements DashboardParameter{
+"""
+Stability: Long-term
+"""
 	values: [FixedListParameterOption!]!
 """
 The ID of the parameter.
+Stability: Long-term
 """
 	id: String!
 """
 The label or 'name' displayed next to the input for the variable to make it more human-readable.
+Stability: Long-term
 """
 	label: String!
 """
 The value assigned to the parameter on dashboard load, if no other value is specified.
+Stability: Long-term
 """
 	defaultValueV2: String
 """
 A number that determines the order in which parameters are displayed on a dashboard. If null, the parameter is ordered after other parameters in alphanumerical order.
+Stability: Long-term
 """
 	order: Int
 """
 A number that determines the width of a parameter.
+Stability: Long-term
 """
 	width: Int
-"""
-[PREVIEW: The multi-value parameters feature is still in development.] A flag indicating whether the parameter supports having multiple values
-"""
-	isMultiParam: Boolean
-"""
-[PREVIEW: The multi-value parameters feature is still in development.] The value assigned to the multi-value parameter on dashboard load, if no other value is specified. This replaces defaultValue whenever isMultiParam is true
-"""
-	defaultMultiValues: [String!]
 }
 
 """
 An option in a fixed list parameter.
 """
 type FixedListParameterOption {
+"""
+Stability: Long-term
+"""
 	label: String!
+"""
+Stability: Long-term
+"""
 	value: String!
 }
 
 type FleetConfigurationTest {
+"""
+Stability: Short-term
+"""
 	collectorIds: [String!]!
+"""
+Stability: Short-term
+"""
 	configId: String!
 }
 
@@ -2661,40 +3015,39 @@ A dashboard parameter without restrictions or suggestions.
 type FreeTextDashboardParameter implements DashboardParameter{
 """
 Regex patterns used to block parameter input.
+Stability: Long-term
 """
 	invalidInputPatterns: [String!]
 """
 Message when parameter input is blocked.
+Stability: Long-term
 """
 	invalidInputMessage: String
 """
 The ID of the parameter.
+Stability: Long-term
 """
 	id: String!
 """
 The label or 'name' displayed next to the input for the variable to make it more human-readable.
+Stability: Long-term
 """
 	label: String!
 """
 The value assigned to the parameter on dashboard load, if no other value is specified.
+Stability: Long-term
 """
 	defaultValueV2: String
 """
 A number that determines the order in which parameters are displayed on a dashboard. If null, the parameter is ordered after other parameters in alphanumerical order.
+Stability: Long-term
 """
 	order: Int
 """
 A number that determines the width of a parameter.
+Stability: Long-term
 """
 	width: Int
-"""
-[PREVIEW: The multi-value parameters feature is still in development.] A flag indicating whether the parameter supports having multiple values
-"""
-	isMultiParam: Boolean
-"""
-[PREVIEW: The multi-value parameters feature is still in development.] The value assigned to the multi-value parameter on dashboard load, if no other value is specified. This replaces defaultValue whenever isMultiParam is true
-"""
-	defaultMultiValues: [String!]
 }
 
 """
@@ -2715,6 +3068,9 @@ Input list of function names
 The organization management roles of the group.
 """
 type GroupOrganizationManagementRole {
+"""
+Stability: Long-term
+"""
 	role: Role!
 }
 
@@ -2729,10 +3085,12 @@ A http request header.
 type HttpHeaderEntry {
 """
 Key of a http(s) header.
+Stability: Long-term
 """
 	header: String!
 """
 Value of a http(s) header.
+Stability: Long-term
 """
 	value: String!
 }
@@ -2757,41 +3115,58 @@ A LogScale repository action.
 type HumioRepoAction implements Action{
 """
 Humio ingest token for the dataspace that the action should ingest into.
+Stability: Long-term
 """
 	ingestToken: String!
 """
 The name of the action.
+Stability: Long-term
 """
 	name: String!
 """
 The display name of the action.
+Stability: Long-term
 """
 	displayName: String!
 """
 The id of the action.
+Stability: Long-term
 """
 	id: String!
 """
 A template that can be used to recreate the action.
+Stability: Long-term
 """
 	yamlTemplate: YAML!
+"""
+Stability: Long-term
+"""
 	packageId: VersionedPackageSpecifier
 """
-The package if any which the action is part of.
+The package, if any, which the action is part of.
+Stability: Long-term
 """
 	package: PackageInstallation
 """
 False if this type of action is disabled because of a security policy, true otherwise
+Stability: Long-term
 """
 	isAllowedToRun: Boolean!
 """
 True if this action is used by triggers, where the query is run by the organization. If true, then the OrganizationOwnedQueries permission is required to edit the action.
+Stability: Long-term
 """
 	requiresOrganizationOwnedQueriesPermissionToEdit: Boolean!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Allowed asset actions
+Allowed asset actions
+Stability: Preview
 """
 	allowedActions: [AssetAction!]!
+"""
+The resource identifier for this action.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 input IPFilterIdInput {
@@ -2810,6 +3185,10 @@ input IPFilterUpdateInput {
 }
 
 type Ignored implements contractual{
+"""
+
+Stability: Long-term
+"""
 	includeUsage: Boolean!
 }
 
@@ -2868,14 +3247,23 @@ input InstallPackageFromRegistryInput {
 }
 
 type InstallPackageFromRegistryResult {
+"""
+Stability: Long-term
+"""
 	package: Package2!
 }
 
 type InstallPackageFromZipResult {
+"""
+Stability: Long-term
+"""
 	wasSuccessful: Boolean!
 }
 
 type InteractionId {
+"""
+Stability: Long-term
+"""
 	id: String!
 }
 
@@ -2885,26 +3273,32 @@ A Kafka event forwarder
 type KafkaEventForwarder implements EventForwarder{
 """
 The Kafka topic the events should be forwarded to
+Stability: Long-term
 """
 	topic: String!
 """
 The Kafka producer configuration used to forward events in the form of properties (x.y.z=abc). See https://library.humio.com/humio-server/ingesting-data-event-forwarders.html#kafka-configuration.
+Stability: Long-term
 """
 	properties: String!
 """
 Id of the event forwarder
+Stability: Long-term
 """
 	id: String!
 """
 Name of the event forwarder
+Stability: Long-term
 """
 	name: String!
 """
 Description of the event forwarder
+Stability: Long-term
 """
 	description: String!
 """
 Is the event forwarder enabled
+Stability: Long-term
 """
 	enabled: Boolean!
 }
@@ -2928,7 +3322,15 @@ Defines how the external function is executed.
 }
 
 type Limited implements contractual{
+"""
+
+Stability: Long-term
+"""
 	limit: Long!
+"""
+
+Stability: Long-term
+"""
 	includeUsage: Boolean!
 }
 
@@ -2941,13 +3343,37 @@ input LinkInput {
 A widget that lists links to other dashboards.
 """
 type LinkWidget implements Widget{
+"""
+Stability: Preview
+"""
 	labels: [String!]!
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	title: String!
+"""
+Stability: Long-term
+"""
 	description: String
+"""
+Stability: Long-term
+"""
 	x: Int!
+"""
+Stability: Long-term
+"""
 	y: Int!
+"""
+Stability: Long-term
+"""
 	width: Int!
+"""
+Stability: Long-term
+"""
 	height: Int!
 }
 
@@ -2957,27 +3383,36 @@ A local cluster connection.
 type LocalClusterConnection implements ClusterConnection{
 """
 Id of the local view to connect with
+Stability: Short-term
 """
 	targetViewId: String!
 """
 Name of the local view to connect with
+Stability: Short-term
 """
 	targetViewName: RepoOrViewName!
+"""
+Stability: Short-term
+"""
 	targetViewType: LocalTargetType!
 """
 Id of the connection
+Stability: Short-term
 """
 	id: String!
 """
 Cluster identity of the connection
+Stability: Short-term
 """
 	clusterId: String!
 """
 Cluster connection tags
+Stability: Short-term
 """
 	tags: [ClusterConnectionTag!]!
 """
 Cluster connection query prefix
+Stability: Short-term
 """
 	queryPrefix: String!
 }
@@ -3047,9 +3482,53 @@ input MigrateLimitsInput {
 	defaultLimit: String
 }
 
+"""
+Modified by a supporter
+"""
+type ModifiedInfoSupporter implements ModifiedInfo{
+"""
+Timestamp of when the asset was last modified
+Stability: Long-term
+"""
+	modifiedAt: Long!
+}
+
+"""
+Modified using a token
+"""
+type ModifiedInfoToken implements ModifiedInfo{
+"""
+Id of the token used to modify the asset.
+Stability: Long-term
+"""
+	tokenId: String!
+"""
+Timestamp of when the asset was last modified
+Stability: Long-term
+"""
+	modifiedAt: Long!
+}
+
+"""
+Modified by a user
+"""
+type ModifiedInfoUser implements ModifiedInfo{
+"""
+User who modified the asset. If null, the user is deleted.
+Stability: Long-term
+"""
+	user: User
+"""
+Timestamp of when the asset was last modified
+Stability: Long-term
+"""
+	modifiedAt: Long!
+}
+
 type Mutation {
 """
-[PREVIEW: Feature still in development] Will clear the search limit and excluded repository making future searches done on this view behave normally, i.e. having no search time-limit applied
+Will clear the search limit and excluded repository making future searches done on this view behave normally, i.e. having no search time-limit applied
+Stability: Preview
 """
 	ClearSearchLimitForSearchDomain(
 """
@@ -3058,7 +3537,8 @@ Data for clearing the search limit on a search domain.
 		input: ClearSearchLimitForSearchDomain!
 	): View!
 """
-[PREVIEW: Feature still in development] Will update search limit, which will restrict future searches to the specified limit, a list of repository names can be supplied and will not be restricted by this limit.
+Will update search limit, which will restrict future searches to the specified limit, a list of repository names can be supplied and will not be restricted by this limit.
+Stability: Preview
 """
 	SetSearchLimitForSearchDomain(
 """
@@ -3068,10 +3548,12 @@ Data for updating search limit on a search domain.
 	): View!
 """
 Client accepts LogScale's Terms and Conditions without providing any additional info
+Stability: Long-term
 """
 	acceptTermsAndConditions: Account!
 """
 Activates a user account supplying additional personal info. By activating the account the client accepts LogScale's Terms and Conditions: https://www.humio.com/terms-and-conditions
+Stability: Long-term
 """
 	activateAccount(
 """
@@ -3110,6 +3592,7 @@ Optional phone number. Required for community mode.
 	): Account!
 """
 Add a label to an alert.
+Stability: Long-term
 """
 	addAlertLabelV2(
 """
@@ -3118,7 +3601,14 @@ Data for adding a label to an alert
 		input: AddAlertLabel!
 	): Alert!
 """
+Stability: Preview
+"""
+	addCrossOrgViewConnections(
+		input: AddCrossOrganizationViewConnectionFiltersInput!
+	): View!
+"""
 Add a new filter to a dashboard's list of filters.
+Stability: Long-term
 """
 	addDashboardFilter(
 		name: String!
@@ -3128,25 +3618,29 @@ Add a new filter to a dashboard's list of filters.
 	): Dashboard!
 """
 Add a label to a dashboard.
+Stability: Long-term
 """
 	addDashboardLabel(
 		id: String!
 		label: String!
 	): Dashboard!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Adds a field alias mapping to an existing schema. Returns the ID of the alias mapping if created successfully.
+Adds a field alias mapping to an existing schema. Returns the ID of the alias mapping if created successfully.
+Stability: Long-term
 """
 	addFieldAliasMapping(
 		input: AddAliasMappingInput!
 	): String!
 """
-[PREVIEW: Internal testing.] Enable functions for use with specified language version.
+Enable functions for use with specified language version.
+Stability: Preview
 """
 	addFunctionsToAllowList(
 		input: FunctionListInput!
 	): Boolean!
 """
 Creates a new group.
+Stability: Long-term
 """
 	addGroup(
 		displayName: String!
@@ -3154,6 +3648,7 @@ Creates a new group.
 	): AddGroupMutation!
 """
 Create a new Ingest API Token.
+Stability: Long-term
 """
 	addIngestTokenV3(
 		input: AddIngestTokenV3Input!
@@ -3166,33 +3661,41 @@ Add a Limit to the given organization
 	): Boolean!
 """
 Add a Limit to the given organization
+Stability: Long-term
 """
 	addLimitV2(
 		input: AddLimitV2Input!
 	): LimitV2!
+"""
+Stability: Long-term
+"""
 	addLoginBridgeAllowedUsers(
 		userID: String!
 	): LoginBridge!
 """
 Add or update default Query Quota Settings
+Stability: Short-term
 """
 	addOrUpdateQueryQuotaDefaultSettings(
 		input: QueryQuotaDefaultSettingsInput!
 	): QueryQuotaDefaultSettings!
 """
 Add or update existing Query Quota User Settings
+Stability: Short-term
 """
 	addOrUpdateQueryQuotaUserSettings(
 		input: QueryQuotaUserSettingsInput!
 	): QueryQuotaUserSettings!
 """
 Adds a query to the list of recent queries. The query is a JSON encoded query and visualization structure produced by the UI.
+Stability: Long-term
 """
 	addRecentQuery(
 		input: AddRecentQueryInput!
 	): AddRecentQuery!
 """
 Add a label to a scheduled search.
+Stability: Long-term
 """
 	addScheduledSearchLabel(
 """
@@ -3211,10 +3714,14 @@ Data for adding a star to an alert
 	): Alert!
 """
 Add a star to a dashboard.
+Stability: Long-term
 """
 	addStarToDashboard(
 		id: String!
 	): Dashboard!
+"""
+Stability: Long-term
+"""
 	addStarToField(
 		input: AddStarToFieldInput!
 	): AddStarToFieldMutation!
@@ -3229,18 +3736,21 @@ Data for adding a star to a scheduled search
 	): ScheduledSearch!
 """
 Add a star to a repository or view.
+Stability: Long-term
 """
 	addStarToSearchDomain(
 		name: String!
 	): SearchDomain!
 """
-[PREVIEW: Requires the feature enabled for the organization.] Adds a subdomain to the organization. Becomes primary subdomain if no primary has been set, and secondary otherwise
+Adds a subdomain to the organization. Becomes primary subdomain if no primary has been set, and secondary otherwise
+Stability: Preview
 """
 	addSubdomain(
 		input: AddSubdomainInput!
 	): Organization!
 """
 Blocklist a query based on a pattern based on a regex or exact match.
+Stability: Long-term
 """
 	addToBlocklist(
 """
@@ -3250,6 +3760,7 @@ Data for adding to the blocklist
 	): [BlockedQuery!]!
 """
 Blocklist a query based on a pattern based on a regex or exact match.
+Stability: Long-term
 """
 	addToBlocklistById(
 """
@@ -3258,7 +3769,7 @@ Data for adding to the blocklist
 		input: AddToBlocklistByIdInput!
 	): [BlockedQuery!]!
 """
-[PREVIEW: Under development] 
+Stability: Long-term
 """
 	addToLogCollectorConfigurationTest(
 		configId: String!
@@ -3266,74 +3777,77 @@ Data for adding to the blocklist
 	): FleetConfigurationTest!
 """
 Add or invite a user. Calling this with an invitation token, will activate the account. By activating the account the client accepts LogScale's Terms and Conditions: https://www.humio.com/terms-and-conditions
+Stability: Long-term
 """
 	addUserV2(
 		input: AddUserInputV2!
 	): userOrPendingUser!
 """
 Adds users to an existing group.
+Stability: Long-term
 """
 	addUsersToGroup(
 		input: AddUsersToGroupInput!
 	): AddUsersToGroupMutation!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Assigns asset permissions to group. Unassignment can be done by providing an empty list of asset permissions for an asset
-"""
-	assignAssetPermissionsToGroup(
-		input: AssignAssetPermissionsToGroupInputType!
-	): Group!
-"""
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Assigns asset permissions to user. Unassignment can be done by providing an empty list of asset permissions for an asset
-"""
-	assignAssetPermissionsToUser(
-		input: AssignAssetPermissionsToUserInputType!
-	): User!
-"""
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	assignLogCollectorConfiguration(
 		configId: String
 		id: String!
 	): Boolean!
 """
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	assignLogCollectorsToConfiguration(
 		configId: String
 		ids: [String!]
 	): [EnrolledCollector!]!
 """
-[PREVIEW: Experimental feature to allow assigning permissions to manage a subset of organizations.] Assigns an organization management role to a group for the provided organizations.
+Assigns an organization management role to a group for the provided organizations.
+Stability: Preview
 """
 	assignOrganizationManagementRoleToGroup(
 		input: AssignOrganizationManagementRoleToGroupInput!
 	): AssignOrganizationManagementRoleToGroupMutation!
 """
-[PREVIEW: No note] Assigns a organization role to a group.
+Assigns an organization role to a group.
+Stability: Long-term
 """
 	assignOrganizationRoleToGroup(
 		input: AssignOrganizationRoleToGroupInput!
 	): AssignOrganizationRoleToGroupMutation!
 """
 Assign an ingest token to be associated with a parser.
+Stability: Long-term
 """
 	assignParserToIngestTokenV2(
 		input: AssignParserToIngestTokenInputV2!
 	): IngestToken!
 """
+Assigns permissions to users or groups for resource.
+Stability: Preview
+"""
+	assignPermissionsForResources(
+		input: [PermissionAssignmentInputType!]!
+	): [UserOrGroup!]!
+"""
 Assigns a role to a group for a given view. If called with overrideExistingAssignmentsForView=false, this mutation can assign multiple roles for the same view. Calling with overrideExistingAssignmentsForView=false is thus only available if the MultipleViewRoleBindings feature is enabled.
+Stability: Long-term
 """
 	assignRoleToGroup(
 		input: AssignRoleToGroupInput!
 	): AssignRoleToGroupMutation!
 """
 Assigns a system role to a group.
+Stability: Long-term
 """
 	assignSystemRoleToGroup(
 		input: AssignSystemRoleToGroupInput!
 	): AssignSystemRoleToGroupMutation!
 """
 Assign node tasks. This is not a replacement, but will add to the existing assigned node tasks. Returns the set of assigned tasks after the assign operation has completed.
+Stability: Short-term
 """
 	assignTasks(
 """
@@ -3346,19 +3860,22 @@ List of tasks to assign.
 		tasks: [NodeTaskEnum!]!
 	): [NodeTaskEnum!]!
 """
-[PREVIEW: This mutation is dependent on the MultipleViewRoleBindings feature being enabled.] Assigns roles for the user in the search domain. This mutation allows assigning multiple roles for the same view and is thus dependent on the MultipleViewRoleBindings feature being enabled.
+Assigns roles for the user in the search domain. This mutation allows assigning multiple roles for the same view and is thus dependent on the MultipleViewRoleBindings feature being enabled.
+Stability: Preview
 """
 	assignUserRolesInSearchDomain(
 		input: AssignUserRolesInSearchDomainInput!
 	): [User!]!
 """
 Batch update query ownership to run queries on behalf of the organization for triggers and shared dashboards.
+Stability: Long-term
 """
 	batchUpdateQueryOwnership(
 		input: BatchUpdateQueryOwnershipInput!
 	): Boolean!
 """
 Block ingest to the specified repository for a number of seconds (at most 1 year) into the future
+Stability: Short-term
 """
 	blockIngest(
 		repositoryName: String!
@@ -3366,16 +3883,22 @@ Block ingest to the specified repository for a number of seconds (at most 1 year
 	): BlockIngestMutation!
 """
 Set whether the organization is blocking ingest and dataspaces are pausing ingest
+Stability: Long-term
 """
 	blockIngestOnOrg(
 		input: BlockIngestOnOrgInput!
 	): Organization!
 """
 Cancel a previously submitted redaction. Returns true if the redaction was cancelled, false otherwise. Cancellation is best effort. If some events have already been redacted, they are not restored.
+Stability: Long-term
 """
 	cancelRedactEvents(
 		input: CancelRedactEventsInput!
 	): Boolean!
+"""
+Updates the user and group role assignments in the search domain.
+Stability: Long-term
+"""
 	changeUserAndGroupRolesForSearchDomain(
 		searchDomainId: String!
 		groups: [GroupRoleAssignment!]!
@@ -3383,10 +3906,12 @@ Cancel a previously submitted redaction. Returns true if the redaction was cance
 	): [UserOrGroup!]!
 """
 Set CID of provisioned organization
+Stability: Short-term
 """
 	clearCid: Organization!
 """
 Clear the error status on an aggregate alert. The status will be updated if the error reoccurs.
+Stability: Long-term
 """
 	clearErrorOnAggregateAlert(
 """
@@ -3396,6 +3921,7 @@ Data for clearing the error on an aggregate alert.
 	): AggregateAlert!
 """
 Clear the error status on an alert. The status will be updated if the error reoccurs.
+Stability: Long-term
 """
 	clearErrorOnAlert(
 """
@@ -3405,6 +3931,7 @@ Data for clearing the error on an alert
 	): Alert!
 """
 Clear the error status on a filter alert. The status will be updated if the error reoccurs.
+Stability: Long-term
 """
 	clearErrorOnFilterAlert(
 """
@@ -3414,6 +3941,7 @@ Data for clearing the error on a filter alert
 	): FilterAlert!
 """
 Clear the error status on a scheduled search. The status will be updated if the error reoccurs.
+Stability: Long-term
 """
 	clearErrorOnScheduledSearch(
 """
@@ -3423,24 +3951,28 @@ Data for clearing the error on a scheduled search
 	): ScheduledSearch!
 """
 Clears UI configurations for all fields for the current user
+Stability: Long-term
 """
 	clearFieldConfigurations(
 		input: ClearFieldConfigurationsInput!
 	): Boolean!
 """
 Clear recent queries for current user on a given view or repository.
+Stability: Long-term
 """
 	clearRecentQueries(
 		input: ClearRecentQueriesInput!
 	): Boolean!
 """
 Create a clone of an existing parser.
+Stability: Long-term
 """
 	cloneParser(
 		input: CloneParserInput!
 	): Parser!
 """
 Unregisters a node from the cluster.
+Stability: Long-term
 """
 	clusterUnregisterNode(
 """
@@ -3454,6 +3986,7 @@ ID of the node to unregister.
 	): UnregisterNodeMutation!
 """
 Create a clone of a dashboard.
+Stability: Long-term
 """
 	copyDashboard(
 		id: String!
@@ -3472,6 +4005,7 @@ The name the copied dashboard should have.
 	): CopyDashboardMutation!
 """
 Create an action from a package action template.
+Stability: Long-term
 """
 	createActionFromPackageTemplate(
 """
@@ -3493,6 +4027,7 @@ The name of the new action to create.
 	): CreateActionFromPackageTemplateMutation!
 """
 Create an action from yaml template
+Stability: Long-term
 """
 	createActionFromTemplate(
 """
@@ -3502,6 +4037,7 @@ Data for creating an action from a yaml template
 	): Action!
 """
 Create an aggregate alert.
+Stability: Long-term
 """
 	createAggregateAlert(
 """
@@ -3511,6 +4047,7 @@ Data for creating an aggregate alert.
 	): AggregateAlert!
 """
 Create an alert.
+Stability: Long-term
 """
 	createAlert(
 """
@@ -3550,6 +4087,7 @@ Data for creating an alert from a yaml template
 	): Alert!
 """
 Create an ingest feed that uses AWS S3 and SQS
+Stability: Long-term
 """
 	createAwsS3SqsIngestFeed(
 """
@@ -3558,19 +4096,28 @@ Data for creating an ingest feed that uses AWS S3 and SQS
 		input: CreateAwsS3SqsIngestFeed!
 	): IngestFeed!
 """
-[PREVIEW: in development.] Create a custom link interaction.
+Stability: Preview
+"""
+	createCrossOrgView(
+		input: CreateCrossOrgViewInput!
+	): View!
+"""
+Create a custom link interaction.
+Stability: Long-term
 """
 	createCustomLinkInteraction(
 		input: CreateCustomLinkInteractionInput!
 	): InteractionId!
 """
 Create a dashboard.
+Stability: Long-term
 """
 	createDashboard(
 		input: CreateDashboardInput!
 	): CreateDashboardMutation!
 """
 Create a dashboard from a package dashboard template.
+Stability: Long-term
 """
 	createDashboardFromPackageTemplate(
 """
@@ -3592,6 +4139,7 @@ The name of the new dashboard to create.
 	): CreateDashboardFromPackageTemplateMutation!
 """
 Create a dashboard from a yaml specification.
+Stability: Long-term
 """
 	createDashboardFromTemplateV2(
 """
@@ -3600,19 +4148,22 @@ Data for creating a dashboard from a yaml specification.
 		input: CreateDashboardFromTemplateV2Input!
 	): Dashboard!
 """
-[PREVIEW: in development.] Create a dashboard link interaction.
+Create a dashboard link interaction.
+Stability: Long-term
 """
 	createDashboardLinkInteraction(
 		input: CreateDashboardLinkInteractionInput!
 	): InteractionId!
 """
 Gets or create a new demo data view.
+Stability: Short-term
 """
 	createDemoDataRepository(
 		demoDataType: String!
 	): Repository!
 """
 Create an email action.
+Stability: Long-term
 """
 	createEmailAction(
 """
@@ -3622,6 +4173,7 @@ Data for creating an email action
 	): EmailAction!
 """
 Create an organization. Root operation.
+Stability: Long-term
 """
 	createEmptyOrganization(
 		name: String!
@@ -3632,6 +4184,7 @@ Create an organization. Root operation.
 	): Organization!
 """
 Create an event forwarding rule on a repository and return it
+Stability: Long-term
 """
 	createEventForwardingRule(
 """
@@ -3641,6 +4194,7 @@ Data for creating an event forwarding rule
 	): EventForwardingRule!
 """
 Create an FDR feed
+Stability: Long-term
 """
 	createFdrFeed(
 """
@@ -3649,13 +4203,22 @@ Data for creating an FDR feed
 		input: CreateFdrFeed!
 	): FdrFeed!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Creates a schema. If another schema already exists with the same name, then this overwrites it.
+Creates a schema. If another schema already exists with the same name, then this overwrites it.
+Stability: Long-term
 """
 	createFieldAliasSchema(
 		input: CreateFieldAliasSchemaInput!
 	): FieldAliasSchema!
 """
+Creates a field aliasing schema from a YAML file
+Stability: Preview
+"""
+	createFieldAliasSchemaFromTemplate(
+		input: CreateFieldAliasSchemaFromTemplateInput!
+	): FieldAliasSchema!
+"""
 Create a filter alert.
+Stability: Long-term
 """
 	createFilterAlert(
 """
@@ -3664,7 +4227,7 @@ Data for creating a filter alert
 		input: CreateFilterAlert!
 	): FilterAlert!
 """
-[PREVIEW: Under development] 
+Stability: Long-term
 """
 	createFleetInstallToken(
 		name: String!
@@ -3672,6 +4235,7 @@ Data for creating a filter alert
 	): FleetInstallationToken!
 """
 Create a LogScale repository action.
+Stability: Long-term
 """
 	createHumioRepoAction(
 """
@@ -3681,18 +4245,21 @@ Data for creating a LogScale repository action
 	): HumioRepoAction!
 """
 Create a new IP filter.
+Stability: Long-term
 """
 	createIPFilter(
 		input: IPFilterInput!
 	): IPFilter!
 """
 Create a new ingest listener.
+Stability: Long-term
 """
 	createIngestListenerV3(
 		input: CreateIngestListenerV3Input!
 	): IngestListener!
 """
 Create a Kafka event forwarder and return it
+Stability: Long-term
 """
 	createKafkaEventForwarder(
 """
@@ -3701,7 +4268,8 @@ Data for creating a Kafka event forwarder
 		input: CreateKafkaEventForwarder!
 	): KafkaEventForwarder!
 """
-[PREVIEW: Experimental feature, not ready for production.] Create a cluster connection to a local view.
+Create a cluster connection to a local view.
+Stability: Short-term
 """
 	createLocalClusterConnection(
 """
@@ -3710,14 +4278,15 @@ Data for creating a local multi-cluster connection
 		input: CreateLocalClusterConnectionInput!
 	): LocalClusterConnection!
 """
-[PREVIEW: Under development] Creates a log collector configuration.
+Creates a log collector configuration.
+Stability: Short-term
 """
 	createLogCollectorConfiguration(
 		name: String!
 		draft: String
 	): LogCollectorConfiguration!
 """
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	createLogCollectorGroup(
 		name: String!
@@ -3726,6 +4295,7 @@ Data for creating a local multi-cluster connection
 	): LogCollectorGroup!
 """
 Create a lookup file from a package lookup file template.
+Stability: Long-term
 """
 	createLookupFileFromPackageTemplate(
 """
@@ -3747,6 +4317,7 @@ The name of the new lookup file to create.
 	): FileNameAndPath!
 """
 Create an OpsGenie action.
+Stability: Long-term
 """
 	createOpsGenieAction(
 """
@@ -3754,9 +4325,6 @@ Data for creating an OpsGenie action
 """
 		input: CreateOpsGenieAction!
 	): OpsGenieAction!
-"""
-[PREVIEW: Feature still in development] 
-"""
 	createOrUpdateCrossOrganizationView(
 		name: String!
 		limitIds: [String!]!
@@ -3764,19 +4332,29 @@ Data for creating an OpsGenie action
 		repoFilters: [RepoFilterInput!]
 	): View!
 """
-[PREVIEW: Experimental prototype not ready for production use] Creates or updates an external function specification.
+Creates or updates an external function specification.
+Stability: Preview
 """
 	createOrUpdateExternalFunction(
 		input: CreateOrUpdateExternalFunctionInput!
 	): ExternalFunctionSpecificationOutput!
 """
 Create a organization permissions token for organizational-level access.
+Stability: Long-term
 """
 	createOrganizationPermissionsToken(
 		input: CreateOrganizationPermissionTokenInput!
 	): String!
 """
+Creates an organization permissions token with the specified permissions.
+Stability: Long-term
+"""
+	createOrganizationPermissionsTokenV2(
+		input: CreateOrganizationPermissionsTokenV2Input!
+	): CreateOrganizationPermissionsTokenV2Output!
+"""
 Create a metric view, usage view and log view for each organization. (Root operation)
+Stability: Long-term
 """
 	createOrganizationsViews(
 		includeDebugView: Boolean
@@ -3784,6 +4362,7 @@ Create a metric view, usage view and log view for each organization. (Root opera
 	): Boolean!
 """
 Create a PagerDuty action.
+Stability: Long-term
 """
 	createPagerDutyAction(
 """
@@ -3799,6 +4378,7 @@ Create a parser.
 	): CreateParserMutation!
 """
 Create a parser from a package parser template.
+Stability: Long-term
 """
 	createParserFromPackageTemplate(
 """
@@ -3820,6 +4400,7 @@ The name of the new parser to create.
 	): CreateParserFromPackageTemplateMutation!
 """
 Create a parser from a yaml specification
+Stability: Long-term
 """
 	createParserFromTemplate(
 """
@@ -3829,18 +4410,28 @@ Data for creating a parser from a yaml template
 	): Parser!
 """
 Create a parser.
+Stability: Long-term
 """
 	createParserV2(
 		input: CreateParserInputV2!
 	): Parser!
 """
 Create a personal user token for the user. It will inherit the same permissions as the user.
+Stability: Long-term
 """
 	createPersonalUserToken(
 		input: CreatePersonalUserTokenInput!
 	): String!
 """
+Create a personal user token for the user. It will inherit the same permissions as the user.
+Stability: Long-term
+"""
+	createPersonalUserTokenV2(
+		input: CreatePersonalUserTokenInput!
+	): CreatePersonalUserTokenV2Output!
+"""
 Create a new sharable link to a dashboard.
+Stability: Long-term
 """
 	createReadonlyToken(
 		id: String!
@@ -3852,7 +4443,8 @@ Ownership of the queries run by this shared dashboard. If value is User, ownersh
 		queryOwnershipType: QueryOwnershipType
 	): DashboardLink!
 """
-[PREVIEW: Experimental feature, not ready for production.] Create a cluster connection to a remote view.
+Create a cluster connection to a remote view.
+Stability: Short-term
 """
 	createRemoteClusterConnection(
 """
@@ -3862,6 +4454,7 @@ Data for creating a remote cluster connection
 	): RemoteClusterConnection!
 """
 Create a new repository.
+Stability: Short-term
 """
 	createRepository(
 		name: String!
@@ -3880,18 +4473,21 @@ The limit the repository should be attached to, only a cloud feature. If not spe
 	): CreateRepositoryMutation!
 """
 Adds a role. Only usable if roles are not managed externally, e.g. in LDAP.
+Stability: Long-term
 """
 	createRole(
 		input: AddRoleInput!
 	): AddRoleMutation!
 """
 Create a saved query.
+Stability: Long-term
 """
 	createSavedQuery(
 		input: CreateSavedQueryInput!
 	): CreateSavedQueryPayload!
 """
 Create a saved query from a package saved query template.
+Stability: Long-term
 """
 	createSavedQueryFromPackageTemplate(
 """
@@ -3913,6 +4509,7 @@ The name of the new saved query to create.
 	): CreateSavedQueryFromPackageTemplateMutation!
 """
 Create a scheduled report.
+Stability: Long-term
 """
 	createScheduledReport(
 """
@@ -3960,13 +4557,25 @@ Data for creating a scheduled search from a yaml template.
 		input: CreateScheduledSearchFromTemplateInput!
 	): ScheduledSearch!
 """
-[PREVIEW: in development.] Create a search link interaction.
+Create a scheduled search.
+Stability: Long-term
+"""
+	createScheduledSearchV2(
+"""
+Data for creating a scheduled search
+"""
+		input: CreateScheduledSearchV2!
+	): ScheduledSearch!
+"""
+Create a search link interaction.
+Stability: Long-term
 """
 	createSearchLinkInteraction(
 		input: CreateSearchLinkInteractionInput!
 	): InteractionId!
 """
 Create a Slack action.
+Stability: Long-term
 """
 	createSlackAction(
 """
@@ -3976,6 +4585,7 @@ Data for creating a Slack action.
 	): SlackAction!
 """
 Create a post message Slack action.
+Stability: Long-term
 """
 	createSlackPostMessageAction(
 """
@@ -3985,12 +4595,21 @@ Data for creating a post message Slack action.
 	): SlackPostMessageAction!
 """
 Create a system permissions token for system-level access.
+Stability: Long-term
 """
 	createSystemPermissionsToken(
 		input: CreateSystemPermissionTokenInput!
 	): String!
 """
+Creates a system permissions token with the specified permissions.
+Stability: Long-term
+"""
+	createSystemPermissionsTokenV2(
+		input: CreateSystemPermissionTokenV2Input!
+	): CreateSystemPermissionsTokenV2Output!
+"""
 Create an upload file action.
+Stability: Long-term
 """
 	createUploadFileAction(
 """
@@ -4000,6 +4619,7 @@ Data for creating an upload file action.
 	): UploadFileAction!
 """
 Create a VictorOps action.
+Stability: Long-term
 """
 	createVictorOpsAction(
 """
@@ -4009,6 +4629,7 @@ Data for creating a VictorOps action.
 	): VictorOpsAction!
 """
 Create a new view.
+Stability: Long-term
 """
 	createView(
 		name: String!
@@ -4019,12 +4640,21 @@ Create a new view.
 	): View!
 """
 Create a view permission token. The permissions will take effect across all the views.
+Stability: Long-term
 """
 	createViewPermissionsToken(
 		input: CreateViewPermissionsTokenInput!
 	): String!
 """
+Creates a view permissions token with the specified permissions on the views specified in the 'viewIds' field.
+Stability: Long-term
+"""
+	createViewPermissionsTokenV2(
+		input: CreateViewPermissionsTokenV2Input!
+	): CreateViewPermissionsTokenV2Output!
+"""
 Create a webhook action.
+Stability: Long-term
 """
 	createWebhookAction(
 """
@@ -4034,6 +4664,7 @@ Data for creating a webhook action.
 	): WebhookAction!
 """
 Delete an action.
+Stability: Long-term
 """
 	deleteAction(
 """
@@ -4043,6 +4674,7 @@ Data for deleting an action.
 	): Boolean!
 """
 Delete an aggregate alert.
+Stability: Long-term
 """
 	deleteAggregateAlert(
 """
@@ -4052,6 +4684,7 @@ Data for deleting an aggregate alert.
 	): Boolean!
 """
 Delete an alert.
+Stability: Long-term
 """
 	deleteAlert(
 """
@@ -4060,7 +4693,8 @@ Data for deleting an alert
 		input: DeleteAlert!
 	): Boolean!
 """
-[PREVIEW: Experimental feature, not ready for production.] Delete a cluster connection from a view.
+Delete a cluster connection from a view.
+Stability: Short-term
 """
 	deleteClusterConnection(
 """
@@ -4070,18 +4704,21 @@ Data for deleting a cluster connection
 	): Boolean!
 """
 Delete a dashboard.
+Stability: Long-term
 """
 	deleteDashboard(
 		input: DeleteDashboardInput!
 	): DeleteDashboardMutation!
 """
 Delete a dashboard by looking up the view with the given viewId and then the dashboard in the view with the given dashboardId.
+Stability: Long-term
 """
 	deleteDashboardV2(
 		input: DeleteDashboardInputV2!
 	): SearchDomain!
 """
 Delete an event forwarder
+Stability: Long-term
 """
 	deleteEventForwarder(
 """
@@ -4091,6 +4728,7 @@ Data for deleting an event forwarder
 	): Boolean!
 """
 Delete an event forwarding rule on a repository
+Stability: Long-term
 """
 	deleteEventForwardingRule(
 """
@@ -4099,13 +4737,15 @@ Data for deleting an event forwarding rule
 		input: DeleteEventForwardingRule!
 	): Boolean!
 """
-[PREVIEW: Experimental prototype not ready for production use] Deletes a given external function specification.
+Deletes a given external function specification.
+Stability: Preview
 """
 	deleteExternalFunction(
 		input: deleteExternalFunctionInput!
 	): Boolean!
 """
 Delete an FDR feed
+Stability: Long-term
 """
 	deleteFdrFeed(
 """
@@ -4115,18 +4755,21 @@ Data for deleting an FDR feed
 	): Boolean!
 """
 Delete a feature flag.
+Stability: Short-term
 """
 	deleteFeatureFlag(
 		feature: String!
 	): Boolean!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] deletes an alias mapping
+Deletes an alias mapping.
+Stability: Long-term
 """
 	deleteFieldAliasSchema(
 		input: DeleteFieldAliasSchema!
 	): Boolean!
 """
 Delete a filter alert.
+Stability: Long-term
 """
 	deleteFilterAlert(
 """
@@ -4135,25 +4778,28 @@ Data for deleting a filter alert
 		input: DeleteFilterAlert!
 	): Boolean!
 """
-[PREVIEW: Under development] 
+Stability: Long-term
 """
 	deleteFleetInstallToken(
 		token: String!
 	): Boolean!
 """
 Delete IP filter.
+Stability: Long-term
 """
 	deleteIPFilter(
 		input: IPFilterIdInput!
 	): Boolean!
 """
 For deleting an identity provider. Root operation.
+Stability: Long-term
 """
 	deleteIdentityProvider(
 		id: String!
 	): Boolean!
 """
 Delete an ingest feed
+Stability: Long-term
 """
 	deleteIngestFeed(
 """
@@ -4163,31 +4809,33 @@ Data for deleting an ingest feed
 	): Boolean!
 """
 Delete an ingest listener.
+Stability: Long-term
 """
 	deleteIngestListener(
 		id: String!
 	): BooleanResultType!
 """
-[PREVIEW: in development.] Delete an interaction.
+Delete an interaction.
+Stability: Long-term
 """
 	deleteInteraction(
 		input: DeleteInteractionInput!
 	): Boolean!
 """
-[PREVIEW: Under development] 
+Stability: Long-term
 """
 	deleteLogCollectorConfiguration(
 		configId: String!
 		versionId: Int!
 	): Boolean!
 """
-[PREVIEW: Under development] 
+Stability: Long-term
 """
 	deleteLogCollectorGroup(
 		id: String!
 	): Boolean!
 """
-[PREVIEW: Under development] 
+Stability: Preview
 """
 	deleteLostCollectors(
 		dryRun: Boolean!
@@ -4195,18 +4843,21 @@ Delete an ingest listener.
 	): Int!
 """
 Delete notification from the system. Requires root.
+Stability: Long-term
 """
 	deleteNotification(
 		notificationId: String!
 	): Boolean!
 """
 Delete a parser.
+Stability: Long-term
 """
 	deleteParser(
 		input: DeleteParserInput!
 	): BooleanResultType!
 """
 Remove a shared link to a dashboard.
+Stability: Long-term
 """
 	deleteReadonlyToken(
 		id: String!
@@ -4214,18 +4865,21 @@ Remove a shared link to a dashboard.
 	): BooleanResultType!
 """
 Deletes a saved query.
+Stability: Long-term
 """
 	deleteSavedQuery(
 		input: DeleteSavedQueryInput!
 	): BooleanResultType!
 """
 Delete a scheduled report.
+Stability: Long-term
 """
 	deleteScheduledReport(
 		input: DeleteScheduledReportInput!
 	): Boolean!
 """
 Delete a scheduled search.
+Stability: Long-term
 """
 	deleteScheduledSearch(
 """
@@ -4235,6 +4889,7 @@ Data for deleting a scheduled search
 	): Boolean!
 """
 Delete a repository or view.
+Stability: Long-term
 """
 	deleteSearchDomain(
 		name: String!
@@ -4242,18 +4897,21 @@ Delete a repository or view.
 	): BooleanResultType!
 """
 Delete a repository or view.
+Stability: Long-term
 """
 	deleteSearchDomainById(
 		input: DeleteSearchDomainByIdInput!
 	): Boolean!
 """
 Delete a token
+Stability: Long-term
 """
 	deleteToken(
 		input: InputData!
 	): Boolean!
 """
 Disable an aggregate alert.
+Stability: Long-term
 """
 	disableAggregateAlert(
 """
@@ -4263,6 +4921,7 @@ Data for disabling an aggregate alert.
 	): Boolean!
 """
 Disable an alert.
+Stability: Long-term
 """
 	disableAlert(
 """
@@ -4271,11 +4930,20 @@ Data for disabling an alert
 		input: DisableAlert!
 	): Boolean!
 """
+Disables the archiving job for the repository.
+Stability: Short-term
+"""
+	disableArchiving(
+		repositoryName: String!
+	): BooleanResultType!
+"""
 Removes demo view.
+Stability: Short-term
 """
 	disableDemoDataForUser: Boolean!
 """
 Disables an event forwarder
+Stability: Long-term
 """
 	disableEventForwarder(
 """
@@ -4285,12 +4953,14 @@ Data for disabling an event forwarder
 	): Boolean!
 """
 Disable a feature.
+Stability: Short-term
 """
 	disableFeature(
 		feature: FeatureFlag!
 	): Boolean!
 """
 Disable a feature for a specific organization.
+Stability: Short-term
 """
 	disableFeatureForOrg(
 		orgId: String!
@@ -4298,25 +4968,36 @@ Disable a feature for a specific organization.
 	): Boolean!
 """
 Disable a feature for a specific user.
+Stability: Short-term
 """
 	disableFeatureForUser(
 		feature: FeatureFlag!
 		userId: String!
 	): Boolean!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Disables the schema on this organization
+Disables the schema on this organization.
+Stability: Long-term
 """
 	disableFieldAliasSchemaOnOrg(
 		input: DisableFieldAliasSchemaOnOrgInput!
 	): Boolean!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Disables the schema on the given view or repository.
+Disables the schema on the given view or repository.
+Stability: Long-term
 """
 	disableFieldAliasSchemaOnView(
 		input: DisableFieldAliasSchemaOnViewInput!
 	): Boolean!
 """
+Disables the schema on the given views or repositories.
+Stability: Preview
+"""
+	disableFieldAliasSchemaOnViews(
+		input: DisableFieldAliasSchemaOnViewsInput!
+	): Boolean!
+"""
 Disable a filter alert.
+Stability: Long-term
 """
 	disableFilterAlert(
 """
@@ -4325,17 +5006,18 @@ Data for disabling a filter alert
 		input: DisableFilterAlert!
 	): Boolean!
 """
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	disableLogCollectorDebugLogging: Boolean!
 """
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	disableLogCollectorInstanceDebugLogging(
 		id: String!
 	): Boolean!
 """
 Disable access to IOCs (indicators of compromise) for an organization. (Requires Organization Manager Permission)
+Stability: Short-term
 """
 	disableOrganizationIocAccess(
 """
@@ -4345,12 +5027,14 @@ Data for disabling access to IOCs (indicators of compromise) for an organization
 	): Organization!
 """
 Disable a scheduled report.
+Stability: Long-term
 """
 	disableScheduledReport(
 		input: DisableScheduledReportInput!
 	): Boolean!
 """
 Disable execution of a scheduled search.
+Stability: Long-term
 """
 	disableScheduledSearch(
 """
@@ -4359,7 +5043,8 @@ Data for disabling a scheduled search
 		input: DisableStarScheduledSearch!
 	): ScheduledSearch!
 """
-[PREVIEW: Internal debugging tool, do not use without explicit instruction from support] Disable query tracing on worker nodes for queries with the given quota key
+Disable query tracing on worker nodes for queries with the given quota key
+Stability: Preview
 """
 	disableWorkerQueryTracing(
 """
@@ -4369,12 +5054,14 @@ The quota key to disable tracing for
 	): Boolean!
 """
 Dismiss notification for specific user, if allowed by notification type.
+Stability: Long-term
 """
 	dismissNotification(
 		notificationId: String!
 	): Boolean!
 """
 Enable an aggregate alert.
+Stability: Long-term
 """
 	enableAggregateAlert(
 """
@@ -4384,6 +5071,7 @@ Data for enabling an aggregate alert.
 	): Boolean!
 """
 Enable an alert.
+Stability: Long-term
 """
 	enableAlert(
 """
@@ -4392,13 +5080,22 @@ Data for enabling an alert
 		input: EnableAlert!
 	): Boolean!
 """
+Enables the archiving job for the repository.
+Stability: Short-term
+"""
+	enableArchiving(
+		repositoryName: String!
+	): BooleanResultType!
+"""
 Gets or create a new demo data view.
+Stability: Short-term
 """
 	enableDemoDataForUser(
 		demoDataType: String!
 	): View!
 """
 Enables an event forwarder
+Stability: Long-term
 """
 	enableEventForwarder(
 """
@@ -4408,42 +5105,58 @@ Data for enabling an event forwarder
 	): Boolean!
 """
 Enable a feature.
+Stability: Short-term
 """
 	enableFeature(
 		feature: FeatureFlag!
+"""
+Enable feature flag regardless of verification result
+"""
+		skipVerification: Boolean
 	): Boolean!
 """
 Enable a feature for a specific organization.
+Stability: Short-term
 """
 	enableFeatureForOrg(
 		orgId: String!
 		feature: FeatureFlag!
+"""
+Enable feature flag regardless of verification result
+"""
+		skipVerification: Boolean
 	): Boolean!
 """
 Enable a feature for a specific user.
+Stability: Short-term
 """
 	enableFeatureForUser(
 		feature: FeatureFlag!
 		userId: String!
+"""
+Enable feature flag regardless of verification result
+"""
+		skipVerification: Boolean
 	): Boolean!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Enables the schema on this organization. Field alias mappings in this schema will be active during search across all views and repositories within this org.
+Enables the schema on this organization. Field alias mappings in this schema will be active during search across all views and repositories within this org.
+Stability: Long-term
 """
 	enableFieldAliasSchemaOnOrg(
 		input: EnableFieldAliasSchemaOnOrgInput!
 	): Boolean!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] 
 Enables the schema on the given list of views or repositories.
 Field alias mappings in this schema will be active during search within this view or repository.
 If at least one view fails to be enabled on the given view, then no changes are performed on any of the views.
-
+Stability: Long-term
 """
 	enableFieldAliasSchemaOnViews(
 		input: EnableFieldAliasSchemaOnViewsInput!
 	): Boolean!
 """
 Enable a filter alert.
+Stability: Long-term
 """
 	enableFilterAlert(
 """
@@ -4452,7 +5165,7 @@ Data for enabling a filter alert
 		input: EnableFilterAlert!
 	): Boolean!
 """
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	enableLogCollectorDebugLogging(
 		url: String
@@ -4461,7 +5174,7 @@ Data for enabling a filter alert
 		repository: String
 	): Boolean!
 """
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	enableLogCollectorInstanceDebugLogging(
 		id: String!
@@ -4472,6 +5185,7 @@ Data for enabling a filter alert
 	): Boolean!
 """
 Enable access to IOCs (indicators of compromise) for an organization. (Requires Organization Manager Permission).
+Stability: Short-term
 """
 	enableOrganizationIocAccess(
 """
@@ -4481,12 +5195,14 @@ Data for enabling access to IOCs (indicators of compromise) for an organization
 	): Organization!
 """
 Enable a scheduled report.
+Stability: Long-term
 """
 	enableScheduledReport(
 		input: EnableScheduledReportInput!
 	): Boolean!
 """
 Enable execution of a scheduled search.
+Stability: Long-term
 """
 	enableScheduledSearch(
 """
@@ -4495,13 +5211,15 @@ Data for enabling a scheduled search
 		input: EnableStarScheduledSearch!
 	): ScheduledSearch!
 """
-[PREVIEW: Internal debugging tool, do not use without explicit instruction from support] Enable query tracing on worker nodes for queries with the given quota key
+Enable query tracing on worker nodes for queries with the given quota key
+Stability: Preview
 """
 	enableWorkerQueryTracing(
 		input: EnableWorkerQueryTracingInputType!
 	): Boolean!
 """
 Extend a Cloud Trial. (Requires Root Permissions)
+Stability: Short-term
 """
 	extendCloudTrial(
 		organizationId: String!
@@ -4509,18 +5227,32 @@ Extend a Cloud Trial. (Requires Root Permissions)
 	): Boolean!
 """
 Set the primary bucket target for the organization.
+Stability: Long-term
 """
 	findOrCreateBucketStorageEntity(
 		organizationId: String!
 	): Int!
 """
+Configures GCS archiving for a repository. E.g. bucket.
+Stability: Preview
+"""
+	gcsConfigureArchiving(
+		repositoryName: String!
+		bucket: String!
+		format: ArchivingFormat!
+		tagOrderInName: [String!]
+		startFromDateTime: DateTime
+	): BooleanResultType!
+"""
 Installs a package in a specific view.
+Stability: Long-term
 """
 	installPackageFromRegistryV2(
 		InstallPackageFromRegistryInput: InstallPackageFromRegistryInput!
 	): InstallPackageFromRegistryResult!
 """
 Installs a package from file provided in multipart/form-data (name=file) in a specific view.
+Stability: Long-term
 """
 	installPackageFromZip(
 """
@@ -4532,46 +5264,55 @@ Overwrite existing installed package
 """
 		overwrite: Boolean
 """
-[PREVIEW: The query ownership feature is still in development] Ownership of the queries run by the triggers (e.g. alerts and scheduled searches) that are installed as part of this package. If value is User, ownership will be based on the calling user.
+Ownership of the queries run by the triggers (e.g. alerts and scheduled searches) that are installed as part of this package. If value is User, ownership will be based on the calling user.
 """
 		queryOwnershipType: QueryOwnershipType
 	): InstallPackageFromZipResult!
+"""
+
+Stability: Short-term
+"""
 	killQuery(
 		viewName: String!
 		pattern: String!
 	): BooleanResultType!
 """
-[PREVIEW: Internal testing.] Enable a or disable language restrictions for specified version.
+Enable a or disable language restrictions for specified version.
+Stability: Preview
 """
 	languageRestrictionsEnable(
 		input: EnabledInput!
 	): Boolean!
 """
-[PREVIEW: Feature still in development] 
+Stability: Preview
 """
 	linkChildOrganization(
 		childId: String!
 	): OrganizationLink!
 """
 Log UI Action.
+Stability: Short-term
 """
 	logAnalytics(
 		input: AnalyticsLog!
 	): Boolean!
 """
-[PREVIEW: New analytics implementation] Log UI Action.
+Log UI Action.
+Stability: Preview
 """
 	logAnalyticsBatch(
 		input: [AnalyticsLogWithTimestamp!]!
 	): Boolean!
 """
-[PREVIEW: This feature is under development] Logs a service level indicator to the humio repo with #kind=frontend.
+Logs a service level indicator to the humio repo with #kind=frontend.
+Stability: Preview
 """
 	logFrontendServiceLevelIndicators(
 		input: [ServiceLevelIndicatorLogArg!]!
 	): Boolean!
 """
 Logs out of a users session.
+Stability: Long-term
 """
 	logoutOfSession: Boolean!
 """
@@ -4582,12 +5323,14 @@ Set a limits deleted mark
 	): Boolean!
 """
 Migrate all organizations to the new Limits model (requires root).
+Stability: Long-term
 """
 	migrateToNewLimits(
 		input: MigrateLimitsInput!
 	): Boolean!
 """
 For setting up a new Azure AD OIDC idp. Root operation.
+Stability: Long-term
 """
 	newAzureAdOidcIdentityProvider(
 		name: String!
@@ -4600,6 +5343,7 @@ For setting up a new Azure AD OIDC idp. Root operation.
 	): OidcIdentityProvider!
 """
 Create new file
+Stability: Long-term
 """
 	newFile(
 		fileName: String!
@@ -4607,10 +5351,14 @@ Create new file
 	): UploadedFileSnapshot!
 """
 For setting up a new OIDC idp. Root operation.
+Stability: Long-term
 """
 	newOIDCIdentityProvider(
 		input: OidcConfigurationInput!
 	): OidcIdentityProvider!
+"""
+Stability: Long-term
+"""
 	newSamlIdentityProvider(
 """
 Optional specify the ID externally (root only)
@@ -4644,6 +5392,10 @@ Only used internal
 Lazy create users during login
 """
 		lazyCreateUsers: Boolean
+"""
+An alternative certificate to be used for IdP signature validation. Useful for handling certificate rollover
+"""
+		alternativeIdpCertificateInBase64: String
 	): SamlIdentityProvider!
 """
 Create notification. Required permissions depends on targets.
@@ -4654,12 +5406,14 @@ Create notification. Required permissions depends on targets.
  mutation{notify(Target:All,...)} # Notify all users
  mutation{notify(Target:All,["UserId1", "UserId2", "UserId3"],...)} #Notify user 1, 2 & 3
 
+Stability: Long-term
 """
 	notify(
 		input: NotificationInput!
 	): Notification!
 """
 Override whether feature should be rolled out.
+Stability: Short-term
 """
 	overrideRolledOutFeatureFlag(
 		feature: FeatureFlag!
@@ -4667,12 +5421,14 @@ Override whether feature should be rolled out.
 	): Boolean!
 """
 Proxy mutation through a specific organization. Root operation.
+Stability: Long-term
 """
 	proxyOrganization(
 		organizationId: String!
 	): Organization!
 """
-[PREVIEW: Under development] Updates a log collector configuration.
+Updates a log collector configuration.
+Stability: Short-term
 """
 	publishLogCollectorConfiguration(
 		id: String!
@@ -4681,22 +5437,36 @@ Proxy mutation through a specific organization. Root operation.
 	): LogCollectorConfiguration!
 """
 Recover the organization with the given id.
+Stability: Short-term
 """
 	recoverOrganization(
 		organizationId: String!
 	): Organization!
 """
 Redact events matching a certain query within a certain time interval. Returns the id of the submitted redaction task
+Stability: Long-term
 """
 	redactEvents(
 		input: RedactEventsInputType!
 	): String!
 """
+Force a refresh of the ClusterManagementStats cache and return reasonsNodeCannotBeSafelyUnregistered for the specified node.
+Stability: Preview
+"""
+	refreshClusterManagementStats(
+"""
+Id of the node for which refreshed data must be retrieved.
+"""
+		nodeId: Int!
+	): RefreshClusterManagementStatsMutation!
+"""
 Refresh the list of regions
+Stability: Short-term
 """
 	refreshRegions: Boolean!
 """
 Remove a label from an alert.
+Stability: Long-term
 """
 	removeAlertLabelV2(
 """
@@ -4705,7 +5475,14 @@ Data for removing a label from an alert
 		input: RemoveAlertLabel!
 	): Alert!
 """
+Stability: Preview
+"""
+	removeCrossOrgViewConnections(
+		input: RemoveCrossOrgViewConnectionsInput!
+	): View!
+"""
 Remove a filter from a dashboard's list of filters.
+Stability: Long-term
 """
 	removeDashboardFilter(
 		id: String!
@@ -4713,6 +5490,7 @@ Remove a filter from a dashboard's list of filters.
 	): Dashboard!
 """
 Remove a label from a dashboard.
+Stability: Long-term
 """
 	removeDashboardLabel(
 		id: String!
@@ -4720,18 +5498,21 @@ Remove a label from a dashboard.
 	): Dashboard!
 """
 Gets or create a new demo data view.
+Stability: Short-term
 """
 	removeDemoDataRepository(
 		demoDataType: String!
 	): Boolean!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Removes a field alias mapping to an existing schema.
+Removes a field alias mapping to an existing schema.
+Stability: Long-term
 """
 	removeFieldAliasMapping(
 		input: RemoveAliasMappingInput!
 	): Boolean!
 """
 Remove file
+Stability: Long-term
 """
 	removeFile(
 		fileName: String!
@@ -4739,6 +5520,7 @@ Remove file
 	): BooleanResultType!
 """
 Remove an item on the query blocklist.
+Stability: Long-term
 """
 	removeFromBlocklist(
 """
@@ -4747,30 +5529,34 @@ Data for removing a blocklist entry
 		input: RemoveFromBlocklistInput!
 	): Boolean!
 """
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	removeFromLogCollectorConfigurationTest(
 		configId: String!
 		collectorIds: [String!]!
 	): FleetConfigurationTest!
 """
-[PREVIEW: Internal testing.] Disable functions for use with specified language version.
+Disable functions for use with specified language version.
+Stability: Preview
 """
 	removeFunctionsFromAllowList(
 		input: FunctionListInput!
 	): Boolean!
 """
-[PREVIEW: Cache policies are a limited feature and is subject to change] Removes the global default cache policy
+Removes the global default cache policy
+Stability: Preview
 """
 	removeGlobalDefaultCachePolicy: Boolean!
 """
 Removes a group. Only usable if roles are not managed externally, e.g. in LDAP.
+Stability: Long-term
 """
 	removeGroup(
 		groupId: String!
 	): RemoveGroupMutation!
 """
 Remove an Ingest Token.
+Stability: Long-term
 """
 	removeIngestToken(
 """
@@ -4788,22 +5574,38 @@ Remove a limit in the given organization
 	removeLimit(
 		input: RemoveLimitInput!
 	): Boolean!
+"""
+Remove a limit with id in the given organization
+Stability: Short-term
+"""
+	removeLimitWithId(
+		limitId: String!
+	): Boolean!
+"""
+Stability: Long-term
+"""
 	removeLoginBridge: Boolean!
+"""
+Stability: Long-term
+"""
 	removeLoginBridgeAllowedUsers(
 		userID: String!
 	): LoginBridge!
 """
-[PREVIEW: Cache policies are a limited feature and is subject to change] Removes the default cache policy of the current organization.
+Removes the default cache policy of the current organization.
+Stability: Preview
 """
 	removeOrgDefaultCachePolicy: Boolean!
 """
 Remove the organization with the given id (needs to be the same organization ID as the requesting user is in).
+Stability: Short-term
 """
 	removeOrganization(
 		organizationId: String!
 	): Boolean!
 """
 Remove the bucket config for the organization.
+Stability: Long-term
 """
 	removeOrganizationBucketConfig: Organization!
 """
@@ -4812,12 +5614,19 @@ Remove a parser.
 	removeParser(
 		input: RemoveParserInput!
 	): RemoveParserMutation!
+"""
+Stability: Short-term
+"""
 	removeQueryQuotaDefaultSettings: Boolean!
+"""
+Stability: Short-term
+"""
 	removeQueryQuotaUserSettings(
 		username: String!
 	): Boolean!
 """
-[PREVIEW: Cache policies are a limited feature and is subject to change] Removes the cache policy of a repository
+Removes the cache policy of a repository
+Stability: Preview
 """
 	removeRepoCachePolicy(
 """
@@ -4827,12 +5636,14 @@ Data to remove a repository cache policy
 	): Boolean!
 """
 Removes a role. Only usable if roles are not managed externally, e.g. in LDAP.
+Stability: Long-term
 """
 	removeRole(
 		roleId: String!
 	): BooleanResultType!
 """
 Remove a label from a scheduled search.
+Stability: Long-term
 """
 	removeScheduledSearchLabel(
 """
@@ -4841,7 +5652,8 @@ Data for removing a label
 		input: RemoveLabelScheduledSearch!
 	): ScheduledSearch!
 """
-[PREVIEW: Requires the feature enabled for the organization.] Removes a secondary subdomain from the organization
+Removes a secondary subdomain from the organization
+Stability: Preview
 """
 	removeSecondarySubdomain(
 		input: RemoveSecondarySubdomainInput!
@@ -4861,10 +5673,14 @@ Data for removing a star from an alert
 	): Alert!
 """
 Remove a star from a dashboard.
+Stability: Long-term
 """
 	removeStarFromDashboard(
 		id: String!
 	): Dashboard!
+"""
+Stability: Long-term
+"""
 	removeStarFromField(
 		input: RemoveStarToFieldInput!
 	): RemoveStarToFieldMutation!
@@ -4879,34 +5695,40 @@ Data for removing a star
 	): ScheduledSearch!
 """
 Remove a star from a repository or view.
+Stability: Long-term
 """
 	removeStarFromSearchDomain(
 		name: String!
 	): SearchDomain!
 """
-[PREVIEW: Requires the feature enabled for the organization.] Remove the subdomain settings for the organization.
+Remove the subdomain settings for the organization.
+Stability: Preview
 """
 	removeSubdomainSettings: Organization!
 """
 Remove a user.
+Stability: Long-term
 """
 	removeUser(
 		input: RemoveUserInput!
 	): RemoveUserMutation!
 """
 Remove a user.
+Stability: Long-term
 """
 	removeUserById(
 		input: RemoveUserByIdInput!
 	): RemoveUserByIdMutation!
 """
 Removes users from an existing group.
+Stability: Long-term
 """
 	removeUsersFromGroup(
 		input: RemoveUsersFromGroupInput!
 	): RemoveUsersFromGroupMutation!
 """
 Rename a dashboard.
+Stability: Long-term
 """
 	renameDashboard(
 		id: String!
@@ -4914,6 +5736,7 @@ Rename a dashboard.
 	): Dashboard!
 """
 Rename a Repository or View.
+Stability: Long-term
 """
 	renameSearchDomain(
 """
@@ -4927,10 +5750,14 @@ New name for Repository or View. Note that this changes the URLs for accessing t
 	): SearchDomain!
 """
 Rename a Repository or View.
+Stability: Long-term
 """
 	renameSearchDomainById(
 		input: RenameSearchDomainByIdInput!
 	): SearchDomain!
+"""
+Stability: Long-term
+"""
 	renameWidget(
 		id: String!
 		widgetId: String!
@@ -4938,12 +5765,14 @@ Rename a Repository or View.
 	): Dashboard!
 """
 Resend an invite to a pending user.
+Stability: Long-term
 """
 	resendInvitation(
 		input: TokenInput!
 	): Boolean!
 """
-[PREVIEW: Feature still in development] Resets the flight recorder settings to default for the given vhost
+Resets the flight recorder settings to default for the given vhost
+Stability: Preview
 """
 	resetFlightRecorderSettings(
 """
@@ -4953,6 +5782,7 @@ The vhost to change the settings for.
 	): Boolean!
 """
 Sets the quota and rate to the given value or resets it to defaults
+Stability: Long-term
 """
 	resetQuota(
 """
@@ -4960,51 +5790,75 @@ Data for resetting quota
 """
 		input: ResetQuotaInput!
 	): Boolean!
+"""
+Stability: Short-term
+"""
 	resetToFactorySettings: Account!
 """
-[PREVIEW: BETA feature.] Restore a deleted search domain.
+Mark all segment files as unarchived.
+Stability: Short-term
+"""
+	restartArchiving(
+		repositoryName: String!
+		archivalKind: ArchivalKind
+	): BooleanResultType!
+"""
+Restore a deleted search domain.
+Stability: Preview
 """
 	restoreDeletedSearchDomain(
 		input: RestoreDeletedSearchDomainInput!
 	): SearchDomain!
 """
 Resubmit marketo lead. Requires root level privileges and an organization owner in the organization (the lead).
+Stability: Long-term
 """
 	resubmitMarketoLead(
 		input: ResubmitMarketoLeadData!
 	): Boolean!
 """
 Revoke a pending user. Once revoked, the invitation link sent to the user becomes invalid.
+Stability: Long-term
 """
 	revokePendingUser(
 		input: TokenInput!
 	): Boolean!
 """
 Revoke the specified session. Can be a single session, all sessions for a user or all sessions in an organization.
+Stability: Long-term
 """
 	revokeSession(
 		input: RevokeSessionInput!
 	): Boolean!
 """
 Rollback the organization with the given id.
+Stability: Short-term
 """
 	rollbackOrganization(
 		organizationId: String!
 	): Boolean!
 """
 Rotate a token
+Stability: Long-term
 """
 	rotateToken(
 		input: RotateTokenInputData!
 	): String!
 """
-[PREVIEW: This feature is under development] Manually start the organization inconsistency job. This job will check for inconsistencies like orphaned entities, references to non-existent entities. The job can be run in a dry-run mode that only logs what would have happened.
+This is used to initiate a global consistency check on a cluster. Returns the checkId of the consistency check run
+Stability: Preview
+"""
+	runGlobalConsistencyCheck: String!
+"""
+Manually start the organization inconsistency job. This job will check for inconsistencies like orphaned entities, references to non-existent entities. The job can be run in a dry-run mode that only logs what would have happened.
+Stability: Preview
 """
 	runInconsistencyCheck(
 		input: RunInconsistencyCheckInput!
 	): String!
 """
 Configures S3 archiving for a repository. E.g. bucket and region.
+Stability: Short-term
 """
 	s3ConfigureArchiving(
 		repositoryName: String!
@@ -5013,39 +5867,47 @@ Configures S3 archiving for a repository. E.g. bucket and region.
 		format: S3ArchivingFormat!
 		tagOrderInName: [String!]
 		startFromDateTime: DateTime
+		roleArn: String
 	): BooleanResultType!
 """
 Disables the archiving job for the repository.
+Stability: Short-term
 """
 	s3DisableArchiving(
 		repositoryName: String!
 	): BooleanResultType!
 """
 Enables the archiving job for the repository.
+Stability: Short-term
 """
 	s3EnableArchiving(
 		repositoryName: String!
 	): BooleanResultType!
 """
 Mark all segment files as unarchived.
+Stability: Short-term
 """
 	s3ResetArchiving(
 		repositoryName: String!
+		archivalKind: ArchivalKind
 	): BooleanResultType!
 """
 Scheduled report result failed.
+Stability: Long-term
 """
 	scheduledReportResultFailed(
 		input: ScheduledReportResultFailedInput!
 	): Boolean!
 """
 Scheduled report result succeeded.
+Stability: Long-term
 """
 	scheduledReportResultSucceeded(
 		input: ScheduledReportResultSucceededInput!
 	): Boolean!
 """
-[PREVIEW: Feature still in development] Set to true to allow moving existing segments between nodes to achieve a better data distribution
+Set to true to allow moving existing segments between nodes to achieve a better data distribution
+Stability: Short-term
 """
 	setAllowRebalanceExistingSegments(
 """
@@ -5054,7 +5916,8 @@ true if the cluster should allow moving existing segments between nodes to achie
 		allowRebalanceExistingSegments: Boolean!
 	): Boolean!
 """
-[PREVIEW: Feature still in development] Set whether or not to allow updating the desired digesters automatically
+Set whether or not to allow updating the desired digesters automatically
+Stability: Short-term
 """
 	setAllowUpdateDesiredDigesters(
 """
@@ -5064,6 +5927,7 @@ Whether or not to allow updating the desired digesters automatically
 	): Boolean!
 """
 Automatically search when arriving at the search page
+Stability: Long-term
 """
 	setAutomaticSearching(
 		name: String!
@@ -5071,6 +5935,7 @@ Automatically search when arriving at the search page
 	): setAutomaticSearching!
 """
 Set CID of provisioned organization
+Stability: Short-term
 """
 	setCid(
 		cid: String!
@@ -5103,6 +5968,7 @@ Time in the future
 	): DateTime
 """
 Mark a filter as the default for a dashboard. This filter will automatically be active when the dashboard is opened.
+Stability: Long-term
 """
 	setDefaultDashboardFilter(
 		id: String!
@@ -5110,12 +5976,14 @@ Mark a filter as the default for a dashboard. This filter will automatically be 
 	): Dashboard!
 """
 Set the query that should be loaded on entering the search page in a specific view.
+Stability: Long-term
 """
 	setDefaultSavedQuery(
 		input: SetDefaultSavedQueryInput!
 	): BooleanResultType!
 """
-[PREVIEW: Feature still in development] Sets the digest replication factor to the supplied value
+Sets the digest replication factor to the supplied value
+Stability: Short-term
 """
 	setDigestReplicationFactor(
 """
@@ -5125,24 +5993,28 @@ The replication factor for segments newly written to digest nodes. Applies until
 	): Int!
 """
 Set a dynamic config. Requires root level access.
+Stability: Short-term
 """
 	setDynamicConfig(
 		input: DynamicConfigInputObject!
 	): Boolean!
 """
-[PREVIEW: Requires the feature enabled for the organization.] Configures whether subdomains are enforced for the organization
+Configures whether subdomains are enforced for the organization
+Stability: Preview
 """
 	setEnforceSubdomains(
 		input: EnforceSubdomainsInput!
 	): Organization!
 """
 Save UI styling and other properties for a field. These will be used whenever that field is added to a table or event list in LogScale's UI.
+Stability: Long-term
 """
 	setFieldConfiguration(
 		input: FieldConfigurationInput!
 	): Boolean!
 """
-[PREVIEW: Cache policies are a limited feature and is subject to change] Sets the global default cache policy. This policy will be applied to a repo if neither a repo or org cache policy is set.
+Sets the global default cache policy. This policy will be applied to a repo if neither a repo or org cache policy is set.
+Stability: Preview
 """
 	setGlobalDefaultCachePolicy(
 """
@@ -5151,7 +6023,8 @@ Data to set a global default cache policy
 		input: SetGlobalDefaultCachePolicyInput!
 	): Boolean!
 """
-[PREVIEW: Feature still in development] Toggle whether the specified host should be prepared for eviction from the cluster. If preparing for eviction, the cluster will attempt to move data and work away from the host.
+Toggle whether the specified host should be prepared for eviction from the cluster. If preparing for eviction, the cluster will attempt to move data and work away from the host.
+Stability: Short-term
 """
 	setIsBeingEvicted(
 """
@@ -5165,24 +6038,32 @@ Eviction flag indicating whether a node should be prepared for eviction from the
 	): Boolean!
 """
 Remove a limit in the given organization
+Stability: Long-term
 """
 	setLimitDisplayName(
 		input: SetLimitDisplayNameInput!
 	): Boolean!
+"""
+Stability: Long-term
+"""
 	setLoginBridge(
 		input: LoginBridgeInput!
 	): LoginBridge!
+"""
+Stability: Long-term
+"""
 	setLoginBridgeTermsState(
 		accepted: Boolean!
 	): LoginBridge!
 """
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	setLostCollectorDays(
 		days: Int
 	): Boolean!
 """
-[PREVIEW: Feature still in development] Sets the percentage of all hosts relevant to a particular cluster rebalance operation that need to be alive before we allow the system to automatically execute the operation to the supplied value. Cluster rebalance operations currently include reassigning digest work, and moving existing segments to balance disk usage.
+Sets the percentage of all hosts relevant to a particular cluster rebalance operation that need to be alive before we allow the system to automatically execute the operation to the supplied value. Cluster rebalance operations currently include reassigning digest work, and moving existing segments to balance disk usage.
+Stability: Short-term
 """
 	setMinHostAlivePercentageToEnableClusterRebalancing(
 """
@@ -5191,7 +6072,18 @@ Percentage of all hosts relevant to a particular cluster rebalance operation tha
 		minHostAlivePercentageToEnableClusterRebalancing: Int!
 	): Int!
 """
-[PREVIEW: Feature still in development] Sets the duration old object sampling will run for before dumping results and restarting
+Sets the starting read offset for the given ingest partition.
+Stability: Preview
+"""
+	setOffsetForDatasourcesOnPartition(
+"""
+Data for setting offset for datasources on partition type.
+"""
+		input: SetOffsetForDatasourcesOnPartitionInput!
+	): Boolean!
+"""
+Sets the duration old object sampling will run for before dumping results and restarting
+Stability: Preview
 """
 	setOldObjectSampleDurationMinutes(
 """
@@ -5204,7 +6096,8 @@ The duration old object sampling will run for before dumping results and restart
 		oldObjectSampleDurationMinutes: Long!
 	): Long!
 """
-[PREVIEW: Feature still in development] Toggles the OldObjectSample event on or off
+Toggles the OldObjectSample event on or off
+Stability: Preview
 """
 	setOldObjectSampleEnabled(
 """
@@ -5217,7 +6110,8 @@ true to enable the OldObjectSample event
 		oldObjectSampleEnabled: Boolean!
 	): Boolean!
 """
-[PREVIEW: Cache policies are a limited feature and is subject to change] Sets the default cache policy of the current organization. This policy will be applied to repos within the current organizatio if a repo cache policy is set.
+Sets the default cache policy of the current organization. This policy will be applied to repos within the current organizatio if a repo cache policy is set.
+Stability: Preview
 """
 	setOrgDefaultCachePolicy(
 """
@@ -5227,24 +6121,28 @@ Data to set a organization default cache policy
 	): Boolean!
 """
 Set the primary bucket target for the organization.
+Stability: Long-term
 """
 	setOrganizationBucket1(
 		targetBucketId1: String!
 	): Organization!
 """
 Set the secondary bucket target for the organization.
+Stability: Long-term
 """
 	setOrganizationBucket2(
 		targetBucketId2: String!
 	): Organization!
 """
-[PREVIEW: Requires the feature enabled for the organization.] Set the primary domain for the organization. If a primary domain is already set the existing primary domain is converted to a secondary domain
+Set the primary domain for the organization. If a primary domain is already set the existing primary domain is converted to a secondary domain
+Stability: Preview
 """
 	setPrimarySubdomain(
 		input: SetPrimarySubdomainInput!
 	): Organization!
 """
-[PREVIEW: Cache policies are a limited feature and is subject to change] Sets the cache policy of a repository.
+Sets the cache policy of a repository.
+Stability: Preview
 """
 	setRepoCachePolicy(
 """
@@ -5253,7 +6151,8 @@ Data to set a repo cache policy
 		input: SetRepoCachePolicyInput!
 	): Boolean!
 """
-[PREVIEW: Feature still in development] Sets the segment replication factor to the supplied value
+Sets the segment replication factor to the supplied value
+Stability: Short-term
 """
 	setSegmentReplicationFactor(
 """
@@ -5262,13 +6161,15 @@ replication factor for segment storage
 		segmentReplicationFactor: Int!
 	): Int!
 """
-[PREVIEW: Requires the feature enabled for the organization.] Set the subdomain settings for an organization. This overrides previously configured settings
+Set the subdomain settings for an organization. This overrides previously configured settings
+Stability: Preview
 """
 	setSubdomainSettings(
 		input: SetSubdomainSettingsInput!
 	): Organization!
 """
 Set current tag groupings for a repository.
+Stability: Long-term
 """
 	setTagGroupings(
 """
@@ -5281,7 +6182,7 @@ The tag groupings to set for the repository.
 		tagGroupings: [TagGroupingRuleInput!]!
 	): [TagGroupingRule!]!
 """
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	setWantedLogCollectorVersion(
 		id: String!
@@ -5290,19 +6191,21 @@ The tag groupings to set for the repository.
 	): Boolean!
 """
 Star a saved query in user settings.
+Stability: Long-term
 """
 	starQuery(
 		input: AddStarToQueryInput!
 	): BooleanResultType!
 """
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	startLogCollectorConfigurationTest(
 		configId: String!
 		collectorIds: [String!]!
 	): FleetConfigurationTest!
 """
-[PREVIEW: Feature still in development] Stops all running queries including streaming queries
+Stops all running queries including streaming queries
+Stability: Short-term
 """
 	stopAllQueries(
 """
@@ -5311,7 +6214,8 @@ Input to stopping queries.
 		input: StopQueriesInput
 	): Boolean!
 """
-[PREVIEW: Feature still in development] Stops all historical queries, ignores live and streaming queries
+Stops all historical queries, ignores live and streaming queries
+Stability: Short-term
 """
 	stopHistoricalQueries(
 """
@@ -5320,13 +6224,14 @@ Input to stopping queries.
 		input: StopQueriesInput
 	): Boolean!
 """
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	stopLogCollectorConfigurationTest(
 		configId: String!
 	): FleetConfigurationTest!
 """
 Stops all streaming queries
+Stability: Short-term
 """
 	stopStreamingQueries(
 """
@@ -5336,6 +6241,7 @@ Input to stopping queries.
 	): Boolean!
 """
 Tests whether the Iam role is setup correctly and that there is a connection to the SQS queue.
+Stability: Long-term
 """
 	testAwsS3SqsIngestFeed(
 """
@@ -5345,6 +6251,7 @@ Data for testing an ingest feed that uses AWS S3 and SQS
 	): Boolean!
 """
 Test an email action
+Stability: Long-term
 """
 	testEmailAction(
 """
@@ -5353,7 +6260,8 @@ Data for testing an email action
 		input: TestEmailAction!
 	): TestResult!
 """
-[PREVIEW: Not used by UI yet. Output is subject to change.] Test an FDR feed.
+Test an FDR feed.
+Stability: Long-term
 """
 	testFdrFeed(
 """
@@ -5363,6 +6271,7 @@ Data for testing an FDR feed.
 	): TestFdrResult!
 """
 Test a Humio repo action.
+Stability: Long-term
 """
 	testHumioRepoAction(
 """
@@ -5374,6 +6283,7 @@ Data for testing a Humio repo action
 Test that a Kafka event forwarder can connect to the specified Kafka server and topic.
 Note that this may create the topic on the broker if the Kafka broker is configured to automatically create
 topics.
+Stability: Long-term
 """
 	testKafkaEventForwarderV2(
 """
@@ -5383,6 +6293,7 @@ Data for testing a Kafka event forwarder
 	): TestResult!
 """
 Test an OpsGenie action.
+Stability: Long-term
 """
 	testOpsGenieAction(
 """
@@ -5392,6 +6303,7 @@ Data for testing an OpsGenie action
 	): TestResult!
 """
 Test a PagerDuty action.
+Stability: Long-term
 """
 	testPagerDutyAction(
 """
@@ -5407,12 +6319,14 @@ Test a parser on some test events. If the parser fails to run, an error is retur
 	): TestParserResultV2!
 """
 Test a parser on some test cases.
+Stability: Long-term
 """
 	testParserV2(
 		input: ParserTestRunInput!
 	): ParserTestRunOutput!
 """
 Test a Slack action.
+Stability: Long-term
 """
 	testSlackAction(
 """
@@ -5422,6 +6336,7 @@ Data for testing a Slack action.
 	): TestResult!
 """
 Test a post message Slack action.
+Stability: Long-term
 """
 	testSlackPostMessageAction(
 """
@@ -5431,6 +6346,7 @@ Data for testing a post message Slack action.
 	): TestResult!
 """
 Test an upload file action
+Stability: Long-term
 """
 	testUploadFileAction(
 """
@@ -5440,6 +6356,7 @@ Data for testing an upload file action.
 	): TestResult!
 """
 Test a VictorOps action.
+Stability: Long-term
 """
 	testVictorOpsAction(
 """
@@ -5449,6 +6366,7 @@ Data for testing a VictorOps action.
 	): TestResult!
 """
 Test a webhook action.
+Stability: Long-term
 """
 	testWebhookAction(
 """
@@ -5458,6 +6376,7 @@ Data for testing a webhook action.
 	): TestResult!
 """
 Will attempt to trigger a poll on an ingest feed.
+Stability: Long-term
 """
 	triggerPollIngestFeed(
 """
@@ -5467,6 +6386,7 @@ Data for trigger polling an ingest feed
 	): Boolean!
 """
 Un-associates a token with its currently assigned parser.
+Stability: Long-term
 """
 	unassignIngestToken(
 """
@@ -5479,31 +6399,36 @@ The name of the token.
 		tokenName: String!
 	): UnassignIngestTokenMutation!
 """
-[PREVIEW: Experimental feature to allow unassigning permissions to manage a subset of organizations.] Removes the organization management role assigned to the group for the provided organizations.
+Removes the organization management role assigned to the group for the provided organizations.
+Stability: Preview
 """
 	unassignOrganizationManagementRoleFromGroup(
 		input: UnassignOrganizationManagementRoleFromGroupInput!
-	): UnassignSystemRoleFromGroup!
+	): UnassignOrganizationManagementRoleFromGroup!
 """
-[PREVIEW: No note] Removes the organization role assigned to the group.
+Removes the organization role assigned to the group.
+Stability: Long-term
 """
 	unassignOrganizationRoleFromGroup(
 		input: RemoveOrganizationRoleFromGroupInput!
 	): UnassignOrganizationRoleFromGroup!
 """
 Removes the role assigned to the group for a given view.
+Stability: Long-term
 """
 	unassignRoleFromGroup(
 		input: RemoveRoleFromGroupInput!
 	): UnassignRoleFromGroup!
 """
-[PREVIEW: No note] Removes the system role assigned to the group.
+Removes the system role assigned to the group.
+Stability: Long-term
 """
 	unassignSystemRoleFromGroup(
 		input: RemoveSystemRoleFromGroupInput!
 	): UnassignSystemRoleFromGroup!
 """
 Unassign node tasks. Returns the set of assigned tasks after the unassign operation has completed.
+Stability: Short-term
 """
 	unassignTasks(
 """
@@ -5515,6 +6440,10 @@ List of tasks to unassign.
 """
 		tasks: [NodeTaskEnum!]!
 	): [NodeTaskEnum!]!
+"""
+Unassigns role(s) for user in the search domain.
+Stability: Long-term
+"""
 	unassignUserRoleForSearchDomain(
 		userId: String!
 		searchDomainId: String!
@@ -5525,18 +6454,20 @@ If specified, only unassigns the role with the specified id. If not specified, u
 	): User!
 """
 Unblock ingest to the specified repository. (Requires ManageCluster Permission)
+Stability: Long-term
 """
 	unblockIngest(
 		repositoryName: String!
 	): UnblockIngestMutation!
 """
-[PREVIEW: Under development] 
+Stability: Long-term
 """
 	unenrollLogCollectors(
 		ids: [String!]
 	): [EnrolledCollector!]!
 """
 Uninstalls a package from a specific view.
+Stability: Long-term
 """
 	uninstallPackage(
 """
@@ -5549,35 +6480,40 @@ The name of the view the package to uninstall is installed in.
 		viewName: String!
 	): BooleanResultType!
 """
-[PREVIEW: Feature still in development] 
+Stability: Preview
 """
 	unlinkChildOrganization(
 		childId: String!
 	): Boolean!
 """
 Unset a dynamic config. Requires Manage Cluster permission.
+Stability: Short-term
 """
 	unsetDynamicConfig(
 		input: UnsetDynamicConfigInputObject!
 	): Boolean!
 """
 Unset the secondary bucket target for the organization.
+Stability: Long-term
 """
 	unsetOrganizationBucket2: Organization!
 """
 Unstar a saved query in user settings.
+Stability: Long-term
 """
 	unstarQuery(
 		input: RemoveStarFromQueryInput!
 	): SavedQueryStarredUpdate!
 """
 Update the action security policies for the organization
+Stability: Long-term
 """
 	updateActionSecurityPolicies(
 		input: ActionSecurityPoliciesInput!
 	): Organization!
 """
 Update an aggregate alert.
+Stability: Long-term
 """
 	updateAggregateAlert(
 """
@@ -5587,6 +6523,7 @@ Data for updating an aggregate alert.
 	): AggregateAlert!
 """
 Update an alert.
+Stability: Long-term
 """
 	updateAlert(
 """
@@ -5596,6 +6533,7 @@ Data for updating an alert
 	): Alert!
 """
 Update an ingest feed, which uses AWS S3 and SQS
+Stability: Long-term
 """
 	updateAwsS3SqsIngestFeed(
 """
@@ -5604,19 +6542,28 @@ Data for updating an ingest feed which uses AWS S3 with SQS. The update is a del
 		input: UpdateAwsS3SqsIngestFeed!
 	): IngestFeed!
 """
-[PREVIEW: in development.] Update a custom link interaction.
+Stability: Preview
+"""
+	updateCrossOrgViewConnectionFilters(
+		input: UpdateCrossOrganizationViewConnectionFiltersInput!
+	): View!
+"""
+Update a custom link interaction.
+Stability: Long-term
 """
 	updateCustomLinkInteraction(
 		input: UpdateCustomLinkInteractionInput!
 	): InteractionId!
 """
 Update a dashboard.
+Stability: Long-term
 """
 	updateDashboard(
 		input: UpdateDashboardInput!
 	): UpdateDashboardMutation!
 """
 Update a dashboard filter.
+Stability: Long-term
 """
 	updateDashboardFilter(
 		id: String!
@@ -5625,13 +6572,15 @@ Update a dashboard filter.
 		prefixFilter: String!
 	): Dashboard!
 """
-[PREVIEW: in development.] Update a dashboard link interaction.
+Update a dashboard link interaction.
+Stability: Long-term
 """
 	updateDashboardLinkInteraction(
 		input: UpdateDashboardLinkInteractionInput!
 	): InteractionId!
 """
 Update a dashboard token to run as another user
+Stability: Long-term
 """
 	updateDashboardToken(
 		viewId: String!
@@ -5647,22 +6596,28 @@ Ownership of the query run by this shared dashboard. If value is User, ownership
 	): View!
 """
 Updates the default queryprefix for a group.
+Stability: Long-term
 """
 	updateDefaultQueryPrefix(
 		input: UpdateDefaultQueryPrefixInput!
 	): UpdateDefaultQueryPrefixMutation!
 """
 Updates the default role for a group.
+Stability: Long-term
 """
 	updateDefaultRole(
 		input: UpdateDefaultRoleInput!
 	): updateDefaultRoleMutation!
+"""
+Stability: Long-term
+"""
 	updateDescriptionForSearchDomain(
 		name: String!
 		newDescription: String!
 	): UpdateDescriptionMutation!
 """
-[PREVIEW: Under development] Updates a log collector configuration.
+Updates a log collector configuration.
+Stability: Short-term
 """
 	updateDraftLogCollectorConfiguration(
 		id: String!
@@ -5670,6 +6625,7 @@ Updates the default role for a group.
 	): LogCollectorConfiguration!
 """
 Update an email action.
+Stability: Long-term
 """
 	updateEmailAction(
 """
@@ -5679,6 +6635,7 @@ Data for updating an email action.
 	): EmailAction!
 """
 Update an event forwarding rule on a repository and return it
+Stability: Long-term
 """
 	updateEventForwardingRule(
 """
@@ -5688,6 +6645,7 @@ Data for updating an event forwarding rule
 	): EventForwardingRule!
 """
 Update an FDR feed with the supplied changes. Note that the input fields to this method, apart from `id` and `repositoryName`, only need to be supplied if the field should be changed.
+Stability: Long-term
 """
 	updateFdrFeed(
 """
@@ -5696,7 +6654,8 @@ Data for updating an FDR feed. Note that the fields, apart from `id` and `reposi
 		input: UpdateFdrFeed!
 	): FdrFeed!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] FDR feed administrator control update
+FDR feed administrator control update
+Stability: Long-term
 """
 	updateFdrFeedControl(
 """
@@ -5705,19 +6664,22 @@ Data for updating the administrator control of an FDR feed.
 		input: UpdateFdrFeedControl!
 	): FdrFeedControl!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Updates an alias mapping on a schema.
+Updates an alias mapping on a schema.
+Stability: Long-term
 """
 	updateFieldAliasMapping(
 		input: UpdateFieldAliasMappingInput!
 	): String!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Updates an existing schema.
+Updates an existing schema.
+Stability: Long-term
 """
 	updateFieldAliasSchema(
 		input: UpdateFieldAliasSchemaInput!
 	): FieldAliasSchema!
 """
 Change file
+Stability: Long-term
 """
 	updateFile(
 		fileName: String!
@@ -5745,6 +6707,7 @@ Starting index to replace the old rows with the updated ones. It does not take i
 	): UploadedFileSnapshot!
 """
 Update a filter alert.
+Stability: Long-term
 """
 	updateFilterAlert(
 """
@@ -5753,14 +6716,14 @@ Data for updating a filter alert
 		input: UpdateFilterAlert!
 	): FilterAlert!
 """
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	updateFleetInstallTokenConfigId(
 		token: String!
 		configId: String
 	): FleetInstallationToken!
 """
-[PREVIEW: Under development] 
+Stability: Long-term
 """
 	updateFleetInstallTokenName(
 		token: String!
@@ -5768,12 +6731,14 @@ Data for updating a filter alert
 	): FleetInstallationToken!
 """
 Updates the group.
+Stability: Long-term
 """
 	updateGroup(
 		input: UpdateGroupInput!
 	): UpdateGroupMutation!
 """
 Update a LogScale repository action.
+Stability: Long-term
 """
 	updateHumioRepoAction(
 """
@@ -5783,18 +6748,21 @@ Data for updating a LogScale repository action.
 	): HumioRepoAction!
 """
 Update IP filter.
+Stability: Long-term
 """
 	updateIPFilter(
 		input: IPFilterUpdateInput!
 	): IPFilter!
 """
 Update an ingest listener.
+Stability: Long-term
 """
 	updateIngestListenerV3(
 		input: UpdateIngestListenerV3Input!
 	): IngestListener!
 """
 Sets the ingest partition scheme of the LogScale cluster. Requires ManageCluster permission. Be aware that the ingest partition scheme is normally automated, and changes will be overwritten by the automation. This mutation should generally not be used unless the automation is temporarily disabled.
+Stability: Short-term
 """
 	updateIngestPartitionScheme(
 """
@@ -5804,6 +6772,7 @@ The list of ingest partitions. If partitions are missing in the input, they are 
 	): BooleanResultType!
 """
 Update a Kafka event forwarder and return it
+Stability: Long-term
 """
 	updateKafkaEventForwarder(
 """
@@ -5813,6 +6782,7 @@ Data for updating a Kafka event forwarder
 	): KafkaEventForwarder!
 """
 Update the license key for the LogScale cluster. If there is an existing license on this cluster this operation requires permission to manage cluster.
+Stability: Long-term
 """
 	updateLicenseKey(
 		license: String!
@@ -5825,12 +6795,14 @@ Update the limit with the given name, only the arguments defined will be updated
 	): Boolean!
 """
 Update the limit with the given name, only the arguments defined will be updated
+Stability: Long-term
 """
 	updateLimitV2(
 		input: UpdateLimitInputV2!
 	): LimitV2!
 """
-[PREVIEW: Experimental feature, not ready for production.] Update a cluster connection to a local view.
+Update a cluster connection to a local view.
+Stability: Short-term
 """
 	updateLocalClusterConnection(
 """
@@ -5839,52 +6811,56 @@ Data for updating a local cluster connection
 		input: UpdateLocalClusterConnectionInput!
 	): LocalClusterConnection!
 """
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	updateLogCollectorConfigurationDescription(
 		configId: String!
 		description: String
 	): LogCollectorConfiguration!
 """
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	updateLogCollectorConfigurationName(
 		configId: String!
 		name: String!
 	): LogCollectorConfiguration!
 """
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	updateLogCollectorGroupConfigIds(
 		id: String!
 		configIds: [String!]
 	): LogCollectorGroup!
 """
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	updateLogCollectorGroupFilter(
 		id: String!
 		filter: String
 	): LogCollectorGroup!
 """
-[PREVIEW: Under development] 
+Stability: Long-term
 """
 	updateLogCollectorGroupName(
 		id: String!
 		name: String!
 	): LogCollectorGroup!
 """
-[PREVIEW: Under development] 
+Stability: Short-term
 """
 	updateLogCollectorGroupWantedVersion(
 		id: String!
 		wantedVersion: String
 	): LogCollectorGroup!
+"""
+Stability: Long-term
+"""
 	updateLoginBridge(
 		input: LoginBridgeUpdateInput!
 	): LoginBridge!
 """
 Override the globally configured maximum number of auto shards.
+Stability: Long-term
 """
 	updateMaxAutoShardCount(
 		repositoryName: String!
@@ -5895,6 +6871,7 @@ New override value. Set to zero to remove current override.
 	): Repository!
 """
 Override the globally configured maximum size of ingest requests.
+Stability: Long-term
 """
 	updateMaxIngestRequestSize(
 		repositoryName: String!
@@ -5903,11 +6880,15 @@ New override value. Set to zero to remove current override.
 """
 		maxIngestRequestSize: Int!
 	): Repository!
+"""
+Stability: Long-term
+"""
 	updateOIDCIdentityProvider(
 		input: UpdateOidcConfigurationInput!
 	): OidcIdentityProvider!
 """
 Update an OpsGenie action.
+Stability: Long-term
 """
 	updateOpsGenieAction(
 """
@@ -5917,6 +6898,7 @@ Data for updating an OpsGenie action
 	): OpsGenieAction!
 """
 For manually fixing bad references. Root operation.
+Stability: Preview
 """
 	updateOrganizationForeignKey(
 		id: String!
@@ -5925,6 +6907,7 @@ For manually fixing bad references. Root operation.
 	): Organization!
 """
 Update information about the organization
+Stability: Short-term
 """
 	updateOrganizationInfo(
 		name: String!
@@ -5934,6 +6917,7 @@ Update information about the organization
 	): Organization!
 """
 For manually updating contract limits. System operation.
+Stability: Short-term
 """
 	updateOrganizationLimits(
 		input: OrganizationLimitsInput!
@@ -5948,18 +6932,21 @@ Update mutability of the organization
 	): Organization!
 """
 Update a note for a given organization. Requires root.
+Stability: Short-term
 """
 	updateOrganizationNotes(
 		notes: String!
 	): Boolean!
 """
 Update the permissions of an organization permission token.
+Stability: Long-term
 """
 	updateOrganizationPermissionsTokenPermissions(
 		input: UpdateOrganizationPermissionsTokenPermissionsInput!
 	): String!
 """
 Update an users organizations root state
+Stability: Short-term
 """
 	updateOrganizationRoot(
 		userId: String!
@@ -5967,18 +6954,21 @@ Update an users organizations root state
 	): Organization!
 """
 Update the subscription of the organization. Root operation.
+Stability: Short-term
 """
 	updateOrganizationSubscription(
 		input: UpdateSubscriptionInputObject!
 	): Organization!
 """
 Updates a package in a specific view.
+Stability: Long-term
 """
 	updatePackageFromRegistryV2(
 		UpdatePackageFromRegistryInput: UpdatePackageFromRegistryInput!
 	): PackageUpdateResult!
 """
 Updates a package from file provided in multipart/form-data (name=file) in a specific view.
+Stability: Long-term
 """
 	updatePackageFromZip(
 """
@@ -5990,12 +6980,13 @@ how to handle conflicts
 """
 		conflictResolutions: [ConflictResolutionConfiguration!]!
 """
-[PREVIEW: The query ownership feature is still in development] Ownership of the queries run by the triggers (e.g. alerts and scheduled searches) that are installed as part of this package. If value is User, ownership will be based on the calling user.
+Ownership of the queries run by the triggers (e.g. alerts and scheduled searches) that are installed as part of this package. If value is User, ownership will be based on the calling user.
 """
 		queryOwnershipType: QueryOwnershipType
 	): BooleanResultType!
 """
 Update a PagerDuty action.
+Stability: Long-term
 """
 	updatePagerDutyAction(
 """
@@ -6011,12 +7002,14 @@ Update a parser.
 	): UpdateParserMutation!
 """
 Update a parser. Only the provided fields are updated on the parser, and the remaining fields not provided are unchanged.
+Stability: Long-term
 """
 	updateParserV2(
 		input: UpdateParserInputV2!
 	): Parser!
 """
 Update the viewers profile.
+Stability: Long-term
 """
 	updateProfile(
 		firstName: String
@@ -6024,18 +7017,21 @@ Update the viewers profile.
 	): Account!
 """
 Updates queryprefix for a group in a view.
+Stability: Long-term
 """
 	updateQueryPrefix(
 		input: UpdateQueryPrefixInput!
 	): UpdateQueryPrefixMutation!
 """
 Update the readonly dashboard ip filter
+Stability: Long-term
 """
 	updateReadonlyDashboardIPFilter(
 		ipFilter: String
 	): Boolean!
 """
-[PREVIEW: Experimental feature, not ready for production.] Update a cluster connection to a remote view.
+Update a cluster connection to a remote view.
+Stability: Short-term
 """
 	updateRemoteClusterConnection(
 """
@@ -6045,18 +7041,21 @@ Data for updating a remote cluster connection
 	): RemoteClusterConnection!
 """
 Change the data type of a repository.
+Stability: Short-term
 """
 	updateRepositoryDataType(
 		input: UpdateRepoDataTypeInputObject!
 	): Boolean!
 """
 Change the limit id of a repository.
+Stability: Short-term
 """
 	updateRepositoryLimitId(
 		input: UpdateRepoLimitIdInputObject!
 	): Boolean!
 """
 Change the type of a repository. Only useful in Cloud setups.
+Stability: Long-term
 """
 	updateRepositoryType(
 		name: String!
@@ -6064,6 +7063,7 @@ Change the type of a repository. Only useful in Cloud setups.
 	): BooleanResultType!
 """
 Change the usage tag of a repository.
+Stability: Short-term
 """
 	updateRepositoryUsageTag(
 		name: String!
@@ -6071,6 +7071,7 @@ Change the usage tag of a repository.
 	): Boolean!
 """
 Update the retention policy of a repository.
+Stability: Long-term
 """
 	updateRetention(
 """
@@ -6094,9 +7095,15 @@ Sets time (in days) to keep backups before they are deleted.
 """
 		timeBasedBackupRetention: Float
 	): UpdateRetentionMutation!
+"""
+Stability: Long-term
+"""
 	updateRole(
 		input: UpdateRoleInput!
 	): UpdateRoleMutation!
+"""
+Stability: Long-term
+"""
 	updateSamlIdentityProvider(
 		id: String!
 		name: String!
@@ -6127,15 +7134,21 @@ Only used internal
 Lazy create users during login
 """
 		lazyCreateUsers: Boolean
+"""
+An alternative certificate to be used for IdP signature validation. Useful for handling certificate rollover
+"""
+		alternativeIdpCertificateInBase64: String
 	): SamlIdentityProvider!
 """
 Updates a saved query.
+Stability: Long-term
 """
 	updateSavedQuery(
 		input: UpdateSavedQueryInput!
 	): UpdateSavedQueryPayload!
 """
 Update a scheduled report. Only the supplied property values are updated.
+Stability: Long-term
 """
 	updateScheduledReport(
 		input: UpdateScheduledReportInput!
@@ -6150,19 +7163,32 @@ Data for updating a scheduled search
 		input: UpdateScheduledSearch!
 	): ScheduledSearch!
 """
-[PREVIEW: in development.] Update a search link interaction.
+Update a scheduled search.
+Stability: Long-term
+"""
+	updateScheduledSearchV2(
+"""
+Data for updating a scheduled search
+"""
+		input: UpdateScheduledSearchV2!
+	): ScheduledSearch!
+"""
+Update a search link interaction.
+Stability: Long-term
 """
 	updateSearchLinkInteraction(
 		input: UpdateSearchLinkInteractionInput!
 	): InteractionId!
 """
 Update session settings for the organization.
+Stability: Short-term
 """
 	updateSessionSettings(
 		input: SessionInput!
 	): Organization!
 """
-[PREVIEW: This mutation is dictated by the needs of the LogScale UI, and may include unstable or ephemeral settings.] Set flags for UI states and help messages.
+Set flags for UI states and help messages.
+Stability: Preview
 """
 	updateSettings(
 		isWelcomeMessageDismissed: Boolean
@@ -6181,12 +7207,14 @@ Update session settings for the organization.
 	): UserSettings!
 """
 Update the shared dashboards security policies for the organization. Updating the policies will update or delete all existing tokens that do not fit into the changes. For instance, enforcing an IP filter will set the IP filter on all shared dashboard tokens. Disabling shared dashboard tokens, will delete all shared dashboard tokens.
+Stability: Long-term
 """
 	updateSharedDashboardsSecurityPolicies(
 		input: SharedDashboardsSecurityPoliciesInput!
 	): Organization!
 """
 Update a Slack action.
+Stability: Long-term
 """
 	updateSlackAction(
 """
@@ -6196,6 +7224,7 @@ Data for updating a Slack action
 	): SlackAction!
 """
 Update a post-message Slack action.
+Stability: Long-term
 """
 	updateSlackPostMessageAction(
 """
@@ -6204,25 +7233,29 @@ Data for updating a post-message Slack action
 		input: UpdatePostMessageSlackAction!
 	): SlackPostMessageAction!
 """
-[PREVIEW: Requires the feature enabled for the organization.] Update the social login options for the organization
+Update the social login options for the organization
+Stability: Preview
 """
 	updateSocialLoginSettings(
 		input: [SocialLoginSettingsInput!]!
 	): Organization!
 """
 Update the permissions of a system permission token.
+Stability: Long-term
 """
 	updateSystemPermissionsTokenPermissions(
 		input: UpdateSystemPermissionsTokenPermissionsInput!
 	): String!
 """
 Update the token security policies for the organization. Updating the policies will update or delete all existing tokens that do not fit into the changes. For instance, enforcing an IP filter for personal user tokens will set the IP filter on all tokens of that type. Disabling a token type, will delete all tokens of that type. Finally setting an enforce expiration after will set that on all tokens that are above the interval and keep their current expiration if inside the interval. Tokens below the expiration will be deleted.
+Stability: Long-term
 """
 	updateTokenSecurityPolicies(
 		input: TokenSecurityPoliciesInput!
 	): Organization!
 """
 Update an upload file action.
+Stability: Long-term
 """
 	updateUploadFileAction(
 """
@@ -6232,24 +7265,28 @@ Data for updating an upload file action.
 	): UploadFileAction!
 """
 Updates a user. Requires Root Permission.
+Stability: Long-term
 """
 	updateUser(
 		input: AddUserInput!
 	): UpdateUserMutation!
 """
 Updates a user.
+Stability: Long-term
 """
 	updateUserById(
 		input: UpdateUserByIdInput!
 	): UpdateUserByIdMutation!
 """
 Update user default settings for the organization.
+Stability: Short-term
 """
 	updateUserDefaultSettings(
 		input: UserDefaultSettingsInput!
 	): Organization!
 """
 Update a VictorOps action.
+Stability: Long-term
 """
 	updateVictorOpsAction(
 """
@@ -6259,6 +7296,7 @@ Data for updating a VictorOps action.
 	): VictorOpsAction!
 """
 Update a view.
+Stability: Long-term
 """
 	updateView(
 		viewName: String!
@@ -6266,12 +7304,14 @@ Update a view.
 	): View!
 """
 Update the permissions of a view permission token.
+Stability: Long-term
 """
 	updateViewPermissionsTokenPermissions(
 		input: UpdateViewPermissionsTokenPermissionsInput!
 	): String!
 """
 Update a webhook action.
+Stability: Long-term
 """
 	updateWebhookAction(
 """
@@ -6281,6 +7321,7 @@ Data for updating a webhook action
 	): WebhookAction!
 """
 Upgrade the account.
+Stability: Long-term
 """
 	upgradeAccount(
 		input: UpgradeAccountData!
@@ -6291,6 +7332,9 @@ Upgrade the account.
 This authentication type can be used to use LogScale without authentication. This should only be considered for testing and development purposes, it is not recommended for production systems and prevents LogScale from doing proper Audit Logging.
 """
 type NoAuthentication implements AuthenticationMethod{
+"""
+Stability: Preview
+"""
 	name: String!
 }
 
@@ -6298,15 +7342,45 @@ type NoAuthentication implements AuthenticationMethod{
 A widget get text, links, etc.
 """
 type NoteWidget implements Widget{
+"""
+Stability: Long-term
+"""
 	backgroundColor: String
+"""
+Stability: Long-term
+"""
 	textColor: String
+"""
+Stability: Long-term
+"""
 	text: String!
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	title: String!
+"""
+Stability: Long-term
+"""
 	description: String
+"""
+Stability: Long-term
+"""
 	x: Int!
+"""
+Stability: Long-term
+"""
 	y: Int!
+"""
+Stability: Long-term
+"""
 	width: Int!
+"""
+Stability: Long-term
+"""
 	height: Int!
 }
 
@@ -6326,11 +7400,29 @@ input NotificationInput {
 Authentication through OAuth Identity Providers.
 """
 type OAuthAuthentication implements AuthenticationMethod{
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	uiLoginFlow: Boolean!
+"""
+Stability: Long-term
+"""
 	google: OAuthProvider
+"""
+Stability: Long-term
+"""
 	github: OAuthProvider
+"""
+Stability: Long-term
+"""
 	bitbucket: OAuthProvider
+"""
+Stability: Long-term
+"""
 	oidc: OIDCProvider
 }
 
@@ -6338,8 +7430,17 @@ type OAuthAuthentication implements AuthenticationMethod{
 An OAuth Identity Provider.
 """
 type OAuthProvider {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	clientId: String!
+"""
+Stability: Long-term
+"""
 	redirectUrl: String!
 }
 
@@ -6347,12 +7448,33 @@ type OAuthProvider {
 An OIDC identity provider
 """
 type OIDCProvider {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	clientId: String!
+"""
+Stability: Long-term
+"""
 	redirectUrl: String!
+"""
+Stability: Long-term
+"""
 	authorizationEndpoint: String
+"""
+Stability: Long-term
+"""
 	serviceName: String
+"""
+Stability: Long-term
+"""
 	scopes: [String!]!
+"""
+Stability: Long-term
+"""
 	federatedIdp: String
 }
 
@@ -6386,13 +7508,37 @@ input OidcConfigurationInput {
 }
 
 type OidcIdentityProviderAuth implements AuthenticationMethodAuth{
+"""
+Stability: Long-term
+"""
 	redirectUrl: String!
+"""
+Stability: Long-term
+"""
 	authType: String!
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	scopes: [String!]!
+"""
+Stability: Long-term
+"""
 	serviceName: String!
+"""
+Stability: Long-term
+"""
 	authorizeEndpoint: String!
+"""
+Stability: Long-term
+"""
 	clientId: String!
+"""
+Stability: Long-term
+"""
 	federatedIdp: String
 }
 
@@ -6402,30 +7548,37 @@ Represents information about a LogScale License.
 type OnPremLicense implements License{
 """
 The time at which the license expires.
+Stability: Long-term
 """
 	expiresAt: DateTime!
 """
 The time at which the license was issued.
+Stability: Long-term
 """
 	issuedAt: DateTime!
 """
 license id.
+Stability: Long-term
 """
 	uid: String!
 """
 The maximum number of user accounts allowed in LogScale. Unlimited if undefined.
+Stability: Long-term
 """
 	maxUsers: Int
 """
 The name of the entity the license was issued to.
+Stability: Long-term
 """
 	owner: String!
 """
 Indicates whether the license allows running LogScale as a SaaS platform.
+Stability: Long-term
 """
 	isSaaS: Boolean!
 """
 Indicates whether the license is an OEM license.
+Stability: Long-term
 """
 	isOem: Boolean!
 }
@@ -6436,49 +7589,68 @@ An OpsGenie action
 type OpsGenieAction implements Action{
 """
 OpsGenie webhook url to send the request to.
+Stability: Long-term
 """
 	apiUrl: String!
 """
 Key to authenticate with OpsGenie.
+Stability: Long-term
 """
 	genieKey: String!
 """
 Defines whether the action should use the configured proxy to make web requests.
+Stability: Long-term
 """
 	useProxy: Boolean!
 """
 The name of the action.
+Stability: Long-term
 """
 	name: String!
 """
 The display name of the action.
+Stability: Long-term
 """
 	displayName: String!
 """
 The id of the action.
+Stability: Long-term
 """
 	id: String!
 """
 A template that can be used to recreate the action.
+Stability: Long-term
 """
 	yamlTemplate: YAML!
+"""
+Stability: Long-term
+"""
 	packageId: VersionedPackageSpecifier
 """
-The package if any which the action is part of.
+The package, if any, which the action is part of.
+Stability: Long-term
 """
 	package: PackageInstallation
 """
 False if this type of action is disabled because of a security policy, true otherwise
+Stability: Long-term
 """
 	isAllowedToRun: Boolean!
 """
 True if this action is used by triggers, where the query is run by the organization. If true, then the OrganizationOwnedQueries permission is required to edit the action.
+Stability: Long-term
 """
 	requiresOrganizationOwnedQueriesPermissionToEdit: Boolean!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Allowed asset actions
+Allowed asset actions
+Stability: Preview
 """
 	allowedActions: [AssetAction!]!
+"""
+The resource identifier for this action.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 input OrganizationLimitsInput {
@@ -6494,7 +7666,13 @@ input OrganizationLimitsInput {
 A link between two organizations
 """
 type OrganizationLink {
+"""
+Stability: Preview
+"""
 	parentOrganization: Organization!
+"""
+Stability: Preview
+"""
 	childOrganization: Organization!
 }
 
@@ -6504,10 +7682,12 @@ Query running with organization based ownership
 type OrganizationOwnership implements QueryOwnership{
 """
 Organization owning and running the query
+Stability: Long-term
 """
 	organization: Organization!
 """
 Id of organization owning and running the query
+Stability: Long-term
 """
 	id: String!
 }
@@ -6518,30 +7698,37 @@ Organization permissions token. The token allows the caller to work with organiz
 type OrganizationPermissionsToken implements Token{
 """
 The set of permissions on the token
+Stability: Long-term
 """
 	permissions: [String!]!
 """
 The id of the token.
+Stability: Long-term
 """
 	id: String!
 """
 The name of the token.
+Stability: Long-term
 """
 	name: String!
 """
 The time at which the token expires.
+Stability: Long-term
 """
 	expireAt: Long
 """
 The ip filter on the token.
+Stability: Long-term
 """
 	ipFilter: String
 """
 The ip filter on the token.
+Stability: Long-term
 """
 	ipFilterV2: IPFilter
 """
 The date the token was created.
+Stability: Long-term
 """
 	createdAt: Long!
 }
@@ -6572,11 +7759,15 @@ An event produced by a parser in a test run
 type OutputEvent {
 """
 The fields of the event
+Stability: Long-term
 """
 	fields: [EventField!]!
 }
 
 type PackageUpdateResult {
+"""
+Stability: Long-term
+"""
 	package: Package2!
 }
 
@@ -6586,49 +7777,68 @@ A PagerDuty action.
 type PagerDutyAction implements Action{
 """
 Severity level to give to the message.
+Stability: Long-term
 """
 	severity: String!
 """
 Routing key to authenticate with PagerDuty.
+Stability: Long-term
 """
 	routingKey: String!
 """
 Defines whether the action should use the configured proxy to make web requests.
+Stability: Long-term
 """
 	useProxy: Boolean!
 """
 The name of the action.
+Stability: Long-term
 """
 	name: String!
 """
 The display name of the action.
+Stability: Long-term
 """
 	displayName: String!
 """
 The id of the action.
+Stability: Long-term
 """
 	id: String!
 """
 A template that can be used to recreate the action.
+Stability: Long-term
 """
 	yamlTemplate: YAML!
+"""
+Stability: Long-term
+"""
 	packageId: VersionedPackageSpecifier
 """
-The package if any which the action is part of.
+The package, if any, which the action is part of.
+Stability: Long-term
 """
 	package: PackageInstallation
 """
 False if this type of action is disabled because of a security policy, true otherwise
+Stability: Long-term
 """
 	isAllowedToRun: Boolean!
 """
 True if this action is used by triggers, where the query is run by the organization. If true, then the OrganizationOwnedQueries permission is required to edit the action.
+Stability: Long-term
 """
 	requiresOrganizationOwnedQueriesPermissionToEdit: Boolean!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Allowed asset actions
+Allowed asset actions
+Stability: Preview
 """
 	allowedActions: [AssetAction!]!
+"""
+The resource identifier for this action.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 input ParameterFilePropertiesInput {
@@ -6677,13 +7887,37 @@ input ParameterInput {
 A widget that contains dashboard parameters.
 """
 type ParameterPanel implements Widget{
+"""
+Stability: Long-term
+"""
 	parameterIds: [String!]!
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	title: String!
+"""
+Stability: Long-term
+"""
 	description: String
+"""
+Stability: Long-term
+"""
 	x: Int!
+"""
+Stability: Long-term
+"""
 	y: Int!
+"""
+Stability: Long-term
+"""
 	width: Int!
+"""
+Stability: Long-term
+"""
 	height: Int!
 }
 
@@ -6801,10 +8035,12 @@ Contains any test failures that relates to a specific output event. This is a ke
 type ParserTestCaseFailuresForOutput {
 """
 The index of the output event which these failures pertain to. Note that there may be failures pointing to non-existing output events, if e.g. an assertion was made on an output event which was not produced.
+Stability: Long-term
 """
 	outputEventIndex: Int!
 """
 Failures for the output event.
+Stability: Long-term
 """
 	failures: ParserTestCaseOutputFailures!
 }
@@ -6843,20 +8079,29 @@ Failures for an output event.
 type ParserTestCaseOutputFailures {
 """
 Any errors produced by the parser when creating an output event.
+Stability: Long-term
 """
 	parsingErrors: [String!]!
 """
 Any assertion failures on the given output event. Note that all assertion failures can be uniquely identified by the output event index and the field name they operate on.
+Stability: Long-term
 """
 	assertionFailuresOnFields: [AssertionFailureOnField!]!
 """
-[PREVIEW: API under active development] Fields where the name begins with `#` even though they are not a tag. In LogScale, field names beginning with `#` are treated specially, and should only be constructed through the tagging mechanism. Fields which do begin with `#`, but are not proper tags, will be effectively unsearchable.
+Fields where the name begins with `#` even though they are not a tag. In LogScale, field names beginning with `#` are treated specially, and should only be constructed through the tagging mechanism. Fields which do begin with `#`, but are not proper tags, will be effectively unsearchable.
+Stability: Preview
 """
 	falselyTaggedFields: [String!]!
 """
-[PREVIEW: API under active development] Any arrays with gaps in them. That is, if the fields `a[0]` and `a[2]` exist on an event, but not `a[1]`, we consider the array `a` to have a gap. This means LogScale will not include the `a[2]` field when doing array-based searches, since it considers `a[0]` to be the last element of the array.
+Any arrays with gaps in them. That is, if the fields `a[0]` and `a[2]` exist on an event, but not `a[1]`, we consider the array `a` to have a gap. This means LogScale will not include the `a[2]` field when doing array-based searches, since it considers `a[0]` to be the last element of the array.
+Stability: Preview
 """
 	arraysWithGaps: [ArrayWithGap!]!
+"""
+Returns violations of a schema, given that a schema has been provided in the request.
+Stability: Preview
+"""
+	schemaViolations: [SchemaViolation!]!
 }
 
 """
@@ -6865,10 +8110,12 @@ The output for parsing and verifying a test case
 type ParserTestCaseResult {
 """
 The events produced by the parser. Contains zero to many events, as a parser can both drop events, or produce multiple output events from a single input.
+Stability: Long-term
 """
 	outputEvents: [OutputEvent!]!
 """
 Any failures produced during testing. If the list is empty, the test case can be considered to have passed. If the list contains elements, they are key-value pairs to be treated as a map-construct, where the index of the output event is the key, and the failures are the value.
+Stability: Long-term
 """
 	outputFailures: [ParserTestCaseFailuresForOutput!]!
 }
@@ -6887,6 +8134,9 @@ An event for a parser to parse during testing.
 A parser test result, where an unexpected error occurred during parsing.
 """
 type ParserTestRunAborted {
+"""
+Stability: Long-term
+"""
 	errorMessage: String!
 }
 
@@ -6896,6 +8146,7 @@ A parser test result, where all test cases were parsed and assertions run. Each 
 type ParserTestRunCompleted {
 """
 The results for running each test case.
+Stability: Long-term
 """
 	results: [ParserTestCaseResult!]!
 }
@@ -6932,12 +8183,46 @@ Input for testing a parser
 Input for testing a parser
 """
 	languageVersion: LanguageVersionInputType
+"""
+Input for testing a parser
+"""
+	schema: YAML
 }
 
 """
 The output of running all the parser test cases.
 """
 union ParserTestRunOutput =ParserTestRunCompleted | ParserTestRunAborted
+
+input PermissionAssignmentInputType {
+	actor: ActorInput!
+	resource: String!
+	permissionSet: PermissionSetInput!
+	queryPrefix: String
+}
+
+input PermissionSetInput {
+	permissionSetType: PermissionSetType!
+	values: [String!]!
+}
+
+"""
+The different ways to specify a set of permissions.
+"""
+enum PermissionSetType {
+"""
+Permission set is expressed directly as a list of permissions
+"""
+	Direct
+"""
+Permission set is expressed as a list of role Ids
+"""
+	RoleId
+"""
+Permission set is expressed as a list of role names each matching one of values defined in the ReadonlyDefaultRole enum.
+"""
+	ReadonlyDefaultRole
+}
 
 enum Purposes {
 	MSP
@@ -6953,85 +8238,126 @@ A dashboard parameter where suggestions are sourced from query results from LogS
 type QueryBasedDashboardParameter implements DashboardParameter{
 """
 The LogScale query executed to find suggestions for the parameter value.
+Stability: Long-term
 """
 	queryString: String!
 """
 The time window (relative to now) in which LogScale will search for suggestions. E.g. 24h or 30d.
+Stability: Long-term
 """
 	timeWindow: String!
 """
 The field in the result set used as the 'value' of the suggestions.
+Stability: Long-term
 """
 	optionValueField: String!
 """
 The field in the result set used as the 'label' (the text in the dropdown) of the suggestions.
+Stability: Long-term
 """
 	optionLabelField: String!
 """
 If true, the parameters search time window will automatically change to match the dashboard's global time when active.
+Stability: Long-term
 """
 	useDashboardTimeIfSet: Boolean!
 """
 Regex patterns used to block parameter input.
+Stability: Long-term
 """
 	invalidInputPatterns: [String!]
 """
 Message when parameter input is blocked.
+Stability: Long-term
 """
 	invalidInputMessage: String
 """
 The ID of the parameter.
+Stability: Long-term
 """
 	id: String!
 """
 The label or 'name' displayed next to the input for the variable to make it more human-readable.
+Stability: Long-term
 """
 	label: String!
 """
 The value assigned to the parameter on dashboard load, if no other value is specified.
+Stability: Long-term
 """
 	defaultValueV2: String
 """
 A number that determines the order in which parameters are displayed on a dashboard. If null, the parameter is ordered after other parameters in alphanumerical order.
+Stability: Long-term
 """
 	order: Int
 """
 A number that determines the width of a parameter.
+Stability: Long-term
 """
 	width: Int
-"""
-[PREVIEW: The multi-value parameters feature is still in development.] A flag indicating whether the parameter supports having multiple values
-"""
-	isMultiParam: Boolean
-"""
-[PREVIEW: The multi-value parameters feature is still in development.] The value assigned to the multi-value parameter on dashboard load, if no other value is specified. This replaces defaultValue whenever isMultiParam is true
-"""
-	defaultMultiValues: [String!]
 }
 
 """
 A widget with a visualization of a query result.
 """
 type QueryBasedWidget implements Widget{
+"""
+Stability: Long-term
+"""
 	queryString: String!
+"""
+Stability: Long-term
+"""
 	start: String!
+"""
+Stability: Long-term
+"""
 	end: String!
+"""
+Stability: Long-term
+"""
 	isLive: Boolean!
+"""
+Stability: Long-term
+"""
 	widgetType: String!
 """
 An optional JSON value containing styling and other settings for the widget. This is solely used by the UI.
+Stability: Long-term
 """
 	options: JSON
 """
-[PREVIEW: Widget based interaction feature is under preview.] 
+Stability: Long-term
 """
 	interactions: [QueryBasedWidgetInteraction!]!
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	title: String!
+"""
+Stability: Long-term
+"""
 	description: String
+"""
+Stability: Long-term
+"""
 	x: Int!
+"""
+Stability: Long-term
+"""
 	y: Int!
+"""
+Stability: Long-term
+"""
 	width: Int!
+"""
+Stability: Long-term
+"""
 	height: Int!
 }
 
@@ -7073,6 +8399,7 @@ Default Query Quota Settings for users which have not had specific settings assi
 type QueryQuotaDefaultSettings {
 """
 List of the rules that apply
+Stability: Short-term
 """
 	settings: [QueryQuotaIntervalSetting!]!
 }
@@ -7101,28 +8428,40 @@ input RedactEventsInputType {
 	userMessage: String
 }
 
+type RefreshClusterManagementStatsMutation {
+"""
+Stability: Preview
+"""
+	reasonsNodeCannotBeSafelyUnregistered: ReasonsNodeCannotBeSafelyUnregistered!
+}
+
 """
 A remote cluster connection.
 """
 type RemoteClusterConnection implements ClusterConnection{
 """
 Public URL of the remote cluster to connect with
+Stability: Short-term
 """
 	publicUrl: String!
 """
 Id of the connection
+Stability: Short-term
 """
 	id: String!
 """
 Cluster identity of the connection
+Stability: Short-term
 """
 	clusterId: String!
 """
 Cluster connection tags
+Stability: Short-term
 """
 	tags: [ClusterConnectionTag!]!
 """
 Cluster connection query prefix
+Stability: Short-term
 """
 	queryPrefix: String!
 }
@@ -7146,17 +8485,27 @@ Data for removing a label from an alert
 }
 
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field removeFieldAliasMapping
+Input object for field removeFieldAliasMapping
 """
 input RemoveAliasMappingInput {
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field removeFieldAliasMapping
+Input object for field removeFieldAliasMapping
 """
 	schemaId: String!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field removeFieldAliasMapping
+Input object for field removeFieldAliasMapping
 """
 	aliasMappingId: String!
+}
+
+input RemoveCrossOrgViewConnectionModel {
+	repoName: String!
+	organizationId: String!
+}
+
+input RemoveCrossOrgViewConnectionsInput {
+	name: String!
+	connectionsToRemove: [RemoveCrossOrgViewConnectionModel!]!
 }
 
 """
@@ -7170,6 +8519,9 @@ Data for removing a blocklist entry
 }
 
 type RemoveGroupMutation {
+"""
+Stability: Long-term
+"""
 	group: Group!
 }
 
@@ -7206,6 +8558,9 @@ input RemoveParserInput {
 }
 
 type RemoveParserMutation {
+"""
+Stability: Long-term
+"""
 	parser: Parser!
 }
 
@@ -7268,6 +8623,9 @@ input RemoveStarToFieldInput {
 }
 
 type RemoveStarToFieldMutation {
+"""
+Stability: Long-term
+"""
 	starredFields: [String!]!
 }
 
@@ -7281,6 +8639,9 @@ input RemoveUserByIdInput {
 }
 
 type RemoveUserByIdMutation {
+"""
+Stability: Long-term
+"""
 	user: User!
 }
 
@@ -7289,6 +8650,9 @@ input RemoveUserInput {
 }
 
 type RemoveUserMutation {
+"""
+Stability: Long-term
+"""
 	user: User!
 }
 
@@ -7298,6 +8662,9 @@ input RemoveUsersFromGroupInput {
 }
 
 type RemoveUsersFromGroupMutation {
+"""
+Stability: Long-term
+"""
 	group: Group!
 }
 
@@ -7342,6 +8709,7 @@ Data for resetting quota
 
 input RestoreDeletedSearchDomainInput {
 	id: String!
+	fallbackLimitId: String
 }
 
 input ResubmitMarketoLeadData {
@@ -7366,20 +8734,38 @@ input RunInconsistencyCheckInput {
 This authentication type implements the SAML 2.0 Web Browser SSO Profile.
 """
 type SAMLAuthentication implements AuthenticationMethod{
+"""
+Stability: Long-term
+"""
 	name: String!
 }
 
 type SamlIdentityProviderAuth implements AuthenticationMethodAuth{
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	authType: String!
 }
 
 type SavedQueryIsStarred {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	isStarred: Boolean!
 }
 
 type SavedQueryStarredUpdate {
+"""
+Stability: Long-term
+"""
 	savedQuery: SavedQueryIsStarred!
 }
 
@@ -7408,6 +8794,22 @@ input SchemaFieldInput {
 	description: String
 }
 
+"""
+Violations detected against the provided schema
+"""
+type SchemaViolation {
+"""
+The name of the field on which the violation was detected
+Stability: Preview
+"""
+	fieldName: String!
+"""
+Error message for the violation
+Stability: Preview
+"""
+	errorMessage: String!
+}
+
 input SearchLinkInteractionInput {
 	name: String!
 	titleTemplate: String
@@ -7428,6 +8830,12 @@ input SectionInput {
 	timeSelector: TimeIntervalInput
 	widgetIds: [String!]!
 	order: Int!
+}
+
+input SeriesConfigInput {
+	name: String!
+	title: String
+	color: String
 }
 
 input ServiceLevelIndicatorLogArg {
@@ -7464,6 +8872,20 @@ Data to set a global default cache policy
 input SetLimitDisplayNameInput {
 	limitName: String!
 	displayName: String
+}
+
+"""
+Data for setting offset for datasources on partition type.
+"""
+input SetOffsetForDatasourcesOnPartitionInput {
+"""
+Data for setting offset for datasources on partition type.
+"""
+	offset: Long!
+"""
+Data for setting offset for datasources on partition type.
+"""
+	partition: Int!
 }
 
 """
@@ -7538,49 +8960,68 @@ A Slack action
 type SlackAction implements Action{
 """
 Slack webhook url to send the request to.
+Stability: Long-term
 """
 	url: String!
 """
 Fields to include within the Slack message. Can be templated with values from the result.
+Stability: Long-term
 """
 	fields: [SlackFieldEntry!]!
 """
 Defines whether the action should use the configured proxy to make web requests.
+Stability: Long-term
 """
 	useProxy: Boolean!
 """
 The name of the action.
+Stability: Long-term
 """
 	name: String!
 """
 The display name of the action.
+Stability: Long-term
 """
 	displayName: String!
 """
 The id of the action.
+Stability: Long-term
 """
 	id: String!
 """
 A template that can be used to recreate the action.
+Stability: Long-term
 """
 	yamlTemplate: YAML!
+"""
+Stability: Long-term
+"""
 	packageId: VersionedPackageSpecifier
 """
-The package if any which the action is part of.
+The package, if any, which the action is part of.
+Stability: Long-term
 """
 	package: PackageInstallation
 """
 False if this type of action is disabled because of a security policy, true otherwise
+Stability: Long-term
 """
 	isAllowedToRun: Boolean!
 """
 True if this action is used by triggers, where the query is run by the organization. If true, then the OrganizationOwnedQueries permission is required to edit the action.
+Stability: Long-term
 """
 	requiresOrganizationOwnedQueriesPermissionToEdit: Boolean!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Allowed asset actions
+Allowed asset actions
+Stability: Preview
 """
 	allowedActions: [AssetAction!]!
+"""
+The resource identifier for this action.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 """
@@ -7589,10 +9030,12 @@ Field entry in a Slack message
 type SlackFieldEntry {
 """
 Key of a Slack field.
+Stability: Long-term
 """
 	fieldName: String!
 """
 Value of a Slack field.
+Stability: Long-term
 """
 	value: String!
 }
@@ -7617,59 +9060,104 @@ A slack post-message action.
 type SlackPostMessageAction implements Action{
 """
 Api token to authenticate with Slack.
+Stability: Long-term
 """
 	apiToken: String!
 """
 List of Slack channels to message.
+Stability: Long-term
 """
 	channels: [String!]!
 """
 Fields to include within the Slack message. Can be templated with values from the result.
+Stability: Long-term
 """
 	fields: [SlackFieldEntry!]!
 """
 Defines whether the action should use the configured proxy to make web requests.
+Stability: Long-term
 """
 	useProxy: Boolean!
 """
 The name of the action.
+Stability: Long-term
 """
 	name: String!
 """
 The display name of the action.
+Stability: Long-term
 """
 	displayName: String!
 """
 The id of the action.
+Stability: Long-term
 """
 	id: String!
 """
 A template that can be used to recreate the action.
+Stability: Long-term
 """
 	yamlTemplate: YAML!
+"""
+Stability: Long-term
+"""
 	packageId: VersionedPackageSpecifier
 """
-The package if any which the action is part of.
+The package, if any, which the action is part of.
+Stability: Long-term
 """
 	package: PackageInstallation
 """
 False if this type of action is disabled because of a security policy, true otherwise
+Stability: Long-term
 """
 	isAllowedToRun: Boolean!
 """
 True if this action is used by triggers, where the query is run by the organization. If true, then the OrganizationOwnedQueries permission is required to edit the action.
+Stability: Long-term
 """
 	requiresOrganizationOwnedQueriesPermissionToEdit: Boolean!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Allowed asset actions
+Allowed asset actions
+Stability: Preview
 """
 	allowedActions: [AssetAction!]!
+"""
+The resource identifier for this action.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 input SocialLoginSettingsInput {
 	socialProviderProfile: SocialProviderProfile!
 	filter: SocialLoginField!
 	allowList: [String!]!
+}
+
+type Stability {
+"""
+Stability: Long-term
+"""
+	level: StabilityLevel!
+}
+
+"""
+How stable a field or enum value is.
+"""
+enum StabilityLevel {
+"""
+This part of the API is still under development and can change without warning.
+"""
+	Preview
+"""
+This part of the API is short-term stable which means that breaking changes will be announced 12 weeks in advance, except in extraordinary situations like security issues.
+"""
+	ShortTerm
+"""
+This part of the API is long-term stable which means that breaking changes will be announced 1 year in advance, except in extraordinary situations like security issues.
+"""
+	LongTerm
 }
 
 input StopQueriesInput {
@@ -7682,30 +9170,37 @@ System permissions token. The token allows the caller to work with system-level 
 type SystemPermissionsToken implements Token{
 """
 The set of permissions on the token
+Stability: Long-term
 """
 	permissions: [String!]!
 """
 The id of the token.
+Stability: Long-term
 """
 	id: String!
 """
 The name of the token.
+Stability: Long-term
 """
 	name: String!
 """
 The time at which the token expires.
+Stability: Long-term
 """
 	expireAt: Long
 """
 The ip filter on the token.
+Stability: Long-term
 """
 	ipFilter: String
 """
 The ip filter on the token.
+Stability: Long-term
 """
 	ipFilterV2: IPFilter
 """
 The date the token was created.
+Stability: Long-term
 """
 	createdAt: Long!
 }
@@ -7806,6 +9301,7 @@ Collection of errors, which occurred during test.
 type TestFdrErrorResult {
 """
 List of test errors.
+Stability: Long-term
 """
 	errors: [error!]!
 }
@@ -7846,10 +9342,12 @@ An error, which occurred when making a request towards an AWS resource.
 type TestFdrRequestError {
 """
 Name of the AWS resource, which the request was made towards.
+Stability: Long-term
 """
 	resourceName: String!
 """
 Message specifying the request error.
+Stability: Long-term
 """
 	message: String!
 }
@@ -7865,6 +9363,7 @@ Test was a success.
 type TestFdrSuccessResult {
 """
 This field is always 'true'
+Stability: Long-term
 """
 	result: Boolean!
 }
@@ -7875,10 +9374,12 @@ A validation error related to a particular input field.
 type TestFdrValidationError {
 """
 Name of the field, which the error relates to.
+Stability: Long-term
 """
 	fieldName: String!
 """
 Message specifying the validation error.
+Stability: Long-term
 """
 	message: String!
 }
@@ -8098,10 +9599,12 @@ The result of the test
 type TestResult {
 """
 True if the test was a success, false otherwise
+Stability: Long-term
 """
 	success: Boolean!
 """
 A message explaining the test result
+Stability: Long-term
 """
 	message: String!
 }
@@ -8327,10 +9830,12 @@ Represents information about an on-going trial of LogScale.
 type TrialLicense implements License{
 """
 The time at which the trial ends.
+Stability: Long-term
 """
 	expiresAt: DateTime!
 """
 The time at which the trial started.
+Stability: Long-term
 """
 	issuedAt: DateTime!
 }
@@ -8350,7 +9855,17 @@ Data for trigger polling an ingest feed
 }
 
 type UnassignIngestTokenMutation {
+"""
+Stability: Long-term
+"""
 	repository: Repository!
+}
+
+type UnassignOrganizationManagementRoleFromGroup {
+"""
+Stability: Preview
+"""
+	group: Group!
 }
 
 input UnassignOrganizationManagementRoleFromGroupInput {
@@ -8360,18 +9875,30 @@ input UnassignOrganizationManagementRoleFromGroupInput {
 }
 
 type UnassignOrganizationRoleFromGroup {
+"""
+Stability: Long-term
+"""
 	group: Group!
 }
 
 type UnassignRoleFromGroup {
+"""
+Stability: Long-term
+"""
 	group: Group!
 }
 
 type UnassignSystemRoleFromGroup {
+"""
+Stability: Long-term
+"""
 	group: Group!
 }
 
 type UnblockIngestMutation {
+"""
+Stability: Long-term
+"""
 	repository: Repository!
 }
 
@@ -8379,20 +9906,48 @@ type UnblockIngestMutation {
 A widget that represents an unknown widget type.
 """
 type UnknownWidget implements Widget{
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	title: String!
+"""
+Stability: Long-term
+"""
 	description: String
+"""
+Stability: Long-term
+"""
 	x: Int!
+"""
+Stability: Long-term
+"""
 	y: Int!
+"""
+Stability: Long-term
+"""
 	width: Int!
+"""
+Stability: Long-term
+"""
 	height: Int!
 }
 
 type Unlimited implements contractual{
+"""
+
+Stability: Long-term
+"""
 	includeUsage: Boolean!
 }
 
 type UnregisterNodeMutation {
+"""
+Stability: Long-term
+"""
 	cluster: Cluster!
 }
 
@@ -8574,6 +10129,11 @@ Data for updating an ingest feed which uses AWS S3 with SQS. The update is a del
 	compression: IngestFeedCompression
 }
 
+input UpdateCrossOrganizationViewConnectionFiltersInput {
+	name: String!
+	connectionsToUpdate: [CrossOrganizationViewConnectionInputModel!]!
+}
+
 input UpdateCustomLinkInteractionInput {
 	path: String!
 	interactionId: String!
@@ -8596,6 +10156,7 @@ input UpdateDashboardInput {
 	defaultSharedTimeStart: String
 	defaultSharedTimeEnd: String
 	defaultSharedTimeEnabled: Boolean
+	series: [SeriesConfigInput!]
 }
 
 input UpdateDashboardLinkInteractionInput {
@@ -8605,6 +10166,9 @@ input UpdateDashboardLinkInteractionInput {
 }
 
 type UpdateDashboardMutation {
+"""
+Stability: Long-term
+"""
 	dashboard: Dashboard!
 }
 
@@ -8614,6 +10178,9 @@ input UpdateDefaultQueryPrefixInput {
 }
 
 type UpdateDefaultQueryPrefixMutation {
+"""
+Stability: Long-term
+"""
 	group: Group!
 }
 
@@ -8633,6 +10200,9 @@ Type for updating the description. If the description should be cleared, supply 
 }
 
 type UpdateDescriptionMutation {
+"""
+Stability: Long-term
+"""
 	description: String!
 }
 
@@ -8769,53 +10339,53 @@ Data for updating the administrator control of an FDR feed.
 }
 
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field updateFieldAliasMapping
+Input object for field updateFieldAliasMapping
 """
 input UpdateFieldAliasMappingInput {
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field updateFieldAliasMapping
+Input object for field updateFieldAliasMapping
 """
 	schemaId: String!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field updateFieldAliasMapping
+Input object for field updateFieldAliasMapping
 """
 	aliasMappingId: String!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field updateFieldAliasMapping
+Input object for field updateFieldAliasMapping
 """
 	name: String
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field updateFieldAliasMapping
+Input object for field updateFieldAliasMapping
 """
 	tags: [TagsInput!]
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field updateFieldAliasMapping
+Input object for field updateFieldAliasMapping
 """
 	aliases: [AliasInfoInput!]
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field updateFieldAliasMapping
+Input object for field updateFieldAliasMapping
 """
 	originalFieldsToKeep: [String!]
 }
 
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field updateFieldAliasSchema
+Input object for field updateFieldAliasSchema
 """
 input UpdateFieldAliasSchemaInput {
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field updateFieldAliasSchema
+Input object for field updateFieldAliasSchema
 """
 	id: String!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field updateFieldAliasSchema
+Input object for field updateFieldAliasSchema
 """
 	name: String
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field updateFieldAliasSchema
+Input object for field updateFieldAliasSchema
 """
 	fields: [SchemaFieldInput!]
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Input object for field updateFieldAliasSchema
+Input object for field updateFieldAliasSchema
 """
 	aliasMappings: [AliasMappingInput!]
 }
@@ -8881,6 +10451,9 @@ input UpdateGroupInput {
 }
 
 type UpdateGroupMutation {
+"""
+Stability: Long-term
+"""
 	group: Group!
 }
 
@@ -9233,6 +10806,9 @@ Input for updating a parser.
 }
 
 type UpdateParserMutation {
+"""
+Stability: Long-term
+"""
 	parser: Parser!
 }
 
@@ -9291,6 +10867,9 @@ input UpdateQueryPrefixInput {
 }
 
 type UpdateQueryPrefixMutation {
+"""
+Stability: Long-term
+"""
 	group: Group!
 }
 
@@ -9335,6 +10914,9 @@ input UpdateRepoLimitIdInputObject {
 }
 
 type UpdateRetentionMutation {
+"""
+Stability: Long-term
+"""
 	repository: SearchDomain!
 }
 
@@ -9351,6 +10933,9 @@ input UpdateRoleInput {
 }
 
 type UpdateRoleMutation {
+"""
+Stability: Long-term
+"""
 	role: Role!
 }
 
@@ -9371,6 +10956,9 @@ input UpdateSavedQueryInput {
 }
 
 type UpdateSavedQueryPayload {
+"""
+Stability: Long-term
+"""
 	savedQuery: SavedQuery!
 }
 
@@ -9580,6 +11168,80 @@ Data for updating a scheduled search
 	queryOwnershipType: QueryOwnershipType
 }
 
+"""
+Data for updating a scheduled search
+"""
+input UpdateScheduledSearchV2 {
+"""
+Data for updating a scheduled search
+"""
+	viewName: String!
+"""
+Data for updating a scheduled search
+"""
+	id: String!
+"""
+Data for updating a scheduled search
+"""
+	name: String!
+"""
+Data for updating a scheduled search
+"""
+	description: String
+"""
+Data for updating a scheduled search
+"""
+	queryString: String!
+"""
+Data for updating a scheduled search
+"""
+	schedule: String!
+"""
+Data for updating a scheduled search
+"""
+	timeZone: String!
+"""
+Data for updating a scheduled search
+"""
+	searchIntervalSeconds: Long!
+"""
+Data for updating a scheduled search
+"""
+	searchIntervalOffsetSeconds: Long
+"""
+Data for updating a scheduled search
+"""
+	maxWaitTimeSeconds: Long
+"""
+Data for updating a scheduled search
+"""
+	queryTimestampType: QueryTimestampType!
+"""
+Data for updating a scheduled search
+"""
+	backfillLimit: Int
+"""
+Data for updating a scheduled search
+"""
+	enabled: Boolean!
+"""
+Data for updating a scheduled search
+"""
+	actionIdsOrNames: [String!]!
+"""
+Data for updating a scheduled search
+"""
+	labels: [String!]!
+"""
+Data for updating a scheduled search
+"""
+	runAsUserId: String
+"""
+Data for updating a scheduled search
+"""
+	queryOwnershipType: QueryOwnershipType!
+}
+
 input UpdateSearchLinkInteractionInput {
 	path: String!
 	interactionId: String!
@@ -9663,10 +11325,16 @@ input UpdateUserByIdInput {
 }
 
 type UpdateUserByIdMutation {
+"""
+Stability: Long-term
+"""
 	user: User!
 }
 
 type UpdateUserMutation {
+"""
+Stability: Long-term
+"""
 	user: User!
 }
 
@@ -9765,41 +11433,83 @@ An upload file action.
 type UploadFileAction implements Action{
 """
 File name for the uploaded file.
+Stability: Long-term
 """
 	fileName: String!
 """
 The name of the action.
+Stability: Long-term
 """
 	name: String!
 """
 The display name of the action.
+Stability: Long-term
 """
 	displayName: String!
 """
 The id of the action.
+Stability: Long-term
 """
 	id: String!
 """
 A template that can be used to recreate the action.
+Stability: Long-term
 """
 	yamlTemplate: YAML!
+"""
+Stability: Long-term
+"""
 	packageId: VersionedPackageSpecifier
 """
-The package if any which the action is part of.
+The package, if any, which the action is part of.
+Stability: Long-term
 """
 	package: PackageInstallation
 """
 False if this type of action is disabled because of a security policy, true otherwise
+Stability: Long-term
 """
 	isAllowedToRun: Boolean!
 """
 True if this action is used by triggers, where the query is run by the organization. If true, then the OrganizationOwnedQueries permission is required to edit the action.
+Stability: Long-term
 """
 	requiresOrganizationOwnedQueriesPermissionToEdit: Boolean!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Allowed asset actions
+Allowed asset actions
+Stability: Preview
 """
 	allowedActions: [AssetAction!]!
+"""
+The resource identifier for this action.
+Stability: Short-term
+"""
+	resource: String!
+}
+
+"""
+Asset actions given by direct user assignments for a specific asset
+"""
+type UserAssetActionsBySource implements AssetActionsBySource{
+"""
+Stability: Preview
+"""
+	user: User!
+"""
+Asset actions granted because user is root.
+Stability: Preview
+"""
+	assetActionsGrantedBecauseUserIsRoot: [AssetAction!]!
+"""
+List of roles assigned to the user or group and the asset actions they allow
+Stability: Preview
+"""
+	assetActionsByRoles: [AssetActionsByRole!]!
+"""
+Asset permissions assigned directly to the user or group
+Stability: Preview
+"""
+	directlyAssigned: DirectlyAssignedAssetPermissions!
 }
 
 input UserDefaultSettingsInput {
@@ -9812,10 +11522,12 @@ Query running with user based ownership
 type UserOwnership implements QueryOwnership{
 """
 User owning and running the query. If null, then the user doesn't exist anymore.
+Stability: Long-term
 """
 	user: User
 """
 Id of user owning and running the query
+Stability: Long-term
 """
 	id: String!
 }
@@ -9834,6 +11546,9 @@ input UserRoleAssignmentInput {
 Username and password authentication. The underlying authentication mechanism is configured by the server, e.g. LDAP.
 """
 type UsernameAndPasswordAuthentication implements AuthenticationMethod{
+"""
+Stability: Long-term
+"""
 	name: String!
 }
 
@@ -9851,49 +11566,68 @@ A VictorOps action.
 type VictorOpsAction implements Action{
 """
 Type of the VictorOps message to make.
+Stability: Long-term
 """
 	messageType: String!
 """
 VictorOps webhook url to send the request to.
+Stability: Long-term
 """
 	notifyUrl: String!
 """
 Defines whether the action should use the configured proxy to make web requests.
+Stability: Long-term
 """
 	useProxy: Boolean!
 """
 The name of the action.
+Stability: Long-term
 """
 	name: String!
 """
 The display name of the action.
+Stability: Long-term
 """
 	displayName: String!
 """
 The id of the action.
+Stability: Long-term
 """
 	id: String!
 """
 A template that can be used to recreate the action.
+Stability: Long-term
 """
 	yamlTemplate: YAML!
+"""
+Stability: Long-term
+"""
 	packageId: VersionedPackageSpecifier
 """
-The package if any which the action is part of.
+The package, if any, which the action is part of.
+Stability: Long-term
 """
 	package: PackageInstallation
 """
 False if this type of action is disabled because of a security policy, true otherwise
+Stability: Long-term
 """
 	isAllowedToRun: Boolean!
 """
 True if this action is used by triggers, where the query is run by the organization. If true, then the OrganizationOwnedQueries permission is required to edit the action.
+Stability: Long-term
 """
 	requiresOrganizationOwnedQueriesPermissionToEdit: Boolean!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Allowed asset actions
+Allowed asset actions
+Stability: Preview
 """
 	allowedActions: [AssetAction!]!
+"""
+The resource identifier for this action.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 """
@@ -9920,36 +11654,87 @@ View permissions token. The token allows the caller to work with the same set of
 type ViewPermissionsToken implements Token{
 """
 The set of permissions on the token
+Stability: Long-term
 """
 	permissions: [String!]!
 """
 The set of views on the token. Will only list the views the user has access to.
+Stability: Long-term
 """
 	views: [SearchDomain!]!
 """
+The permissions assigned to the token for individual view assets.
+Stability: Preview
+"""
+	searchAssetPermissions(
+"""
+Filter results based on this string
+"""
+		searchFilter: String
+"""
+The number of results to skip or the offset to use. For instance if implementing pagination, set skip = limit * (page - 1)
+"""
+		skip: Int
+"""
+The amount of results to return.
+"""
+		limit: Int
+"""
+Choose the order in which the results are returned.
+"""
+		orderBy: OrderBy
+"""
+The sort by options for assets. Asset name is default
+"""
+		sortBy: SortBy
+"""
+List of asset types
+"""
+		assetTypes: [AssetPermissionsAssetType!]
+"""
+List of search domain id's to search within. Null or empty list is interpreted as all search domains
+"""
+		searchDomainIds: [String!]
+"""
+Include Read, Update and/or Delete permission assignments. The filter will accept all assets if the argument Null or the empty list.
+"""
+		permissions: [AssetAction!]
+	): AssetPermissionSearchResultSet!
+"""
 The id of the token.
+Stability: Long-term
 """
 	id: String!
 """
 The name of the token.
+Stability: Long-term
 """
 	name: String!
 """
 The time at which the token expires.
+Stability: Long-term
 """
 	expireAt: Long
 """
 The ip filter on the token.
+Stability: Long-term
 """
 	ipFilter: String
 """
 The ip filter on the token.
+Stability: Long-term
 """
 	ipFilterV2: IPFilter
 """
 The date the token was created.
+Stability: Long-term
 """
 	createdAt: Long!
+}
+
+input ViewPermissionsTokenAssetPermissionAssignmentInput {
+	assetResourceIdentifier: String!
+	permissions: [AssetPermission!]!
 }
 
 """
@@ -9958,61 +11743,83 @@ A webhook action
 type WebhookAction implements Action{
 """
 Method to use for the request.
+Stability: Long-term
 """
 	method: String!
 """
 Url to send the http(s) request to.
+Stability: Long-term
 """
 	url: String!
 """
 Headers of the http(s) request.
+Stability: Long-term
 """
 	headers: [HttpHeaderEntry!]!
 """
 Body of the http(s) request. Can be templated with values from the result.
+Stability: Long-term
 """
 	bodyTemplate: String!
 """
 Flag indicating whether SSL should be ignored for the request.
+Stability: Long-term
 """
 	ignoreSSL: Boolean!
 """
 Defines whether the action should use the configured proxy to make web requests.
+Stability: Long-term
 """
 	useProxy: Boolean!
 """
 The name of the action.
+Stability: Long-term
 """
 	name: String!
 """
 The display name of the action.
+Stability: Long-term
 """
 	displayName: String!
 """
 The id of the action.
+Stability: Long-term
 """
 	id: String!
 """
 A template that can be used to recreate the action.
+Stability: Long-term
 """
 	yamlTemplate: YAML!
+"""
+Stability: Long-term
+"""
 	packageId: VersionedPackageSpecifier
 """
-The package if any which the action is part of.
+The package, if any, which the action is part of.
+Stability: Long-term
 """
 	package: PackageInstallation
 """
 False if this type of action is disabled because of a security policy, true otherwise
+Stability: Long-term
 """
 	isAllowedToRun: Boolean!
 """
 True if this action is used by triggers, where the query is run by the organization. If true, then the OrganizationOwnedQueries permission is required to edit the action.
+Stability: Long-term
 """
 	requiresOrganizationOwnedQueriesPermissionToEdit: Boolean!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Allowed asset actions
+Allowed asset actions
+Stability: Preview
 """
 	allowedActions: [AssetAction!]!
+"""
+The resource identifier for this action.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 input WidgetInput {
@@ -10071,10 +11878,16 @@ FDR test errors
 union error =TestFdrValidationError | TestFdrRequestError
 
 type setAutomaticSearching {
+"""
+Stability: Long-term
+"""
 	automaticSearch: Boolean!
 }
 
 type updateDefaultRoleMutation {
+"""
+Stability: Long-term
+"""
 	group: Group!
 }
 
@@ -10084,7 +11897,13 @@ A user or pending user, depending on whether an invitation was sent
 union userOrPendingUser =User | PendingUser
 
 type AccessTokenValidatorResultType {
+"""
+Stability: Long-term
+"""
 	sessionId: String
+"""
+Stability: Long-term
+"""
 	showTermsAndConditions: ShowTermsAndConditions
 }
 
@@ -10092,31 +11911,100 @@ type AccessTokenValidatorResultType {
 A user account.
 """
 type Account {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	enabledFeaturesForAccount: [FeatureFlag!]!
+"""
+Stability: Long-term
+"""
 	username: String!
+"""
+Stability: Long-term
+"""
 	isRoot: Boolean!
+"""
+Stability: Long-term
+"""
 	isOrganizationRoot: Boolean!
+"""
+Stability: Long-term
+"""
 	fullName: String
+"""
+Stability: Long-term
+"""
 	firstName: String
+"""
+Stability: Long-term
+"""
 	lastName: String
+"""
+Stability: Long-term
+"""
 	phoneNumber: String
+"""
+Stability: Long-term
+"""
 	email: String
+"""
+Stability: Long-term
+"""
 	picture: String
+"""
+Stability: Long-term
+"""
 	settings: UserSettings!
+"""
+Stability: Long-term
+"""
 	createdAt: DateTime!
+"""
+Stability: Long-term
+"""
 	countryCode: String
+"""
+Stability: Long-term
+"""
 	stateCode: String
+"""
+Stability: Long-term
+"""
 	company: String
+"""
+Stability: Long-term
+"""
 	canCreateCloudTrialRepo: Boolean!
+"""
+Stability: Long-term
+"""
 	isCloudProAccount: Boolean!
+"""
+Stability: Long-term
+"""
 	canCreateRepo: Boolean!
+"""
+Stability: Long-term
+"""
 	externalPermissions: Boolean!
+"""
+Stability: Long-term
+"""
 	externalGroupSynchronization: Boolean!
+"""
+Stability: Long-term
+"""
 	currentOrganization: Organization!
+"""
+Stability: Long-term
+"""
 	announcement: Notification
 """
-[PREVIEW: New sorting and filtering options might be added.] 
+Stability: Preview
 """
 	notificationsV2(
 		typeFilter: [NotificationTypes!]
@@ -10133,7 +12021,13 @@ The amount of results to return.
 """
 		limit: Int
 	): NotificationsResultSet!
+"""
+Stability: Long-term
+"""
 	token: PersonalUserToken
+"""
+Stability: Long-term
+"""
 	fieldConfigurations(
 		viewName: String!
 	): [FieldConfiguration!]!
@@ -10179,6 +12073,10 @@ An action that can be invoked from a trigger.
 An action that can be invoked from a trigger.
 """
 	allowedActions: [AssetAction!]!
+"""
+An action that can be invoked from a trigger.
+"""
+	resource: String!
 }
 
 """
@@ -10187,56 +12085,77 @@ Security policies for actions in the organization
 type ActionSecurityPolicies {
 """
 Indicates if email actions can be configured and triggered
+Stability: Short-term
 """
 	emailActionEnabled: Boolean!
 """
 Allow list of glob patterns for acceptable email action recipients. Empty means no recipients allowed whereas null means all.
+Stability: Short-term
 """
 	emailActionRecipientAllowList: [String!]
 """
 Indicates if repository actions can be configured and triggered
+Stability: Short-term
 """
 	repoActionEnabled: Boolean!
 """
 Indicates if OpsGenie actions can be configured and triggered
+Stability: Short-term
 """
 	opsGenieActionEnabled: Boolean!
 """
 Indicates if PagerDuty actions can be configured and triggered
+Stability: Short-term
 """
 	pagerDutyActionEnabled: Boolean!
 """
 Indicates if single channel Slack actions can be configured and triggered
+Stability: Short-term
 """
 	slackSingleChannelActionEnabled: Boolean!
 """
 Indicates if multi channel Slack actions can be configured and triggered
+Stability: Short-term
 """
 	slackMultiChannelActionEnabled: Boolean!
 """
 Indicates if upload file actions can be configured and triggered
+Stability: Short-term
 """
 	uploadFileActionEnabled: Boolean!
 """
 Indicates if VictorOps actions can be configured and triggered
+Stability: Short-term
 """
 	victorOpsActionEnabled: Boolean!
 """
 Indicates if Webhook actions can be configured and triggered
+Stability: Short-term
 """
 	webhookActionEnabled: Boolean!
 """
 Allow list of glob patterns for acceptable webhook URLs. Empty means no recipients allowed whereas null means all.
+Stability: Short-term
 """
 	webhookActionUrlAllowList: [String!]
 }
 
 type ActionTemplate {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	displayName: String!
+"""
+Stability: Long-term
+"""
 	yamlTemplate: String!
 """
 The type of action
+Stability: Long-term
 """
 	type: ActionType!
 }
@@ -10257,8 +12176,17 @@ enum ActionType {
 }
 
 type ActiveSchemaOnView {
+"""
+Stability: Long-term
+"""
 	viewName: RepoOrViewName!
+"""
+Stability: Long-term
+"""
 	schemaId: String!
+"""
+Stability: Long-term
+"""
 	is1to1Linked: Boolean!
 }
 
@@ -10268,94 +12196,137 @@ An aggregate alert.
 type AggregateAlert {
 """
 Id of the aggregate alert.
+Stability: Long-term
 """
 	id: String!
 """
 Name of the aggregate alert.
+Stability: Long-term
 """
 	name: String!
 """
 Description of the aggregate alert.
+Stability: Long-term
 """
 	description: String
 """
 LogScale query to execute.
+Stability: Long-term
 """
 	queryString: String!
 """
 List of actions to fire on query result.
+Stability: Long-term
 """
 	actions: [Action!]!
 """
 Labels attached to the aggregate alert.
+Stability: Long-term
 """
 	labels: [String!]!
 """
 Flag indicating whether the aggregate alert is enabled.
+Stability: Long-term
 """
 	enabled: Boolean!
 """
 Throttle time in seconds.
+Stability: Long-term
 """
 	throttleTimeSeconds: Long!
 """
 A field to throttle on. Can only be set if throttleTimeSeconds is set.
+Stability: Long-term
 """
 	throttleField: String
 """
 Search interval in seconds.
+Stability: Long-term
 """
 	searchIntervalSeconds: Long!
 """
 Timestamp type to use for a query.
+Stability: Long-term
 """
 	queryTimestampType: QueryTimestampType!
 """
 Trigger mode used for triggering the alert.
+Stability: Long-term
 """
 	triggerMode: TriggerMode!
 """
 Unix timestamp for last execution of trigger.
+Stability: Long-term
 """
 	lastTriggered: Long
 """
 Unix timestamp for last successful poll (including action invocation if applicable) of the aggregate alert query. If this is not quite recent, then the alert might be having problems.
+Stability: Long-term
 """
 	lastSuccessfulPoll: Long
 """
 Last error encountered while running the aggregate alert.
+Stability: Long-term
 """
 	lastError: String
 """
 Last warnings encountered while running the aggregate alert.
+Stability: Long-term
 """
 	lastWarnings: [String!]!
 """
 YAML specification of the aggregate alert.
+Stability: Long-term
 """
 	yamlTemplate: YAML!
 """
 The id of the package of the aggregate alert template.
+Stability: Long-term
 """
 	packageId: VersionedPackageSpecifier
 """
+User or token used to modify the asset.
+Stability: Preview
+"""
+	modifiedInfo: ModifiedInfo!
+"""
 The package that the aggregate alert was installed as part of.
+Stability: Long-term
 """
 	package: PackageInstallation
 """
 Ownership of the query run by this alert
+Stability: Long-term
 """
 	queryOwnership: QueryOwnership!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Allowed asset actions
+Allowed asset actions
+Stability: Preview
 """
 	allowedActions: [AssetAction!]!
+"""
+The resource identifier for this aggregate alert.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 type AggregateAlertTemplate {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	displayName: String!
+"""
+Stability: Long-term
+"""
 	yamlTemplate: YAML!
+"""
+Stability: Long-term
+"""
 	labels: [String!]!
 }
 
@@ -10365,67 +12336,83 @@ An alert.
 type Alert {
 """
 Id of the alert.
+Stability: Long-term
 """
 	id: String!
 """
 Name of the alert.
+Stability: Long-term
 """
 	name: String!
 	assetType: AssetType!
 """
 Id of user which the alert is running as.
+Stability: Long-term
 """
 	runAsUser: User
 """
 Name of the alert.
+Stability: Long-term
 """
 	displayName: String!
 """
 Name of the alert.
+Stability: Long-term
 """
 	description: String
 """
 LogScale query to execute.
+Stability: Long-term
 """
 	queryString: String!
 """
 Start of the relative time interval for the query.
+Stability: Long-term
 """
 	queryStart: String!
 """
 Throttle time in milliseconds.
+Stability: Long-term
 """
 	throttleTimeMillis: Long!
 """
 Field to throttle on.
+Stability: Long-term
 """
 	throttleField: String
 """
 Unix timestamp for when the alert was last triggered.
+Stability: Long-term
 """
 	timeOfLastTrigger: Long
 """
 Flag indicating whether the alert is enabled.
+Stability: Long-term
 """
 	enabled: Boolean!
 """
 List of ids for actions to fire on query result.
+Stability: Long-term
 """
 	actions: [String!]!
 """
 List of ids for actions to fire on query result.
+Stability: Long-term
 """
 	actionsV2: [Action!]!
 """
 Last error encountered while running the alert.
+Stability: Long-term
 """
 	lastError: String
 """
 Last warnings encountered while running the alert.
+Stability: Long-term
 """
 	lastWarnings: [String!]!
 """
 Labels attached to the alert.
+Stability: Long-term
 """
 	labels: [String!]!
 """
@@ -10434,24 +12421,34 @@ Flag indicating whether the calling user has 'starred' the alert.
 	isStarred: Boolean!
 """
 A YAML formatted string that describes the alert.
+Stability: Long-term
 """
 	yamlTemplate: String!
 """
 The id of the package that the alert was installed as part of.
+Stability: Long-term
 """
 	packageId: VersionedPackageSpecifier
 """
 The package that the alert was installed as part of.
+Stability: Long-term
 """
 	package: PackageInstallation
 """
 Ownership of the query run by this alert
+Stability: Long-term
 """
 	queryOwnership: QueryOwnership!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Allowed asset actions
+Allowed asset actions
+Stability: Preview
 """
 	allowedActions: [AssetAction!]!
+"""
+The resource identifier for this alert.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 """
@@ -10459,15 +12456,18 @@ All actions, labels and packages used in alerts.
 """
 type AlertFieldValues {
 """
-List of names of actions attached to alerts. Sorted by action names lexicographically..
+List of names of actions attached to alerts. Sorted by action names lexicographically.
+Stability: Preview
 """
 	actionNames: [String!]!
 """
 List of labels attached to alerts. Sorted by label names lexicographically.
+Stability: Preview
 """
 	labels: [String!]!
 """
 List of packages for installed alerts as unversioned qualified package specifiers `scope/packageName`. Sorted lexicographically.
+Stability: Preview
 """
 	unversionedPackageSpecifiers: [String!]!
 }
@@ -10483,9 +12483,21 @@ Arguments for alert field values query.
 }
 
 type AlertTemplate {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	displayName: String!
+"""
+Stability: Long-term
+"""
 	yamlTemplate: String!
+"""
+Stability: Long-term
+"""
 	labels: [String!]!
 }
 
@@ -10499,15 +12511,36 @@ enum AlertType {
 }
 
 type AliasInfo {
+"""
+Stability: Long-term
+"""
 	source: String!
+"""
+Stability: Long-term
+"""
 	alias: String!
 }
 
 type AliasMapping {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	tags: [TagInfo!]!
+"""
+Stability: Long-term
+"""
 	aliases: [AliasInfo!]!
+"""
+Stability: Long-term
+"""
 	originalFieldsToKeep: [String!]!
 }
 
@@ -10535,6 +12568,14 @@ Arguments for analyzeQuery
 Arguments for analyzeQuery
 """
 	viewName: RepoOrViewName
+"""
+Arguments for analyzeQuery
+"""
+	strict: Boolean
+"""
+Arguments for analyzeQuery
+"""
+	rejectFunctions: [String!]
 }
 
 """
@@ -10543,6 +12584,7 @@ Result of analyzing a query.
 type AnalyzeQueryInfo {
 """
 Check if the given query contains any errors or warnings when used in a standard search context.
+Stability: Short-term
 """
 	validateQuery: QueryValidationInfo!
 """
@@ -10550,8 +12592,39 @@ Suggested type of alert to use for the given query.
 Returns null if no suitable alert type could be suggested.
 The given query is not guaranteed to be valid for the suggested alert type.
 
+Stability: Short-term
 """
 	suggestedAlertType: SuggestedAlertTypeInfo
+}
+
+"""
+Configuration for archiving, e.e. bucket name and/or region.
+"""
+interface ArchivingConfiguration {
+"""
+Configuration for archiving, e.e. bucket name and/or region.
+"""
+	bucket: String!
+"""
+Configuration for archiving, e.e. bucket name and/or region.
+"""
+	startFrom: DateTime
+"""
+Configuration for archiving, e.e. bucket name and/or region.
+"""
+	disabled: Boolean
+"""
+Configuration for archiving, e.e. bucket name and/or region.
+"""
+	tagOrderInName: [String!]!
+}
+
+"""
+The format to store archived segments.
+"""
+enum ArchivingFormat {
+	RAW
+	NDJSON
 }
 
 """
@@ -10561,21 +12634,42 @@ enum AssetAction {
 	Read
 	Update
 	Delete
+	ReadMetadata
+}
+
+"""
+A role and the asset actions it allows
+"""
+type AssetActionsByRole {
+"""
+Stability: Preview
+"""
+	role: Role
+"""
+Asset actions allowed by the role
+Stability: Preview
+"""
+	assetActions: [AssetAction!]!
+}
+
+"""
+Common interface for user and group permission assignments
+"""
+interface AssetActionsBySource {
+"""
+Common interface for user and group permission assignments
+"""
+	assetActionsByRoles: [AssetActionsByRole!]!
+"""
+Common interface for user and group permission assignments
+"""
+	directlyAssigned: DirectlyAssignedAssetPermissions!
 }
 
 """
 Asset permissions
 """
-enum AssetPermissionInputEnum {
-	UpdateAsset
-	DeleteAsset
-}
-
-"""
-Asset permission
-"""
-enum AssetPermissionOutputEnum {
-	ReadAsset
+enum AssetPermission {
 	UpdateAsset
 	DeleteAsset
 }
@@ -10586,10 +12680,12 @@ An asset permission search result set
 type AssetPermissionSearchResultSet {
 """
 The total number of matching results
+Stability: Preview
 """
 	totalResults: Int!
 """
 The paginated result set
+Stability: Preview
 """
 	results: [SearchAssetPermissionsResultEntry!]!
 }
@@ -10607,63 +12703,6 @@ enum AssetPermissionsAssetType {
 	Dashboard
 	File
 	SavedQuery
-}
-
-"""
-Asset permissions assigned to the group
-"""
-type AssetPermissionsForGroup {
-"""
-The unique id for the Asset
-"""
-	assetId: String!
-"""
-The type of the Asset
-"""
-	assetType: AssetPermissionsAssetType!
-"""
-The search domain that the asset belongs to
-"""
-	searchDomain: SearchDomain
-"""
-The group role assignments
-"""
-	roles: [GroupRole!]!
-"""
-The directly assigned asset permissions
-"""
-	directlyAssigned: [AssetPermissionOutputEnum!]!
-}
-
-"""
-Asset permissions assigned to the user
-"""
-type AssetPermissionsForUser {
-"""
-The unique id for the Asset
-"""
-	assetId: String!
-"""
-The type of the Asset
-"""
-	assetType: AssetPermissionsAssetType!
-"""
-The search domain that the asset belongs to
-"""
-	searchDomain: SearchDomain
-"""
-The group role assignments
-"""
-	groupRoles: [GroupRole!]!
-"""
-The directly assigned asset permissions per group
-"""
-	groupDirectlyAssigned: [GroupAssetPermissionAssignment!]!
-	userRoles: [Role!]!
-"""
-The directly assigned asset permissions
-"""
-	directlyAssigned: [AssetPermissionOutputEnum!]!
 }
 
 enum AssetType {
@@ -10697,19 +12736,42 @@ interface AuthenticationMethodAuth {
 A regex pattern used to filter queries before they are executed.
 """
 type BlockedQuery {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	expiresAt: DateTime
+"""
+Stability: Long-term
+"""
 	expiresInMilliseconds: Int
+"""
+Stability: Long-term
+"""
 	pattern: String!
+"""
+Stability: Long-term
+"""
 	type: BlockedQueryMatcherType!
+"""
+Stability: Long-term
+"""
 	view: View
 """
 The organization owning the pattern or view, if any.
+Stability: Long-term
 """
 	organization: Organization
+"""
+Stability: Long-term
+"""
 	limitedToOrganization: Boolean!
 """
 True if the current actor is allowed the remove this pattern
+Stability: Long-term
 """
 	unblockAllowed: Boolean!
 }
@@ -10725,10 +12787,12 @@ Bucket storage configuration for the organization
 type BucketStorageConfig {
 """
 The primary bucket storage of the organization
+Stability: Long-term
 """
 	targetBucketId1: String!
 """
 The secondary bucket storage of the organization
+Stability: Long-term
 """
 	targetBucketId2: String
 }
@@ -10757,6 +12821,7 @@ A cache policy can be set either on one of three levels (in order of precedence)
 type CachePolicy {
 """
 Prioritize caching segments younger than this
+Stability: Preview
 """
 	prioritizeMillis: Long
 }
@@ -10825,10 +12890,12 @@ An organization search result set
 type ChildOrganizationsResultSet {
 """
 The total number of matching results
+Stability: Preview
 """
 	totalResults: Int!
 """
 The paginated result set
+Stability: Preview
 """
 	results: [Organization!]!
 }
@@ -10837,8 +12904,17 @@ The paginated result set
 Identifies a client of the query.
 """
 type Client {
+"""
+Stability: Long-term
+"""
 	externalId: String!
+"""
+Stability: Long-term
+"""
 	ip: String
+"""
+Stability: Long-term
+"""
 	user: String
 }
 
@@ -10846,31 +12922,81 @@ type Client {
 Information about the LogScale cluster.
 """
 type Cluster {
+"""
+Stability: Long-term
+"""
 	nodes: [ClusterNode!]!
+"""
+Stability: Long-term
+"""
 	clusterManagementSettings: ClusterManagementSettings!
+"""
+Stability: Long-term
+"""
 	clusterInfoAgeSeconds: Float!
+"""
+Stability: Long-term
+"""
 	underReplicatedSegmentSize: Float!
+"""
+Stability: Long-term
+"""
 	overReplicatedSegmentSize: Float!
+"""
+Stability: Long-term
+"""
 	missingSegmentSize: Float!
+"""
+Stability: Long-term
+"""
 	properlyReplicatedSegmentSize: Float!
+"""
+Stability: Long-term
+"""
 	inBucketStorageSegmentSize: Float!
+"""
+Stability: Long-term
+"""
 	pendingBucketStorageSegmentSize: Float!
+"""
+Stability: Long-term
+"""
 	pendingBucketStorageRiskySegmentSize: Float!
+"""
+Stability: Long-term
+"""
 	targetUnderReplicatedSegmentSize: Float!
+"""
+Stability: Long-term
+"""
 	targetOverReplicatedSegmentSize: Float!
+"""
+Stability: Long-term
+"""
 	targetMissingSegmentSize: Float!
+"""
+Stability: Long-term
+"""
 	targetProperlyReplicatedSegmentSize: Float!
+"""
+Stability: Long-term
+"""
 	ingestPartitions: [IngestPartition!]!
-	ingestPartitionsWarnings: [String!]!
-	suggestedIngestPartitions: [IngestPartition!]!
-	storagePartitions: [StoragePartition!]!
-	storagePartitionsWarnings: [String!]!
-	suggestedStoragePartitions: [StoragePartition!]!
+"""
+Stability: Short-term
+"""
 	storageReplicationFactor: Int
+"""
+Stability: Short-term
+"""
 	digestReplicationFactor: Int
+"""
+Stability: Short-term
+"""
 	stats: ClusterStats!
 """
-[PREVIEW: Cache policies are a limited feature and is subject to change] The default cache policy of this cluster.
+The default cache policy of this cluster.
+Stability: Preview
 """
 	defaultCachePolicy: CachePolicy
 }
@@ -10920,8 +13046,19 @@ The status of a cluster connection.
 	errorMessages: [ConnectionAspectErrorType!]!
 }
 
+"""
+Tag for identifiying the cluster connection
+"""
 type ClusterConnectionTag {
+"""
+Cluster Connection tag key
+Stability: Short-term
+"""
 	key: String!
+"""
+Value for the cluster connection tag
+Stability: Short-term
+"""
 	value: String!
 }
 
@@ -10931,22 +13068,27 @@ Settings for the LogScale cluster.
 type ClusterManagementSettings {
 """
 Replication factor for segments
+Stability: Long-term
 """
 	segmentReplicationFactor: Int!
 """
 Replication factor for the digesters
+Stability: Long-term
 """
 	digestReplicationFactor: Int!
 """
 Percentage of all hosts relevant to a particular cluster rebalance operation that need to be alive before we allow the system to automatically execute the operation. Cluster rebalance operations currently include reassigning digest work, and moving existing segments to balance disk usage. Value is between 0 and 100, both inclusive
+Stability: Long-term
 """
 	minHostAlivePercentageToEnableClusterRebalancing: Int!
 """
 Whether or not desired digesters are allowed to be updated automatically
+Stability: Short-term
 """
 	allowUpdateDesiredDigesters: Boolean!
 """
 true if the cluster should allow moving existing segments between nodes to achieve a better data distribution
+Stability: Short-term
 """
 	allowRebalanceExistingSegments: Boolean!
 }
@@ -10955,101 +13097,161 @@ true if the cluster should allow moving existing segments between nodes to achie
 A node in the a LogScale Cluster.
 """
 type ClusterNode {
+"""
+Stability: Long-term
+"""
 	id: Int!
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	zone: String
+"""
+Stability: Long-term
+"""
 	uri: String!
+"""
+Stability: Long-term
+"""
 	uuid: String!
+"""
+Stability: Long-term
+"""
 	humioVersion: String!
+"""
+Stability: Short-term
+"""
 	supportedTasks: [NodeTaskEnum!]!
+"""
+Stability: Short-term
+"""
 	assignedTasks: [NodeTaskEnum!]
+"""
+Stability: Short-term
+"""
 	unassignedTasks: [NodeTaskEnum!]
+"""
+Stability: Short-term
+"""
 	consideredAliveUntil: DateTime
+"""
+Stability: Long-term
+"""
 	clusterInfoAgeSeconds: Float!
 """
 The size in GB of data this node needs to receive.
+Stability: Long-term
 """
 	inboundSegmentSize: Float!
 """
 The size in GB of data this node has that others need.
+Stability: Short-term
 """
 	outboundSegmentSize: Float!
+"""
+Stability: Long-term
+"""
 	canBeSafelyUnregistered: Boolean!
+"""
+Stability: Long-term
+"""
 	reasonsNodeCannotBeSafelyUnregistered: ReasonsNodeCannotBeSafelyUnregistered!
 """
 The size in GB of data currently on this node.
+Stability: Long-term
 """
 	currentSize: Float!
 """
 The size in GB of the data currently on this node that are in the primary storage location.
+Stability: Long-term
 """
 	primarySize: Float!
 """
 The size in GB of the data currently on this node that are in the secondary storage location. Zero if no secondary is configured.
+Stability: Long-term
 """
 	secondarySize: Float!
 """
 The total size in GB of the primary storage location on this node.
+Stability: Long-term
 """
 	totalSizeOfPrimary: Float!
 """
 The total size in GB of the secondary storage location on this node. Zero if no secondary is configured.
+Stability: Long-term
 """
 	totalSizeOfSecondary: Float!
 """
 The size in GB of the free space on this node of the primary storage location.
+Stability: Long-term
 """
 	freeOnPrimary: Float!
 """
 The size in GB of the free space on this node of the secondary storage location. Zero if no secondary is configured.
+Stability: Long-term
 """
 	freeOnSecondary: Float!
 """
 The size in GB of work-in-progress data files.
+Stability: Long-term
 """
 	wipSize: Float!
 """
 The size in GB of data once the node has received the data allocated to it.
+Stability: Long-term
 """
 	targetSize: Float!
 """
 The size in GB of data that only exists on this node - i.e. only one replica exists in the cluster.
+Stability: Long-term
 """
 	solitarySegmentSize: Float!
 """
 A flag indicating whether the node is considered up or down by the cluster coordinated. This is based on the `lastHeartbeat` field.
+Stability: Long-term
 """
 	isAvailable: Boolean!
 """
 The last time a heartbeat was received from the node.
+Stability: Long-term
 """
 	lastHeartbeat: DateTime!
 """
 The time since a heartbeat was received from the node.
+Stability: Long-term
 """
 	timeSinceLastHeartbeat: Long!
 """
 A flag indicating whether the node is marked for eviction. The Falcon LogScale cluster will start to move segments, digesters and queries away from any node marked for eviction
+Stability: Long-term
 """
 	isBeingEvicted: Boolean
 """
 Contains data describing the status of eviction
+Stability: Long-term
 """
 	evictionStatus: EvictionStatus!
 """
 True if the machine the node runs on has local segment storage
+Stability: Long-term
 """
 	hasStorageRole: Boolean!
 """
 True if the machine the node runs on has the possibility to process kafka partitions
+Stability: Long-term
 """
 	hasDigestRole: Boolean!
 """
 The time at which the host booted
+Stability: Long-term
 """
 	bootedAt: DateTime!
 """
 The time since last boot
+Stability: Long-term
 """
 	timeSinceBooted: Long!
 }
@@ -11058,9 +13260,21 @@ The time since last boot
 Global stats for the cluster
 """
 type ClusterStats {
+"""
+Stability: Long-term
+"""
 	compressedByteSize: Long!
+"""
+Stability: Long-term
+"""
 	uncompressedByteSize: Long!
+"""
+Stability: Long-term
+"""
 	compressedByteSizeOfMerged: Long!
+"""
+Stability: Long-term
+"""
 	uncompressedByteSizeOfMerged: Long!
 }
 
@@ -11096,10 +13310,12 @@ A key-value pair from a connection aspect to an error message pertaining to that
 type ConnectionAspectErrorType {
 """
 A connection aspect
+Stability: Short-term
 """
 	aspect: ConnectionAspect!
 """
 An error message for the connection, tagged by the relevant aspect
+Stability: Short-term
 """
 	error: String!
 }
@@ -11110,19 +13326,26 @@ Represents the connection between a view and an underlying repository in another
 type CrossOrgViewConnection {
 """
 ID of the underlying repository
+Stability: Short-term
 """
 	id: String!
 """
 Name of the underlying repository
+Stability: Short-term
 """
 	name: String!
 """
 The filter applied to all results from the repository.
+Stability: Short-term
 """
 	filter: String!
+"""
+Stability: Short-term
+"""
 	languageVersion: LanguageVersion!
 """
 ID of the organization containing the underlying repository
+Stability: Short-term
 """
 	orgId: String!
 }
@@ -11131,13 +13354,28 @@ ID of the organization containing the underlying repository
 The status the local database of CrowdStrike IOCs
 """
 type CrowdStrikeIocStatus {
+"""
+Stability: Long-term
+"""
 	databaseTables: [IocTableInfo!]!
 }
 
 type CurrentStats {
+"""
+Stability: Long-term
+"""
 	ingest: Ingest!
+"""
+Stability: Long-term
+"""
 	storedData: StoredData!
+"""
+Stability: Long-term
+"""
 	scannedData: ScannedData!
+"""
+Stability: Long-term
+"""
 	users: UsersLimit!
 }
 
@@ -11147,8 +13385,17 @@ Query result for current usage
 union CurrentUsageQueryResult =QueryInProgress | CurrentStats
 
 type CustomLinkInteraction {
+"""
+Stability: Long-term
+"""
 	urlTemplate: String!
+"""
+Stability: Long-term
+"""
 	openInNewTab: Boolean!
+"""
+Stability: Long-term
+"""
 	urlEncodeArgs: Boolean!
 }
 
@@ -11156,41 +13403,119 @@ type CustomLinkInteraction {
 Represents information about a dashboard.
 """
 type Dashboard {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	description: String
 	assetType: AssetType!
 """
 A YAML formatted string that describes the dashboard. It does not contain links or permissions, and is safe to share and use for making copies of a dashboard.
 """
 	templateYaml: String!
+"""
+A YAML formatted string that describes the dashboard. It does not contain links or permissions, and is safe to share and use for making copies of a dashboard.
+Stability: Long-term
+"""
+	yamlTemplate: YAML!
+"""
+Stability: Long-term
+"""
 	displayName: String!
+"""
+Stability: Long-term
+"""
 	labels: [String!]!
+"""
+Stability: Long-term
+"""
 	widgets: [Widget!]!
+"""
+Stability: Long-term
+"""
 	sections: [Section!]!
+"""
+Stability: Long-term
+"""
+	series: [SeriesConfig!]!
+"""
+Stability: Long-term
+"""
 	readOnlyTokens: [DashboardLink!]!
+"""
+Stability: Long-term
+"""
 	filters: [DashboardFilter!]!
+"""
+Stability: Long-term
+"""
 	parameters: [DashboardParameter!]!
+"""
+Stability: Long-term
+"""
 	updateFrequency: DashboardUpdateFrequencyType!
+"""
+Stability: Long-term
+"""
 	isStarred: Boolean!
+"""
+Stability: Long-term
+"""
 	defaultFilter: DashboardFilter
+"""
+Stability: Long-term
+"""
 	defaultSharedTimeStart: String!
+"""
+Stability: Long-term
+"""
 	defaultSharedTimeEnd: String!
+"""
+Stability: Long-term
+"""
 	timeJumpSizeInMs: Int
+"""
+Stability: Long-term
+"""
 	defaultSharedTimeEnabled: Boolean!
+"""
+Stability: Long-term
+"""
 	searchDomain: SearchDomain!
+"""
+Stability: Long-term
+"""
 	packageId: VersionedPackageSpecifier
+"""
+Stability: Long-term
+"""
 	package: PackageInstallation
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Allowed asset actions
+Allowed asset actions
+Stability: Preview
 """
 	allowedActions: [AssetAction!]!
+"""
+The resource identifier for this dashboard.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 """
 A dashboard
 """
 type DashboardEntry {
+"""
+Stability: Preview
+"""
 	dashboard: Dashboard!
 }
 
@@ -11198,8 +13523,17 @@ type DashboardEntry {
 A saved configuration for filtering dashboard widgets.
 """
 type DashboardFilter {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	prefixFilter: String!
 }
 
@@ -11207,23 +13541,46 @@ type DashboardFilter {
 A token that can be used to access the dashboard without logging in. Useful for e.g. wall mounted dashboards or public dashboards.
 """
 type DashboardLink {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	token: String!
+"""
+Stability: Long-term
+"""
 	createdBy: String!
 """
 The ip filter for the dashboard link.
+Stability: Long-term
 """
 	ipFilter: IPFilter
 """
 Ownership of the queries run by this shared dashboard
+Stability: Long-term
 """
 	queryOwnership: QueryOwnership!
 }
 
 type DashboardLinkInteraction {
+"""
+Stability: Long-term
+"""
 	arguments: [DictionaryEntryType!]!
+"""
+Stability: Long-term
+"""
 	dashboardReference: DashboardLinkInteractionDashboardReference!
+"""
+Stability: Long-term
+"""
 	openInNewTab: Boolean!
+"""
+Stability: Long-term
+"""
 	useWidgetTimeWindow: Boolean!
 }
 
@@ -11231,9 +13588,21 @@ type DashboardLinkInteraction {
 A reference to a dashboard either by id or name
 """
 type DashboardLinkInteractionDashboardReference {
+"""
+Stability: Long-term
+"""
 	id: String
+"""
+Stability: Long-term
+"""
 	name: String
+"""
+Stability: Long-term
+"""
 	repoOrViewName: RepoOrViewName
+"""
+Stability: Long-term
+"""
 	packageSpecifier: UnversionedPackageSpecifier
 }
 
@@ -11241,7 +13610,13 @@ type DashboardLinkInteractionDashboardReference {
 A page of dashboards.
 """
 type DashboardPage {
+"""
+Stability: Long-term
+"""
 	pageInfo: PageType!
+"""
+Stability: Long-term
+"""
 	page: [Dashboard!]!
 }
 
@@ -11269,20 +13644,24 @@ Represents a dashboard parameter.
 Represents a dashboard parameter.
 """
 	width: Int
-"""
-Represents a dashboard parameter.
-"""
-	isMultiParam: Boolean
-"""
-Represents a dashboard parameter.
-"""
-	defaultMultiValues: [String!]
 }
 
 type DashboardTemplate {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	displayName: String!
+"""
+Stability: Long-term
+"""
 	yamlTemplate: String!
+"""
+Stability: Long-term
+"""
 	labels: [String!]!
 }
 
@@ -11295,24 +13674,40 @@ union DashboardUpdateFrequencyType =NeverDashboardUpdateFrequency | RealTimeDash
 A datasource, e.g. file name or system sending data to LogScale.
 """
 type Datasource {
+"""
+Stability: Short-term
+"""
 	name: String!
+"""
+Stability: Short-term
+"""
 	oldestTimestamp: DateTime!
+"""
+Stability: Short-term
+"""
 	newestTimestamp: DateTime!
+"""
+Stability: Short-term
+"""
 	tags: [Tag!]!
 """
 The size in Gigabytes of the data from this data source before compression.
+Stability: Short-term
 """
 	sizeAtIngest: Float!
 """
 This size in Gigabytes of the data from this data source currently on disk.
+Stability: Short-term
 """
 	sizeOnDisk: Float!
 """
 The size in Gigabytes of the data from this data source before compression, but only for the parts that are now part of a merged segment file.
+Stability: Short-term
 """
 	sizeAtIngestOfMerged: Float!
 """
 This size in Gigabytes of the data from this data source currently on disk, but only for the parts that are now part of a merged segment file.
+Stability: Short-term
 """
 	sizeOnDiskOfMerged: Float!
 }
@@ -11326,12 +13721,33 @@ scalar DateTime
 A deletion of a set of events.
 """
 type DeleteEvents {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	created: DateTime!
+"""
+Stability: Long-term
+"""
 	start: DateTime!
+"""
+Stability: Long-term
+"""
 	end: DateTime!
+"""
+Stability: Long-term
+"""
 	query: String!
+"""
+Stability: Long-term
+"""
 	createdByUser: String
+"""
+Stability: Long-term
+"""
 	languageVersion: LanguageVersion!
 }
 
@@ -11339,8 +13755,30 @@ type DeleteEvents {
 Entry into a list of unordered key-value pairs with unique keys
 """
 type DictionaryEntryType {
+"""
+Stability: Long-term
+"""
 	key: String!
+"""
+Stability: Long-term
+"""
 	value: String!
+}
+
+"""
+Asset permissions that can be directly assigned to users or groups
+"""
+type DirectlyAssignedAssetPermissions {
+"""
+List of asset permissions
+Stability: Preview
+"""
+	assetPermissions: [AssetPermission!]!
+"""
+Whether permissions were assigned due to asset creator status
+Stability: Preview
+"""
+	assignedBecauseOfCreatorStatus: Boolean!
 }
 
 """
@@ -11372,10 +13810,14 @@ enum DynamicConfig {
 	RdnsDefaultLimit
 	RdnsMaxLimit
 	QueryResultRowCountLimit
+	AggregatorOutputRowLimit
 	ParserThrottlingAllocationFactor
 	UndersizedMergingRetentionPercentage
 	StaticQueryFractionOfCores
 	TargetMaxRateForDatasource
+	VerifySegmentInBucketCompletionIntervalDays
+	VerifySegmentInBucketHeadOnly
+	MaxRelocatedDatasourcesInGlobal
 	DelayIngestResponseDueToIngestLagMaxFactor
 	DelayIngestResponseDueToIngestLagThreshold
 	DelayIngestResponseDueToIngestLagScale
@@ -11389,10 +13831,10 @@ enum DynamicConfig {
 	FlushSegmentsAndGlobalOnShutdown
 	GracePeriodBeforeDeletingDeadEphemeralHostsMs
 	FdrS3FileSizeMax
-	S3ArchivingClusterWideStartFrom
-	S3ArchivingClusterWideEndAt
-	S3ArchivingClusterWideDisabled
-	S3ArchivingClusterWideRegexForRepoName
+	ArchivingClusterWideStartFrom
+	ArchivingClusterWideEndAt
+	ArchivingClusterWideDisabled
+	ArchivingClusterWideRegexForRepoName
 	EnableDemoData
 	MaxNumberOfOrganizations
 	NumberOfDaysToRemoveStaleOrganizationsAfter
@@ -11425,10 +13867,29 @@ enum DynamicConfig {
 	QueryBlockMillisOnHighIngestDelay
 	FileReplicationFactor
 	QueryBacktrackingLimit
+	ParserBacktrackingLimit
 	GraphQlDirectivesAmountLimit
 	TableCacheMemoryAllowanceFraction
 	TableCacheMaxStorageFraction
 	TableCacheMaxStorageFractionForIngestAndHttpOnly
+	RetentionPreservationStartDt
+	RetentionPreservationEndDt
+	RetentionPreservationTag
+	DisableNewRegexEngine
+	EnableGlobalJsonStatsLogger
+	LiveAdhocTableUpdatePeriodMinimumMs
+	MinQueryPermitsFactor
+	CorrelateQueryLimit
+	CorrelateConstraintLimit
+	CorrelateConstellationTickLimit
+	CorrelateLinkValuesLimit
+	CorrelateLinkValuesMaxByteSize
+	CorrelateNumberOfTimeBuckets
+	CorrelateQueryEventLimit
+	MultiPassDefaultIterationLimit
+	MultiPassMaxIterationLimit
+	CorrelateMinIterations
+	GracefulShutdownConsideredAliveSeconds
 }
 
 """
@@ -11437,10 +13898,12 @@ A key value pair of a dynamic config and the accompanying value.
 type DynamicConfigKeyValueType {
 """
 The dynamic config key.
+Stability: Short-term
 """
 	dynamicConfigKey: DynamicConfig!
 """
 The dynamic config value.
+Stability: Short-term
 """
 	dynamicConfigValue: String!
 }
@@ -11505,14 +13968,17 @@ Usage information
 type EnvironmentVariableUsage {
 """
 The source for this environment variable. "Environment": the value is from the environment, "Default": variable not found in the environment, but a default value is used, "Missing": no variable or default found
+Stability: Short-term
 """
 	source: String!
 """
 Value for this variable
+Stability: Short-term
 """
 	value: String!
 """
 Environment variable name
+Stability: Short-term
 """
 	name: String!
 }
@@ -11545,19 +14011,27 @@ An event forwarder
 type EventForwarderForSelection {
 """
 Id of the event forwarder
+Stability: Long-term
 """
 	id: String!
 """
 Name of the event forwarder
+Stability: Long-term
 """
 	name: String!
 """
 Description of the event forwarder
+Stability: Long-term
 """
 	description: String!
+"""
+Is the event forwarder enabled
+Stability: Long-term
+"""
 	enabled: Boolean!
 """
 The kind of event forwarder
+Stability: Long-term
 """
 	kind: EventForwarderKind!
 }
@@ -11575,20 +14049,27 @@ An event forwarding rule
 type EventForwardingRule {
 """
 The unique id for the event forwarding rule
+Stability: Long-term
 """
 	id: String!
 """
 The query string for filtering and mapping the events to forward
+Stability: Long-term
 """
 	queryString: String!
 """
 The id of the event forwarder
+Stability: Long-term
 """
 	eventForwarderId: String!
 """
-The unix timestamp the event forwarder was created
+The unix timestamp that the event forwarder was created at
+Stability: Long-term
 """
 	createdAt: Long
+"""
+Stability: Long-term
+"""
 	languageVersion: LanguageVersion!
 }
 
@@ -11596,9 +14077,21 @@ The unix timestamp the event forwarder was created
 Fields that helps describe the status of eviction
 """
 type EvictionStatus {
+"""
+Stability: Long-term
+"""
 	currentlyUnderReplicatedBytes: Long!
+"""
+Stability: Long-term
+"""
 	totalSegmentBytes: Long!
+"""
+Stability: Long-term
+"""
 	isDigester: Boolean!
+"""
+Stability: Long-term
+"""
 	bytesThatExistOnlyOnThisNode: Float!
 }
 
@@ -11608,22 +14101,27 @@ The specification of an external function.
 type ExternalFunctionSpecificationOutput {
 """
 The name of the external function.
+Stability: Preview
 """
 	name: String!
 """
 The URL for the external function.
+Stability: Preview
 """
 	procedureURL: String!
 """
 The parameter specifications for the external function.
+Stability: Preview
 """
 	parameters: [ParameterSpecificationOutput!]!
 """
 The description for the external function.
+Stability: Preview
 """
 	description: String!
 """
 The kind of external function. This defines how the external function is executed.
+Stability: Preview
 """
 	kind: KindOutput!
 }
@@ -11634,34 +14132,42 @@ Information about an FDR feed.
 type FdrFeed {
 """
 Id of the FDR feed.
+Stability: Long-term
 """
 	id: String!
 """
 Name of the FDR feed.
+Stability: Long-term
 """
 	name: String!
 """
 Description of the FDR feed.
+Stability: Long-term
 """
 	description: String
 """
 The id of the parser that is used to parse the FDR data.
+Stability: Long-term
 """
 	parserId: String!
 """
 AWS client id of the FDR feed.
+Stability: Long-term
 """
 	clientId: String!
 """
 AWS SQS queue url of the FDR feed.
+Stability: Long-term
 """
 	sqsUrl: String!
 """
 AWS S3 Identifier of the FDR feed.
+Stability: Long-term
 """
 	s3Identifier: String!
 """
 Is ingest from the FDR feed enabled?
+Stability: Long-term
 """
 	enabled: Boolean!
 }
@@ -11672,21 +14178,24 @@ Administrator control for an FDR feed
 type FdrFeedControl {
 """
 Id of the FDR feed.
+Stability: Long-term
 """
 	id: String!
 """
 Maximum number of nodes to poll FDR feed with
+Stability: Long-term
 """
 	maxNodes: Int
 """
 Maximum amount of files downloaded from s3 in parallel for a single node.
+Stability: Long-term
 """
 	fileDownloadParallelism: Int
 }
 
 enum FeatureAnnouncement {
-	AggregateAlertSearchPage
-	AggregateAlertOverview
+	TriggerSearchPage
+	TriggerOverview
 	FleetRemoteUpdatesAndGroups
 	FilterMatchHighlighting
 	OrganizationOwnedQueries
@@ -11702,187 +14211,361 @@ Represents a feature flag.
 """
 enum FeatureFlag {
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Export data to bucket storage.
+Export data to bucket storage.
+Stability: Preview
 """
 	ExportToBucket
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Enable repeating queries. Can be used instead of live queries for functions having limitations around live queries.
+Enable repeating queries. Can be used instead of live queries for functions having limitations around live queries.
+Stability: Preview
 """
 	RepeatingQueries
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Enable custom ingest tokens not generated by LogScale.
+Enable custom ingest tokens not generated by LogScale.
+Stability: Preview
 """
 	CustomIngestTokens
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable permission tokens.
-"""
-	PermissionTokens
-"""
-[PREVIEW: This functionality is still under development and can change without warning.] Assign default roles for groups.
-"""
-	DefaultRolesForGroups
-"""
-[PREVIEW: This functionality is still under development and can change without warning.] Use new organization limits.
+Use new organization limits.
+Stability: Preview
 """
 	NewOrganizationLimits
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Authenticate cookies server-side.
-"""
-	CookieAuthServerSide
-"""
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable ArrayFunctions in query language.
+Enable ArrayFunctions in query language.
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
 """
 	ArrayFunctions
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable geography functions in query language.
+Enable geography functions in query language.
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
 """
 	GeographyFunctions
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Prioritize newer over older segments.
+Prioritize newer over older segments.
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
 """
 	CachePolicies
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable searching across LogScale clusters.
+Enable searching across LogScale clusters.
+Stability: Preview
 """
 	MultiClusterSearch
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable subdomains for current cluster.
+Enable subdomains for current cluster.
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
 """
 	SubdomainForOrganizations
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable Humio Managed repositories. The customer is not permitted to change certain configurations in a LogScale Managed repository.
+Enable Humio Managed repositories. The customer is not permitted to change certain configurations in a LogScale Managed repository.
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
 """
 	ManagedRepositories
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Allow users to configure FDR feeds for managed repositories
+Allow users to configure FDR feeds for managed repositories
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
 """
 	ManagedRepositoriesAllowFDRConfig
 """
-[PREVIEW: This functionality is still under development and can change without warning.] The UsagePage shows data from ingestAfterFieldRemovalSize instead of segmentWriteBytes
+The UsagePage shows data from ingestAfterFieldRemovalSize instead of segmentWriteBytes
+Stability: Preview
 """
 	UsagePageUsingIngestAfterFieldRemovalSize
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Enable falcon data connector
+Enable falcon data connector
+Stability: Preview
 """
 	FalconDataConnector
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Flag for testing, does nothing
+Flag for testing, does nothing
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
 """
 	SleepFunction
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Enable login bridge
+Enable login bridge
+Stability: Preview
 """
 	LoginBridge
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables download of macos installer for logcollector through fleet management
+Enables download of macos installer for logcollector through fleet management
+Stability: Preview
 """
 	MacosInstallerForLogCollector
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables UsageJob to log average usage as part of usage log
-"""
-	LogAverageUsage
-"""
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables ephemeral hosts support for fleet management
+Enables ephemeral hosts support for fleet management
+Stability: Preview
 """
 	FleetEphemeralHosts
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables fleet management collector metrics
+Prevents the archiving logic from splitting segments into multiple archived files based on their tag groups
+Stability: Preview
+"""
+	DontSplitSegmentsForArchiving
+"""
+Enables fleet management collector metrics
+Stability: Preview
 """
 	FleetCollectorMetrics
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] No currentHosts writes for segments in buckets
+No currentHosts writes for segments in buckets
+Stability: Preview
 """
 	NoCurrentsForBucketSegments
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Pre-merge mini-segments
+Force a refresh of ClusterManagementStats cache before calculating UnregisterNodeBlockers in clusterUnregisterNode mutation
+Stability: Preview
+"""
+	RefreshClusterManagementStatsInUnregisterNode
+"""
+Pre-merge mini-segments
+Stability: Preview
 """
 	PreMergeMiniSegments
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Use a new segment file format on write - not readable by older versions
+Use new store for Autosharding rules
+Stability: Preview
+"""
+	NewAutoshardRuleStore
+"""
+Use a new segment file format on write - not readable by older versions
+Stability: Preview
 """
 	WriteNewSegmentFileFormat
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables fleet management collector debug logging
+When using the new segment file format on write, also do the old solely for comparison
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
+"""
+	MeasureNewSegmentFileFormat
+"""
+Enables fleet management collector debug logging
+Stability: Preview
 """
 	FleetCollectorDebugLogging
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables LogScale Collector remote updates
+Resolve field names during codegen rather than for every event
+Stability: Preview
+"""
+	ResolveFieldsCodeGen
+"""
+Enables LogScale Collector remote updates
+Stability: Preview
 """
 	FleetRemoteUpdates
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables alternate query merge target handling
+Enables alternate query merge target handling
+Stability: Preview
 """
 	AlternateQueryMergeTargetHandling
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables query optimizations for fleet management
+Allow digesters to start without having all the minis for the current merge target. Requires the AlternateQueryMergeTargetHandling feature flag to be enabled
+Stability: Preview
 """
-	FleetUseStaticQueries
+	DigestersDontNeedMergeTargetMinis
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables labels for fleet management
+Enables labels for fleet management
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
 """
 	FleetLabels
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables Field Aliasing
+Segment rebalancer handles mini segments. Can only take effect when the AlternateQueryMergeTargetHandling and DigestersDontNeedMergeTargetMinis feature flags are also enabled
+Stability: Preview
+"""
+	SegmentRebalancerHandlesMinis
+"""
+Enables dashboards on fleet overview page
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
+"""
+	FleetOverviewDashboards
+"""
+Enables archiving for Google Cloud Storage
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
+"""
+	GoogleCloudArchiving
+"""
+Enables TablePage UI on fleet management pages.
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
+"""
+	FleetTablePageUI
+"""
+Disables periodic ingestOffset pushing for datasources in favor of alternate handling
+Stability: Preview
+"""
+	ReplacePeriodicIngestOffsetPushing
+"""
+Lets the cluster know that non-evicted nodes undergoing a graceful shutdown should be considered alive for 5 minutes with regards to segment rebalancing
+Stability: Preview
+"""
+	SetConsideredAliveUntilOnGracefulShutdown
+"""
+Enables Field Aliasing
+Stability: Preview
 """
 	FieldAliasing
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] External Functions
+External Functions
+THIS FUNCTIONALITY IS RESTRICTED: Enabling this functionality should not be done in any production environment.
+Stability: Preview
 """
 	ExternalFunctions
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable the LogScale Query Assistant
+Enable the LogScale Query Assistant
+THIS FUNCTIONALITY IS RESTRICTED: Enabling this functionality should not be done in any production environment.
+Stability: Preview
 """
 	QueryAssistant
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable Flight Control support in cluster
+Enable Flight Control support in cluster
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
 """
 	FlightControl
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enable organization level security policies. For instance the ability to only enable certain action types.
-"""
-	OrganizationSecurityPolicies
-"""
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables a limit on query backtracking
+Enables a limit on query backtracking
+Stability: Preview
 """
 	QueryBacktrackingLimit
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Adds a derived #repo.cid tag when searching in views or dataspaces within an organization with an associated CID
+Adds a derived #repo.cid tag when searching in views or dataspaces within an organization with an associated CID
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
 """
 	DerivedCidTag
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Live tables
+Live tables
+Stability: Preview
 """
 	LiveTables
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables the MITRE Detection Annotation function
+Enables graph queries
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
+"""
+	GraphQueries
+"""
+Enables the MITRE Detection Annotation function
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
 """
 	MitreDetectionAnnotation
 """
-[PREVIEW: This functionality is still under development and can change without warning. THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] Enables having multiple role bindings for a single view in the same group. This feature flag does nothing until min version is at least 1.150.0
+Enables having multiple role bindings for a single view in the same group. This feature can only be enabled when min version is at least 1.150.0
+Stability: Preview
 """
 	MultipleViewRoleBindings
+"""
+When enabled, queries exceeding the AggregatorOutputRowLimit will get cancelled. When disabled, queries will continue to run, but a log is produced whenever the limit is exceeded.
+Stability: Preview
+"""
+	CancelQueriesExceedingAggregateOutputRowLimit
+"""
+Enables mapping one group to more than one LogScale group with the same lookup name during group synchronization.
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
+"""
+	OneToManyGroupSynchronization
+"""
+Enables support specifying the query time interval using the query function setTimeInterval()
+Stability: Preview
+"""
+	TimeIntervalInQuery
+"""
+Enables LLM parser generation
+THIS FUNCTIONALITY IS EXPERIMENTAL: Enabling experimental functionality is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.
+Stability: Preview
+"""
+	LlmParserGeneration
+"""
+Enables the external data source sync job to sync entity data
+THIS FUNCTIONALITY IS RESTRICTED: Enabling this functionality should not be done in any production environment.
+Stability: Preview
+"""
+	ExternalDataSourceSyncForEntity
+"""
+Enables the external data source sync job to sync identity data
+THIS FUNCTIONALITY IS RESTRICTED: Enabling this functionality should not be done in any production environment.
+Stability: Preview
+"""
+	ExternalDataSourceSyncForIdentity
+"""
+Use the new query coordination partition logic.
+Stability: Preview
+"""
+	UseNewQueryCoordinationPartitions
+"""
+Use the new sort, head, tail, and table datastructure
+Stability: Preview
+"""
+	SortNewDatastructure
 }
 
 """
 Feature flags with details
 """
 type FeatureFlagV2 {
+"""
+Stability: Preview
+"""
 	flag: FeatureFlag!
+"""
+Stability: Preview
+"""
 	description: String!
+"""
+Stability: Preview
+"""
 	experimental: Boolean!
 }
 
 type FieldAliasSchema {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	fields: [SchemaField!]!
+"""
+Stability: Long-term
+"""
 	instances: [AliasMapping!]!
+"""
+Stability: Long-term
+"""
 	version: String!
+"""
+Stability: Long-term
+"""
+	yamlTemplate: YAML!
 }
 
 type FieldAliasSchemasInfo {
+"""
+Stability: Long-term
+"""
 	schemas: [FieldAliasSchema!]!
+"""
+Stability: Long-term
+"""
 	activeSchemaOnOrg: String
+"""
+Stability: Long-term
+"""
 	activeSchemasOnViews: [ActiveSchemaOnView!]!
 }
 
@@ -11907,10 +14590,12 @@ Presentation preferences used when a field is added to table and event list widg
 type FieldConfiguration {
 """
 The field the configuration is associated with.
+Stability: Long-term
 """
 	fieldName: String!
 """
 A JSON object containing the column properties applied to the column when it is added to a widget.
+Stability: Long-term
 """
 	config: JSON!
 }
@@ -11921,10 +14606,12 @@ An assertion that an event output from a parser test case has an expected value 
 type FieldHasValue {
 """
 Field to assert on.
+Stability: Long-term
 """
 	fieldName: String!
 """
 Value expected to be contained in the field.
+Stability: Long-term
 """
 	expectedValue: String!
 }
@@ -11933,30 +14620,65 @@ Value expected to be contained in the field.
 A file upload to LogScale for use with the `match` query function. You can see them under the Files page in the UI.
 """
 type File {
+"""
+Stability: Long-term
+"""
 	contentHash: String!
+"""
+Stability: Long-term
+"""
 	nameAndPath: FileNameAndPath!
+"""
+Stability: Long-term
+"""
 	createdAt: DateTime!
+"""
+Stability: Long-term
+"""
 	createdBy: String!
+"""
+Stability: Long-term
+"""
 	modifiedAt: DateTime!
+"""
+Stability: Long-term
+"""
 	fileSizeBytes: Long
+"""
+Stability: Long-term
+"""
 	modifiedBy: String!
+"""
+Stability: Long-term
+"""
 	packageId: VersionedPackageSpecifier
+"""
+Stability: Long-term
+"""
 	package: PackageInstallation
 """
-The view or repository for the file
-"""
-	view: PartialSearchDomain
-"""
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Allowed asset actions
+Allowed asset actions
+Stability: Preview
 """
 	allowedActions: [AssetAction!]!
+"""
+The resource identifier for this file.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 """
 A file asset
 """
 type FileEntry {
+"""
+Stability: Preview
+"""
 	view: SearchDomain
+"""
+Stability: Preview
+"""
 	file: File!
 }
 
@@ -11975,6 +14697,9 @@ A field in a file and what value the field should have for a given entry to pass
 }
 
 type FileNameAndPath {
+"""
+Stability: Long-term
+"""
 	name: String!
 """
 Paths for files can be one of two types: absolute or relative.
@@ -11986,15 +14711,9 @@ An absolute path points to something that can be addressed from any view,
 and a relative path points to a file located inside the view.
 If there is no path, it means the file is located at your current location.
 
+Stability: Long-term
 """
 	path: String
-}
-
-"""
-The config for lookup files.
-"""
-type FilesConfig {
-	maxFileUploadSize: Int!
 }
 
 """
@@ -12003,80 +14722,109 @@ A filter alert.
 type FilterAlert {
 """
 Id of the filter alert.
+Stability: Long-term
 """
 	id: String!
 """
 Name of the filter alert.
+Stability: Long-term
 """
 	name: String!
 """
 Description of the filter alert.
+Stability: Long-term
 """
 	description: String
 """
 LogScale query to execute.
+Stability: Long-term
 """
 	queryString: String!
 """
 List of ids for actions to fire on query result.
+Stability: Long-term
 """
 	actions: [Action!]!
 """
 Labels attached to the filter alert.
+Stability: Long-term
 """
 	labels: [String!]!
 """
 Flag indicating whether the filter alert is enabled.
+Stability: Long-term
 """
 	enabled: Boolean!
 """
 Throttle time in seconds.
+Stability: Long-term
 """
 	throttleTimeSeconds: Long
 """
 A field to throttle on. Can only be set if throttleTimeSeconds is set.
+Stability: Long-term
 """
 	throttleField: String
 """
 Unix timestamp for last successful poll of the filter alert query. If this is not quite recent, then the alert might be having problems.
+Stability: Long-term
 """
 	lastSuccessfulPoll: Long
 """
 Unix timestamp for last execution of trigger.
+Stability: Long-term
 """
 	lastTriggered: Long
 """
 Unix timestamp for last error.
+Stability: Long-term
 """
 	lastErrorTime: Long
 """
 Last error encountered while running the filter alert.
+Stability: Long-term
 """
 	lastError: String
 """
 Last warnings encountered while running the filter alert.
+Stability: Long-term
 """
 	lastWarnings: [String!]!
 """
 YAML specification of the filter alert.
+Stability: Long-term
 """
 	yamlTemplate: YAML!
 """
 The id of the package that the alert was installed as part of.
+Stability: Long-term
 """
 	packageId: VersionedPackageSpecifier
 """
+User or token used to modify the asset.
+Stability: Preview
+"""
+	modifiedInfo: ModifiedInfo!
+"""
 The package that the alert was installed as part of.
+Stability: Long-term
 """
 	package: PackageInstallation
 """
 Ownership of the query run by this alert
+Stability: Long-term
 """
 	queryOwnership: QueryOwnership!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Allowed asset actions
+Allowed asset actions
+Stability: Preview
 """
 	allowedActions: [AssetAction!]!
+"""
+The resource identifier for this filter alert.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 """
@@ -12085,18 +14833,32 @@ The default config for filter alerts.
 type FilterAlertConfig {
 """
 Maximum trigger limit for filter alerts with one or more email actions.
+Stability: Long-term
 """
 	filterAlertEmailTriggerLimit: Int!
 """
 Maximum trigger limit for filter alerts with no email actions.
+Stability: Long-term
 """
 	filterAlertNonEmailTriggerLimit: Int!
 }
 
 type FilterAlertTemplate {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	displayName: String!
+"""
+Stability: Long-term
+"""
 	yamlTemplate: YAML!
+"""
+Stability: Long-term
+"""
 	labels: [String!]!
 }
 
@@ -12116,9 +14878,25 @@ enum FleetGroups__SortBy {
 }
 
 type FleetInstallationToken {
+"""
+Stability: Short-term
+"""
 	token: String!
+"""
+Stability: Short-term
+"""
+	jwtToken: String!
+"""
+Stability: Short-term
+"""
 	name: String!
+"""
+Stability: Short-term
+"""
 	assignedConfiguration: LogCollectorConfiguration
+"""
+Stability: Short-term
+"""
 	installationCommands: LogCollectorInstallCommand!
 }
 
@@ -12138,6 +14916,7 @@ enum Fleet__SortBy {
 	MemoryMax5Min
 	DiskMax5Min
 	Change
+	Labels
 }
 
 """
@@ -12146,12 +14925,45 @@ Settings for the Java Flight Recorder.
 type FlightRecorderSettings {
 """
 True if OldObjectSample is enabled
+Stability: Preview
 """
 	oldObjectSampleEnabled: Boolean!
 """
 The duration old object sampling will run for before dumping results and restarting
+Stability: Preview
 """
 	oldObjectSampleDurationMinutes: Long!
+}
+
+"""
+Archiving configuration for GCS, i.e. bucket and format.
+"""
+type GCSArchivingConfiguration implements ArchivingConfiguration{
+"""
+Bucket name for storing archived data. Example: acme-bucket.
+Stability: Preview
+"""
+	bucket: String!
+"""
+Do not archive logs older than this.
+Stability: Preview
+"""
+	startFrom: DateTime
+"""
+Whether the archiving has been disabled.
+Stability: Preview
+"""
+	disabled: Boolean
+"""
+The format to store the archived data in Google Cloud Storage
+Stability: Preview
+"""
+	format: ArchivingFormat
+"""
+Array of names of tag fields to use in that order in the output file names.
+Stability: Preview
+"""
+	tagOrderInName: [String!]!
 }
 
 """
@@ -12310,39 +15122,71 @@ The input required to get an external function specification.
 A group.
 """
 type Group {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	displayName: String!
+"""
+Stability: Long-term
+"""
 	defaultQueryPrefix: String
+"""
+Stability: Long-term
+"""
 	defaultRole: Role
+"""
+Stability: Long-term
+"""
 	defaultSearchDomainCount: Int!
+"""
+Stability: Long-term
+"""
 	lookupName: String
+"""
+Stability: Long-term
+"""
 	searchDomainCount: Int!
+"""
+Stability: Long-term
+"""
 	roles: [SearchDomainRole!]!
+"""
+Stability: Long-term
+"""
 	searchDomainRoles(
 		searchDomainId: String
 	): [SearchDomainRole!]!
 	searchDomainRolesByName(
 		searchDomainName: String!
 	): SearchDomainRole
+"""
+Stability: Long-term
+"""
 	searchDomainRolesBySearchDomainName(
 		searchDomainName: String!
 	): [SearchDomainRole!]!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Get asset permissions assigned to the group for the specific asset
+Get allowed asset actions for the group on a specific asset and explain how it has gotten this access
+Stability: Preview
 """
-	assetPermissions(
+	allowedAssetActionsBySource(
 """
 Id of the asset
 """
 		assetId: String!
 """
-Asset type
+The type of the asset.
 """
 		assetType: AssetPermissionsAssetType!
 		searchDomainId: String
-	): AssetPermissionsForGroup!
+	): GroupAssetActionsBySource!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Search for asset permissions for the group
+Search for asset permissions for the group. Only search for asset name is supported with regards to the searchFilter argument.
+Stability: Preview
 """
 	searchAssetPermissions(
 """
@@ -12362,34 +15206,49 @@ Choose the order in which the results are returned.
 """
 		orderBy: OrderBy
 """
-The sort by options for asset permissions.
+The sort by options for assets. Asset name is default
 """
 		sortBy: SortBy
 """
-Asset type
+List of asset types
 """
-		assetType: AssetPermissionsAssetType!
+		assetTypes: [AssetPermissionsAssetType!]
 """
-List of search domain id's to search within
+List of search domain id's to search within. Null or empty list is interpreted as all search domains
 """
 		searchDomainIds: [String!]
 """
-Include UpdateAsset and/or DeleteAsset permission assignments
+Include Read, Update and/or Delete permission assignments. The filter will accept all assets if the argument Null or the empty list.
 """
-		permissions: AssetPermissionInputEnum
-"""
-If this is set to true, the search will also return all assets, that the group has not been assigned any permissions for
-"""
-		includeUnassignedAssets: Boolean
+		permissions: [AssetAction!]
 	): AssetPermissionSearchResultSet!
+"""
+Stability: Long-term
+"""
 	systemRoles: [GroupSystemRole!]!
+"""
+Stability: Long-term
+"""
 	organizationRoles: [GroupOrganizationRole!]!
+"""
+Stability: Long-term
+"""
 	queryPrefixes(
 		onlyIncludeRestrictiveQueryPrefixes: Boolean
 		onlyForRoleWithId: String
+		onlyForViewWithId: String
 	): [QueryPrefixes!]!
+"""
+Stability: Long-term
+"""
 	userCount: Int!
+"""
+Stability: Long-term
+"""
 	users: [User!]!
+"""
+Stability: Long-term
+"""
 	searchUsers(
 """
 Filter results based on this string
@@ -12412,14 +15271,30 @@ Choose the order in which the results are returned.
 """
 		orderBy: OrderBy
 	): UserResultSetType!
+"""
+Stability: Long-term
+"""
+	permissionType: PermissionType
 }
 
 """
-Group to asset permissions assignments
+Asset actions given by a group for a specific asset
 """
-type GroupAssetPermissionAssignment {
-	group: Group!
-	assetPermissions: [AssetPermissionOutputEnum!]!
+type GroupAssetActionsBySource implements AssetActionsBySource{
+"""
+Stability: Preview
+"""
+	group: Group
+"""
+List of roles assigned to the user or group and the asset actions they allow
+Stability: Preview
+"""
+	assetActionsByRoles: [AssetActionsByRole!]!
+"""
+Asset permissions assigned directly to the user or group
+Stability: Preview
+"""
+	directlyAssigned: DirectlyAssignedAssetPermissions!
 }
 
 input GroupFilter {
@@ -12428,9 +15303,21 @@ input GroupFilter {
 }
 
 type GroupFilterInfo {
+"""
+Stability: Short-term
+"""
 	total: Int!
+"""
+Stability: Short-term
+"""
 	added: Int!
+"""
+Stability: Short-term
+"""
 	removed: Int!
+"""
+Stability: Short-term
+"""
 	noChange: Int!
 }
 
@@ -12438,6 +15325,9 @@ type GroupFilterInfo {
 The organization roles of the group.
 """
 type GroupOrganizationRole {
+"""
+Stability: Long-term
+"""
 	role: Role!
 }
 
@@ -12445,7 +15335,13 @@ type GroupOrganizationRole {
 A page of groups in an organization.
 """
 type GroupPage {
+"""
+Stability: Long-term
+"""
 	pageInfo: PageType!
+"""
+Stability: Long-term
+"""
 	page: [Group!]!
 }
 
@@ -12455,28 +15351,31 @@ The groups query result set.
 type GroupResultSetType {
 """
 The total number of matching results
+Stability: Long-term
 """
 	totalResults: Int!
 """
 The paginated result set
+Stability: Long-term
 """
 	results: [Group!]!
-}
-
-"""
-A group to role assignment
-"""
-type GroupRole {
-	group: Group!
-	role: Role!
 }
 
 """
 The role assigned to a group in a SearchDomain
 """
 type GroupSearchDomainRole {
+"""
+Stability: Long-term
+"""
 	role: Role!
+"""
+Stability: Long-term
+"""
 	searchDomain: SearchDomain!
+"""
+Stability: Long-term
+"""
 	group: Group!
 }
 
@@ -12484,7 +15383,15 @@ type GroupSearchDomainRole {
 The system roles of the group.
 """
 type GroupSystemRole {
+"""
+Stability: Long-term
+"""
 	role: Role!
+}
+
+enum GroupsOrUsersFilter {
+	Users
+	Groups
 }
 
 """
@@ -12493,10 +15400,12 @@ Health status of the service
 type HealthStatus {
 """
 The latest status from the service
+Stability: Preview
 """
 	status: String!
 """
 The latest health status message from the service
+Stability: Preview
 """
 	message: String!
 }
@@ -12507,81 +15416,175 @@ Represents information about the LogScale instance.
 type HumioMetadata {
 """
 Returns enabled features that are likely in beta.
+Stability: Short-term
 """
 	isFeatureFlagEnabled(
 		feature: FeatureFlag!
 	): Boolean!
+"""
+Stability: Long-term
+"""
 	externalPermissions: Boolean!
+"""
+Stability: Long-term
+"""
 	version: String!
 """
-[PREVIEW: Experimental field used to improve the user experience during cluster upgrades.] An indication whether or not the cluster is being updated. This is based off of differences in the cluster node versions.
+An indication whether or not the cluster is being updated. This is based off of differences in the cluster node versions.
+Stability: Preview
 """
 	isClusterBeingUpdated: Boolean!
 """
-[PREVIEW: Experimental field used to improve the user experience during cluster upgrades.] The lowest detected node version in the cluster.
+The lowest detected node version in the cluster.
+Stability: Preview
 """
 	minimumNodeVersion: String!
+"""
+Stability: Long-term
+"""
 	environment: EnvironmentType!
+"""
+Stability: Long-term
+"""
 	clusterId: String!
+"""
+Stability: Short-term
+"""
 	falconDataConnectorUrl: String
+"""
+Stability: Long-term
+"""
 	regions: [RegionSelectData!]!
 """
-[PREVIEW: Experimental feature, not ready for production.] List of supported AWS regions
+List of supported AWS regions
+Stability: Long-term
 """
 	awsRegions: [String!]!
 """
-[PREVIEW: Experimental feature, not ready for production.] Cluster AWS IAM role arn (Amazon Resource Name) used to assume role for ingest feeds
+Cluster AWS IAM role arn (Amazon Resource Name) used to assume role for ingest feeds
+Stability: Long-term
 """
 	ingestFeedAwsRoleArn: String
 """
-[PREVIEW: Experimental feature, not ready for production.] Configuration status for AWS ingest feeds.
+Configuration status for AWS ingest feeds.
+Stability: Long-term
 """
 	awsIngestFeedsConfigurationStatus: IngestFeedConfigurationStatus!
+"""
+Stability: Short-term
+"""
 	sharedDashboardsEnabled: Boolean!
+"""
+Stability: Short-term
+"""
 	personalUserTokensEnabled: Boolean!
+"""
+Stability: Long-term
+"""
 	globalAllowListEmailActionsEnabled: Boolean!
+"""
+Stability: Long-term
+"""
 	isAutomaticUpdateCheckingEnabled: Boolean!
 """
 The authentication method used for the cluster node
+Stability: Long-term
 """
 	authenticationMethod: AuthenticationMethod!
+"""
+Stability: Short-term
+"""
 	organizationMultiMode: Boolean!
+"""
+Stability: Short-term
+"""
 	organizationMode: OrganizationMode!
+"""
+Stability: Short-term
+"""
 	sandboxesEnabled: Boolean!
+"""
+Stability: Short-term
+"""
 	externalGroupSynchronization: Boolean!
+"""
+Stability: Long-term
+"""
 	allowActionsNotUseProxy: Boolean!
+"""
+Stability: Long-term
+"""
 	isUsingSmtp: Boolean!
+"""
+Stability: Short-term
+"""
 	isPendingUsersEnabled: Boolean!
+"""
+Stability: Long-term
+"""
 	scheduledSearchMaxBackfillLimit: Int
+"""
+Stability: Short-term
+"""
 	isExternalManaged: Boolean!
+"""
+Stability: Short-term
+"""
 	isApiExplorerEnabled: Boolean!
+"""
+Stability: Short-term
+"""
 	isScheduledReportEnabled: Boolean!
+"""
+Stability: Short-term
+"""
 	eulaUrl: String!
 """
 The time in ms after which a repository has been marked for deletion it will no longer be restorable.
+Stability: Long-term
 """
 	deleteBackupAfter: Long!
+"""
+Stability: Short-term
+"""
 	maxCsvFileUploadSizeBytes: Long!
+"""
+Stability: Short-term
+"""
 	maxJsonFileUploadSizeBytes: Long!
 """
 The filter alert config.
 """
 	filterAlertConfig: FilterAlertConfig!
-"""
-The lookup files config.
-"""
-	filesConfig: FilesConfig!
 }
 
 """
 A LogScale query
 """
 type HumioQuery {
+"""
+Stability: Long-term
+"""
 	languageVersion: LanguageVersion!
+"""
+Stability: Long-term
+"""
 	queryString: String!
+"""
+Stability: Long-term
+"""
 	arguments: [DictionaryEntryType!]!
+"""
+Stability: Long-term
+"""
 	start: String!
+"""
+Stability: Long-term
+"""
 	end: String!
+"""
+Stability: Long-term
+"""
 	isLive: Boolean!
 }
 
@@ -12591,21 +15594,33 @@ An IP Filter
 type IPFilter {
 """
 The unique id for the ip filter
+Stability: Long-term
 """
 	id: String!
 """
 The name for the ip filter
+Stability: Long-term
 """
 	name: String!
 """
 The ip filter
+Stability: Long-term
 """
 	ipFilter: String!
 }
 
 type IdentityProviderAuth {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	authenticationMethod: AuthenticationMethodAuth!
 }
 
@@ -12644,7 +15659,13 @@ An Identity Provider
 }
 
 type Ingest {
+"""
+Stability: Long-term
+"""
 	currentBytes: Long!
+"""
+Stability: Long-term
+"""
 	limit: UsageLimit!
 }
 
@@ -12654,34 +15675,42 @@ An ingest feed.
 type IngestFeed {
 """
 Id of the ingest feed.
+Stability: Long-term
 """
 	id: String!
 """
 Name of the ingest feed.
+Stability: Long-term
 """
 	name: String!
 """
 Description of the ingest feed.
+Stability: Long-term
 """
 	description: String
 """
 Parser used to parse the ingest feed.
+Stability: Long-term
 """
 	parser: Parser
 """
 Is ingest from the ingest feed enabled?
+Stability: Long-term
 """
 	enabled: Boolean!
 """
 The source which this ingest feed will ingest from
+Stability: Long-term
 """
 	source: IngestFeedSource!
 """
 Unix timestamp for when this feed was created
+Stability: Long-term
 """
 	createdAt: Long!
 """
 Details about how the ingest feed is running
+Stability: Long-term
 """
 	executionInfo: IngestFeedExecutionInfo
 }
@@ -12697,10 +15726,12 @@ IAM role authentication
 type IngestFeedAwsAuthenticationIamRole {
 """
 Arn of the role to be assumed
+Stability: Long-term
 """
 	roleArn: String!
 """
 External Id to the role to be assumed
+Stability: Long-term
 """
 	externalId: String!
 }
@@ -12718,6 +15749,9 @@ enum IngestFeedCompression {
 Represents the configuration status of the ingest feed feature on the cluster
 """
 type IngestFeedConfigurationStatus {
+"""
+Stability: Long-term
+"""
 	isConfigured: Boolean!
 }
 
@@ -12727,10 +15761,12 @@ Details about how the ingest feed is running
 type IngestFeedExecutionInfo {
 """
 Unix timestamp of the latest activity for the feed
+Stability: Long-term
 """
 	latestActivity: Long
 """
 Details about the status of the ingest feed
+Stability: Long-term
 """
 	statusMessage: IngestFeedStatus
 }
@@ -12760,6 +15796,7 @@ Interpret the input as AWS JSON record format and emit each record as an event
 type IngestFeedPreprocessingSplitAwsRecords {
 """
 The kind of preprocessing to do.
+Stability: Long-term
 """
 	kind: IngestFeedPreprocessingKind!
 }
@@ -12770,6 +15807,7 @@ Interpret the input as newline-delimited and emit each line as an event
 type IngestFeedPreprocessingSplitNewline {
 """
 The kind of preprocessing to do.
+Stability: Long-term
 """
 	kind: IngestFeedPreprocessingKind!
 }
@@ -12780,10 +15818,12 @@ The ingest feed query result set
 type IngestFeedQueryResultSet {
 """
 The total number of matching results
+Stability: Long-term
 """
 	totalResults: Int!
 """
 The paginated result set
+Stability: Long-term
 """
 	results: [IngestFeed!]!
 }
@@ -12794,22 +15834,27 @@ An ingest feed that polls data from S3 and is notified via SQS
 type IngestFeedS3SqsSource {
 """
 AWS SQS queue url.
+Stability: Long-term
 """
 	sqsUrl: String!
 """
 The preprocessing to apply to an ingest feed before parsing.
+Stability: Long-term
 """
 	preprocessing: IngestFeedPreprocessing!
 """
 How to authenticate to AWS.
+Stability: Long-term
 """
 	awsAuthentication: IngestFeedAwsAuthentication!
 """
 Compression scheme of the file.
+Stability: Long-term
 """
 	compression: IngestFeedCompression!
 """
 The AWS region to connect to.
+Stability: Long-term
 """
 	region: String!
 }
@@ -12825,18 +15870,22 @@ Details about the status of the ingest feed
 type IngestFeedStatus {
 """
 Description of the problem with the ingest feed
+Stability: Long-term
 """
 	problem: String!
 """
 Terse description of the problem with the ingest feed
+Stability: Long-term
 """
 	terseProblem: String
 """
 Timestamp, in milliseconds, of when the status message was set
+Stability: Long-term
 """
 	statusTimestamp: Long!
 """
 Cause of the problem with the ingest feed
+Stability: Long-term
 """
 	cause: IngestFeedStatusCause
 }
@@ -12847,10 +15896,12 @@ Details about the cause of the problem
 type IngestFeedStatusCause {
 """
 Description of the cause of the problem
+Stability: Long-term
 """
 	cause: String!
 """
 Terse description of the cause of the problem
+Stability: Long-term
 """
 	terseCause: String
 }
@@ -12868,31 +15919,46 @@ enum IngestFeeds__Type {
 Ingest Listeners listen on a port for UDP or TCP traffic, used with SysLog.
 """
 type IngestListener {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	repository: Repository!
 """
 The TCP/UDP port to listen to.
+Stability: Long-term
 """
 	port: Int!
 """
 The network protocol data is sent through.
+Stability: Long-term
 """
 	protocol: IngestListenerProtocol!
 """
 The charset used to decode the event stream. Available charsets depend on the JVM running the LogScale instance. Names and aliases can be found at http://www.iana.org/assignments/character-sets/character-sets.xhtml
+Stability: Long-term
 """
 	charset: String!
 """
 Specify which host should open the socket. By default this field is empty and all hosts will open a socket. This field can be used to select only one host to open the socket.
+Stability: Long-term
 """
 	vHost: Int
+"""
+Stability: Long-term
+"""
 	name: String!
 """
 The ip address this listener will bind to. By default (leaving this field empty) it will bind to 0.0.0.0 - all interfaces. Using this field it is also possible to specify the address to bind to. In a cluster setup it is also possible to specify if only one machine should open a socket - The vhost field is used for that.
+Stability: Long-term
 """
 	bindInterface: String!
 """
 The parser configured to parse data for the listener. This returns null if the parser has been removed since the listener was created.
+Stability: Long-term
 """
 	parser: Parser
 }
@@ -12927,9 +15993,13 @@ Netflow over UDP
 A cluster ingest partition. It assigns cluster nodes with the responsibility of ingesting data.
 """
 type IngestPartition {
+"""
+Stability: Long-term
+"""
 	id: Int!
 """
 The ids of the node responsible executing real-time queries for the partition and writing events to time series. The list is ordered so that the first node is the primary node and the rest are followers ready to take over if the primary fails.
+Stability: Long-term
 """
 	nodeIds: [Int!]!
 }
@@ -12938,8 +16008,17 @@ The ids of the node responsible executing real-time queries for the partition an
 An API ingest token used for sending data to LogScale.
 """
 type IngestToken {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	token: String!
+"""
+Stability: Long-term
+"""
 	parser: Parser
 }
 
@@ -12949,15 +16028,21 @@ The status of an IOC database table
 type IocTableInfo {
 """
 The name of the indicator type in this table
+Stability: Long-term
 """
 	name: String!
+"""
+Stability: Long-term
+"""
 	status: IocTableStatus!
 """
 The number of milliseconds since epoch that the IOC database was last updated
+Stability: Long-term
 """
 	lastUpdated: Long
 """
 The number of indicators in the database
+Stability: Long-term
 """
 	count: Int!
 }
@@ -12974,14 +16059,17 @@ Represents information about the IP database used by LogScale
 type IpDatabaseInfo {
 """
 The absolute file path of the file containing the database
+Stability: Long-term
 """
 	dbFilePath: String!
 """
 The update strategy used for the IP Database
+Stability: Long-term
 """
 	updateStrategy: String!
 """
 Metadata about the IP Database used by LogScale
+Stability: Long-term
 """
 	metadata: IpDatabaseMetadata
 }
@@ -12992,18 +16080,22 @@ Represents metadata about the IP database used by LogScale
 type IpDatabaseMetadata {
 """
 The type of database
+Stability: Long-term
 """
 	type: String!
 """
 The date on which the database was build
+Stability: Long-term
 """
 	buildDate: DateTime!
 """
 The description of the database
+Stability: Long-term
 """
 	description: String!
 """
 The md5 hash of the file containing the database
+Stability: Long-term
 """
 	dbFileMd5: String!
 }
@@ -13011,61 +16103,160 @@ The md5 hash of the file containing the database
 scalar JSON
 
 type KafkaClusterDescription {
+"""
+Stability: Short-term
+"""
 	clusterID: String!
+"""
+Stability: Short-term
+"""
 	nodes: [KafkaNode!]!
+"""
+Stability: Short-term
+"""
 	controller: KafkaNode!
+"""
+Stability: Short-term
+"""
 	logDirDescriptions: [KafkaLogDir!]!
+"""
+Stability: Short-term
+"""
 	globalEventsTopic: KafkaTopicDescription!
+"""
+Stability: Short-term
+"""
 	ingestTopic: KafkaTopicDescription!
+"""
+Stability: Short-term
+"""
 	chatterTopic: KafkaTopicDescription!
 }
 
 type KafkaLogDir {
+"""
+Stability: Short-term
+"""
 	nodeID: Int!
+"""
+Stability: Short-term
+"""
 	path: String!
+"""
+Stability: Short-term
+"""
 	error: String
+"""
+Stability: Short-term
+"""
 	topicPartitions: [KafkaNodeTopicPartitionLogDescription!]!
 }
 
 type KafkaNode {
+"""
+Stability: Short-term
+"""
 	id: Int!
+"""
+Stability: Short-term
+"""
 	host: String
+"""
+Stability: Short-term
+"""
 	port: Int!
+"""
+Stability: Short-term
+"""
 	rack: String
 }
 
 type KafkaNodeTopicPartitionLogDescription {
+"""
+Stability: Short-term
+"""
 	topicPartition: KafkaTopicPartition!
+"""
+Stability: Short-term
+"""
 	offset: Long!
+"""
+Stability: Short-term
+"""
 	size: Long!
+"""
+Stability: Short-term
+"""
 	isFuture: Boolean!
 }
 
 type KafkaTopicConfig {
+"""
+Stability: Short-term
+"""
 	key: String!
+"""
+Stability: Short-term
+"""
 	value: String!
 }
 
 type KafkaTopicConfigs {
+"""
+Stability: Short-term
+"""
 	configs: [KafkaTopicConfig!]!
+"""
+Stability: Short-term
+"""
 	defaultConfigs: [KafkaTopicConfig!]!
 }
 
 type KafkaTopicDescription {
+"""
+Stability: Short-term
+"""
 	name: String!
+"""
+Stability: Short-term
+"""
 	config: KafkaTopicConfigs!
+"""
+Stability: Short-term
+"""
 	partitions: [KafkaTopicPartitionDescription!]!
 }
 
+"""
+Kafka Topic Partition
+"""
 type KafkaTopicPartition {
+"""
+Stability: Short-term
+"""
 	topic: String!
+"""
+Stability: Short-term
+"""
 	partition: Int!
 }
 
 type KafkaTopicPartitionDescription {
+"""
+Stability: Short-term
+"""
 	partition: Int!
+"""
+Stability: Short-term
+"""
 	leader: Int!
+"""
+Stability: Short-term
+"""
 	replicas: [Int!]!
+"""
+Stability: Short-term
+"""
 	inSyncReplicas: [Int!]!
 }
 
@@ -13084,14 +16275,17 @@ Defines how the external function is executed.
 type KindOutput {
 """
 The name of the kind of external function.
+Stability: Preview
 """
 	name: KindEnum!
 """
 The parameters that specify the key fields. Use for the 'Enrichment' functions.
+Stability: Preview
 """
 	parametersDefiningKeyFields: [String!]
 """
 The names of the keys when they're returned from the external function. Use for the 'Enrichment' functions.
+Stability: Preview
 """
 	fixedKeyFields: [String!]
 }
@@ -13099,20 +16293,24 @@ The names of the keys when they're returned from the external function. Use for 
 type LanguageVersion {
 """
 If non-null, this is a version known by the current version of LogScale.
+Stability: Long-term
 """
 	name: LanguageVersionEnum
 """
 If non-null, this is a version stored by a future LogScale version.
+Stability: Long-term
 """
 	futureName: String
 """
 The language version.
+Stability: Long-term
 """
 	version: LanguageVersionOutputType!
 """
 If false, this version isn't recognized by the current version of LogScale.
 It must have been stored by a future LogScale version.
 This can happen if LogScale was upgraded, and subsequently downgraded (rolled back).
+Stability: Long-term
 """
 	isKnown: Boolean!
 }
@@ -13144,6 +16342,7 @@ A specific language version.
 type LanguageVersionOutputType {
 """
 The name of the language version. The name is case insensitive.
+Stability: Long-term
 """
 	name: String!
 }
@@ -13168,26 +16367,32 @@ A Limit added to the organization.
 type Limit {
 """
 The limit name
+Stability: Long-term
 """
 	limitName: String!
 """
 If the limit allows logging in
+Stability: Long-term
 """
 	allowLogin: Boolean!
 """
 The daily ingest allowed for the limit
+Stability: Long-term
 """
 	dailyIngest: Long!
 """
 The retention in days allowed for the limit
+Stability: Long-term
 """
 	retention: Int!
 """
 If the limit allows self service
+Stability: Long-term
 """
 	allowSelfService: Boolean!
 """
 The deleted date for the limit
+Stability: Long-term
 """
 	deletedDate: Long
 }
@@ -13198,78 +16403,97 @@ A Limit added to the organization.
 type LimitV2 {
 """
 The id
+Stability: Long-term
 """
 	id: String!
 """
 The limit name
+Stability: Long-term
 """
 	limitName: String!
 """
 The display name of the limit
+Stability: Long-term
 """
 	displayName: String!
 """
 If the limit allows logging in
+Stability: Long-term
 """
 	allowLogin: Boolean!
 """
 The daily ingest allowed for the limit
+Stability: Long-term
 """
 	dailyIngest: contractual!
 """
 The amount of storage allowed for the limit
+Stability: Long-term
 """
 	storageLimit: contractual!
 """
 The data scanned measurement allowed for the limit
+Stability: Long-term
 """
 	dataScannedLimit: contractual!
 """
 The usage measurement type used for the limit
+Stability: Long-term
 """
 	measurementPoint: Organizations__MeasurementType!
 """
 The user seats allowed for the limit
+Stability: Long-term
 """
 	userLimit: contractual!
 """
 The number of repositories allowed for the limit
+Stability: Long-term
 """
 	repoLimit: Int
 """
 The retention in days for the limit, that's the contracted value
+Stability: Long-term
 """
 	retention: Int!
 """
 The max retention in days allowed for the limit, this can be greater than or equal to retention
+Stability: Long-term
 """
 	maxRetention: Int!
 """
 If the limit allows self service
+Stability: Long-term
 """
 	allowSelfService: Boolean!
 """
 The deleted date for the limit
+Stability: Long-term
 """
 	deletedDate: Long
 """
 The expiration date for the limit
+Stability: Long-term
 """
 	expirationDate: Long
 """
 If the limit is a trial
+Stability: Long-term
 """
 	trial: Boolean!
 """
 If the customer is allowed flight control
+Stability: Long-term
 """
 	allowFlightControl: Boolean!
 """
 Data type for the limit, all repositories linked to the limit will get this datatype logged in usage
+Stability: Long-term
 """
 	dataType: String!
 """
 Repositories attached to the limit
+Stability: Long-term
 """
 	repositories: [Repository!]!
 }
@@ -13280,52 +16504,74 @@ All data related to a scheduled report accessible with a readonly scheduled repo
 type LimitedScheduledReport {
 """
 Id of the scheduled report.
+Stability: Long-term
 """
 	id: String!
 """
 Name of the scheduled report.
+Stability: Long-term
 """
 	name: String!
 """
 Description of the scheduled report.
+Stability: Long-term
 """
 	description: String!
 """
 Name of the dashboard referenced by the report.
+Stability: Long-term
 """
 	dashboardName: String!
 """
 Display name of the dashboard referenced by the report.
+Stability: Long-term
 """
 	dashboardDisplayName: String!
 """
 Shared time interval of the dashboard referenced by the report.
+Stability: Long-term
 """
 	dashboardSharedTimeInterval: SharedDashboardTimeInterval
 """
 Widgets of the dashboard referenced by the report.
+Stability: Long-term
 """
 	dashboardWidgets: [Widget!]!
 """
 Sections of the dashboard referenced by the report.
+Stability: Long-term
 """
 	dashboardSections: [Section!]!
 """
+Series configurations of the dashboard referenced by the report.
+Stability: Long-term
+"""
+	dashboardSeries: [SeriesConfig!]!
+"""
 The name of the repository or view queries are executed against.
+Stability: Long-term
 """
 	repoOrViewName: RepoOrViewName!
 """
 Layout of the scheduled report.
+Stability: Long-term
 """
 	layout: ScheduledReportLayout!
 """
 Timezone of the schedule. Examples include UTC, Europe/Copenhagen.
+Stability: Long-term
 """
 	timeZone: String!
 """
 List of parameter value configurations.
+Stability: Long-term
 """
 	parameters: [ParameterValue!]!
+"""
+The resource identifier for this scheduled report.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 """
@@ -13334,18 +16580,22 @@ The status of a local cluster connection.
 type LocalClusterConnectionStatus implements ClusterConnectionStatus{
 """
 Name of the local view
+Stability: Short-term
 """
 	viewName: String
 """
 Id of the connection
+Stability: Short-term
 """
 	id: String
 """
 Whether the connection is valid
+Stability: Short-term
 """
 	isValid: Boolean!
 """
 Errors if the connection is invalid
+Stability: Short-term
 """
 	errorMessages: [ConnectionAspectErrorType!]!
 }
@@ -13356,66 +16606,137 @@ A fleet search result entry
 type LogCollector {
 """
 If the collector is enrolled this is its id
+Stability: Short-term
 """
 	id: String
 """
 The hostname
+Stability: Short-term
 """
 	hostname: String!
 """
 The host system
+Stability: Short-term
 """
 	system: String!
 """
 Version
+Stability: Short-term
 """
 	version: String!
 """
 Last activity recorded
+Stability: Short-term
 """
 	lastActivity: String!
 """
 Ingest last 24h.
+Stability: Short-term
 """
 	ingestLast24H: Long!
 """
 Ip address
+Stability: Short-term
 """
 	ipAddress: String
+"""
+
+Stability: Short-term
+"""
 	logSources: [LogCollectorLogSource!]!
 """
 Log collector machineId
+Stability: Short-term
 """
 	machineId: String!
 """
 contains the name of any manually assigned config
+Stability: Short-term
 """
 	configName: String
 """
 contains the id of any manually assigned config
+Stability: Short-term
 """
 	configId: String
+"""
+Stability: Short-term
+"""
 	configurations: [LogCollectorConfigInfo!]!
+"""
+Stability: Short-term
+"""
 	errors: [String!]!
+"""
+Stability: Short-term
+"""
 	cfgTestId: String
+"""
+Stability: Short-term
+"""
 	cpuAverage5Min: Float
+"""
+Stability: Short-term
+"""
 	memoryMax5Min: Long
+"""
+Stability: Short-term
+"""
 	diskMax5Min: Float
+"""
+Stability: Short-term
+"""
 	change: Changes
+"""
+Stability: Short-term
+"""
 	groups: [LogCollectorGroup!]!
+"""
+Stability: Short-term
+"""
 	wantedVersion: String
+"""
+Stability: Short-term
+"""
 	debugLogging: LogCollectorDebugLogging
+"""
+Stability: Short-term
+"""
 	timeOfUpdate: DateTime
+"""
+Stability: Short-term
+"""
 	usesRemoteUpdate: Boolean!
+"""
+Stability: Short-term
+"""
 	ephemeralTimeout: Int
+"""
+Stability: Short-term
+"""
 	status: LogCollectorStatusType
+"""
+Stability: Short-term
+"""
 	labels: [LogCollectorLabel!]!
 }
 
 type LogCollectorConfigInfo {
+"""
+Stability: Short-term
+"""
 	id: String!
+"""
+Stability: Short-term
+"""
 	name: String!
+"""
+Stability: Short-term
+"""
 	group: LogCollectorGroup
+"""
+Stability: Short-term
+"""
 	assignment: LogCollectorConfigurationAssignmentType!
 }
 
@@ -13423,17 +16744,59 @@ type LogCollectorConfigInfo {
 A configuration file for a log collector
 """
 type LogCollectorConfiguration {
+"""
+
+Stability: Short-term
+"""
 	id: String!
+"""
+
+Stability: Short-term
+"""
 	name: String!
+"""
+
+Stability: Short-term
+"""
 	yaml: String
+"""
+
+Stability: Short-term
+"""
 	draft: String
+"""
+
+Stability: Short-term
+"""
 	version: Int!
+"""
+
+Stability: Short-term
+"""
 	yamlCharactersCount: Int!
+"""
+Stability: Short-term
+"""
 	modifiedAt: DateTime!
+"""
+Stability: Short-term
+"""
 	draftModifiedAt: DateTime
+"""
+Stability: Short-term
+"""
 	modifiedBy: String!
+"""
+Stability: Short-term
+"""
 	instances: Int!
+"""
+Stability: Short-term
+"""
 	description: String
+"""
+Stability: Short-term
+"""
 	isTestRunning: Boolean!
 }
 
@@ -13444,18 +16807,42 @@ enum LogCollectorConfigurationAssignmentType {
 }
 
 type LogCollectorConfigurationProblemAtPath {
+"""
+Stability: Short-term
+"""
 	summary: String!
+"""
+Stability: Short-term
+"""
 	details: String
+"""
+Stability: Short-term
+"""
 	path: String!
+"""
+Stability: Short-term
+"""
 	number: Int!
 }
 
 union LogCollectorDebugLogging =LogCollectorDebugLoggingStatic
 
 type LogCollectorDebugLoggingStatic {
+"""
+Stability: Short-term
+"""
 	url: String
+"""
+Stability: Short-term
+"""
 	token: String!
+"""
+Stability: Short-term
+"""
 	level: String!
+"""
+Stability: Short-term
+"""
 	repository: String
 }
 
@@ -13465,55 +16852,117 @@ Details about a Log Collector
 type LogCollectorDetails {
 """
 If the collector is enrolled this is its id
+Stability: Short-term
 """
 	id: String
 """
 The hostname
+Stability: Short-term
 """
 	hostname: String!
 """
 The host system
+Stability: Short-term
 """
 	system: String!
 """
 Version
+Stability: Short-term
 """
 	version: String!
 """
 Last activity recorded
+Stability: Short-term
 """
 	lastActivity: String!
 """
 Ip address
+Stability: Short-term
 """
 	ipAddress: String
+"""
+
+Stability: Short-term
+"""
 	logSources: [LogCollectorLogSource!]!
 """
 Log collector machineId
+Stability: Short-term
 """
 	machineId: String!
+"""
+Stability: Short-term
+"""
 	configurations: [LogCollectorConfigInfo!]!
+"""
+Stability: Short-term
+"""
 	errors: [String!]!
+"""
+Stability: Short-term
+"""
 	cpuAverage5Min: Float
+"""
+Stability: Short-term
+"""
 	memoryMax5Min: Long
+"""
+Stability: Short-term
+"""
 	diskMax5Min: Float
+"""
+Stability: Short-term
+"""
 	ephemeralTimeout: Int
+"""
+Stability: Short-term
+"""
 	status: LogCollectorStatusType
 }
 
 type LogCollectorGroup {
+"""
+Stability: Short-term
+"""
 	id: String!
+"""
+Stability: Short-term
+"""
 	name: String!
+"""
+Stability: Short-term
+"""
 	filter: String
+"""
+Stability: Short-term
+"""
 	configurations: [LogCollectorConfiguration!]!
+"""
+Stability: Short-term
+"""
 	collectorCount: Int
+"""
+Stability: Short-term
+"""
 	wantedVersion: String
+"""
+Stability: Short-term
+"""
 	onlyUsesRemoteUpdates: Boolean!
 }
 
 type LogCollectorInstallCommand {
+"""
+Stability: Short-term
+"""
 	windowsCommand: String!
+"""
+Stability: Short-term
+"""
 	linuxCommand: String!
+"""
+Stability: Short-term
+"""
 	macosCommand: String!
 }
 
@@ -13523,53 +16972,93 @@ Provides information about an installer of the LogScale Collector.
 type LogCollectorInstaller {
 """
 Installer file name
+Stability: Short-term
 """
 	name: String!
 """
 URL to fetch installer from
+Stability: Short-term
 """
 	url: String!
 """
 LogScale Collector version
+Stability: Short-term
 """
 	version: String!
 """
 Installer CPU architecture
+Stability: Short-term
 """
 	architecture: String!
 """
 Installer type (deb, rpm or msi)
+Stability: Short-term
 """
 	type: String!
 """
 Installer file size
+Stability: Short-term
 """
 	size: Int!
 """
 Config file example
+Stability: Short-term
 """
 	configExample: String
 """
 Icon file name
+Stability: Short-term
 """
 	icon: String
 }
 
 type LogCollectorLabel {
+"""
+Stability: Short-term
+"""
 	name: String!
+"""
+Stability: Short-term
+"""
 	value: String!
 }
 
 type LogCollectorLogSource {
+"""
+
+Stability: Short-term
+"""
 	sourceName: String!
+"""
+
+Stability: Short-term
+"""
 	sourceType: String!
+"""
+
+Stability: Short-term
+"""
 	sinkType: String!
+"""
+
+Stability: Short-term
+"""
 	parser: String
+"""
+
+Stability: Short-term
+"""
 	repository: String
 }
 
 type LogCollectorMergedConfiguration {
+"""
+Stability: Short-term
+"""
 	problems: [LogCollectorConfigurationProblemAtPath!]!
+"""
+Stability: Short-term
+"""
 	content: String!
 }
 
@@ -13579,39 +17068,112 @@ enum LogCollectorStatusType {
 }
 
 type LoginBridge {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	issuer: String!
+"""
+Stability: Long-term
+"""
 	description: String!
+"""
+Stability: Long-term
+"""
 	remoteId: String!
+"""
+Stability: Long-term
+"""
 	loginUrl: String!
+"""
+Stability: Long-term
+"""
 	relayStateUUrl: String!
+"""
+Stability: Long-term
+"""
 	samlEntityId: String!
+"""
+Stability: Long-term
+"""
 	publicSamlCertificate: String!
+"""
+Stability: Long-term
+"""
 	groupAttribute: String!
+"""
+Stability: Long-term
+"""
 	organizationIdAttributeName: String!
+"""
+Stability: Long-term
+"""
 	organizationNameAttributeName: String
+"""
+Stability: Long-term
+"""
 	additionalAttributes: String
+"""
+Stability: Long-term
+"""
 	groups: [String!]!
+"""
+Stability: Long-term
+"""
 	allowedUsers: [User!]!
+"""
+Stability: Long-term
+"""
 	generateUserName: Boolean!
+"""
+Stability: Long-term
+"""
 	termsDescription: String!
+"""
+Stability: Long-term
+"""
 	termsLink: String!
+"""
+Stability: Long-term
+"""
 	showTermsAndConditions: Boolean!
 """
 True if any user in this organization has logged in to CrowdStream via LogScale. Requires manage organizations permissions
+Stability: Long-term
 """
 	anyUserAlreadyLoggedInViaLoginBridge: Boolean!
 }
 
 type LoginBridgeRequest {
+"""
+Stability: Long-term
+"""
 	samlResponse: String!
+"""
+Stability: Long-term
+"""
 	loginUrl: String!
+"""
+Stability: Long-term
+"""
 	relayState: String!
 }
 
 type LookupFileTemplate {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	displayName: String!
+"""
+Stability: Long-term
+"""
 	content: String!
 }
 
@@ -13623,6 +17185,7 @@ A place for LogScale to find packages.
 type Marketplace {
 """
 Gets all categories in the marketplace.
+Stability: Long-term
 """
 	categoryGroups: [MarketplaceCategoryGroup!]!
 }
@@ -13633,10 +17196,12 @@ A category that can be used to filter search results in the marketplace.
 type MarketplaceCategory {
 """
 A display string for the category.
+Stability: Long-term
 """
 	title: String!
 """
 The id is used to filter the searches.
+Stability: Long-term
 """
 	id: String!
 }
@@ -13647,15 +17212,30 @@ A grouping of categories that can be used to filter search results in the market
 type MarketplaceCategoryGroup {
 """
 A display string for the category group.
+Stability: Long-term
 """
 	title: String!
 """
 The categories that are members of the group.
+Stability: Long-term
 """
 	categories: [MarketplaceCategory!]!
 }
 
+"""
+User or token used to modify the asset.
+"""
+interface ModifiedInfo {
+"""
+User or token used to modify the asset.
+"""
+	modifiedAt: Long!
+}
+
 type MonthlyIngest {
+"""
+Stability: Long-term
+"""
 	monthly: [UsageOnDay!]!
 }
 
@@ -13665,6 +17245,9 @@ Query result for monthly ingest
 union MonthlyIngestQueryResult =QueryInProgress | MonthlyIngest
 
 type MonthlyStorage {
+"""
+Stability: Long-term
+"""
 	monthly: [StorageOnDay!]!
 }
 
@@ -13674,6 +17257,9 @@ Query result for monthly storage
 union MonthlyStorageQueryResult =QueryInProgress | MonthlyStorage
 
 type NeverDashboardUpdateFrequency {
+"""
+Stability: Long-term
+"""
 	name: String!
 }
 
@@ -13692,34 +17278,42 @@ A notification
 type Notification {
 """
 The unique id for the notification
+Stability: Long-term
 """
 	id: String!
 """
 The title of the notification
+Stability: Long-term
 """
 	title: String!
 """
 The message for the notification
+Stability: Long-term
 """
 	message: String!
 """
 Whether the notification is dismissable
+Stability: Long-term
 """
 	dismissable: Boolean!
 """
 The severity of the notification
+Stability: Long-term
 """
 	severity: NotificationSeverity!
 """
 The type of the notification
+Stability: Long-term
 """
 	type: NotificationTypes!
 """
 Link accompanying the notification
+Stability: Long-term
 """
 	link: String
 """
 Description for the link
+Stability: Long-term
 """
 	linkDescription: String
 }
@@ -13743,40 +17337,111 @@ Paginated response for notifications.
 type NotificationsResultSet {
 """
 The total number of matching results
+Stability: Long-term
 """
 	totalResults: Int!
 """
 The paginated result set
+Stability: Long-term
 """
 	results: [Notification!]!
 }
 
 type OidcIdentityProvider implements IdentityProviderAuthentication{
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	clientId: String!
+"""
+Stability: Long-term
+"""
 	clientSecret: String!
+"""
+Stability: Long-term
+"""
 	domains: [String!]!
+"""
+Stability: Long-term
+"""
 	issuer: String!
+"""
+Stability: Long-term
+"""
 	tokenEndpointAuthMethod: String!
+"""
+Stability: Long-term
+"""
 	userClaim: String!
+"""
+Stability: Long-term
+"""
 	scopes: [String!]!
+"""
+Stability: Long-term
+"""
 	userInfoEndpoint: String
+"""
+Stability: Long-term
+"""
 	registrationEndpoint: String
+"""
+Stability: Long-term
+"""
 	tokenEndpoint: String
+"""
+Stability: Long-term
+"""
 	groupsClaim: String
+"""
+Stability: Long-term
+"""
 	jwksEndpoint: String
+"""
+Stability: Long-term
+"""
 	authenticationMethod: AuthenticationMethodAuth!
+"""
+Stability: Long-term
+"""
 	authorizationEndpoint: String
+"""
+Stability: Long-term
+"""
 	debug: Boolean!
+"""
+Stability: Long-term
+"""
 	federatedIdp: String
+"""
+Stability: Long-term
+"""
 	scopeClaim: String
+"""
+Stability: Long-term
+"""
 	defaultIdp: Boolean!
+"""
+Stability: Long-term
+"""
 	humioManaged: Boolean!
+"""
+Stability: Long-term
+"""
 	lazyCreateUsers: Boolean!
 }
 
 type OnlyTotal {
+"""
+Stability: Short-term
+"""
 	total: Int!
 }
 
@@ -13807,68 +17472,111 @@ input OrderByUserFieldInput {
 	order: OrderByDirection!
 }
 
+type OrgConfig {
+"""
+Organization ID
+Stability: Short-term
+"""
+	id: String!
+"""
+Organization name
+Stability: Short-term
+"""
+	name: String!
+"""
+bucket region
+Stability: Short-term
+"""
+	region: String!
+"""
+
+Stability: Short-term
+"""
+	bucket: String!
+"""
+bucket prefix
+Stability: Short-term
+"""
+	prefix: String!
+}
+
 """
 An Organization
 """
 type Organization {
 """
 The unique id for the Organization
+Stability: Short-term
 """
 	id: String!
 """
 The CID corresponding to the organization
+Stability: Short-term
 """
 	cid: String
 """
 The name for the Organization
+Stability: Short-term
 """
 	name: String!
 """
 The description for the Organization, can be null
+Stability: Short-term
 """
 	description: String
 """
 Details about the organization
+Stability: Short-term
 """
 	details: OrganizationDetails!
 """
 Stats of the organization
+Stability: Short-term
 """
 	stats: OrganizationStats!
 """
 Organization configurations and settings
+Stability: Short-term
 """
 	configs: OrganizationConfigs!
 """
 Search domains in the organization
+Stability: Short-term
 """
 	searchDomains: [SearchDomain!]!
 """
 IP filter for readonly dashboard links
+Stability: Short-term
 """
 	readonlyDashboardIPFilter: String
 """
 Created date
+Stability: Short-term
 """
 	createdAt: Long
 """
 If the organization has been marked for deletion, this indicates the day it was deleted.
+Stability: Short-term
 """
 	deletedAt: Long
 """
 Trial started at
+Stability: Short-term
 """
 	trialStartedAt: Long
 """
 Public url for the Organization
+Stability: Short-term
 """
 	publicUrl: String
 """
 Ingest url for the Organization
+Stability: Short-term
 """
 	ingestUrl: String
 """
 Check if the current user has a given permission in the organization.
+Stability: Short-term
 """
 	isActionAllowed(
 """
@@ -13878,16 +17586,25 @@ The action to check if a user is allowed to perform on an organization.
 	): Boolean!
 """
 Limits assigned to the organization
+Stability: Short-term
 """
 	limits: [Limit!]!
 """
 Limits assigned to the organizations
+Stability: Short-term
 """
 	limitsV2: [LimitV2!]!
+"""
+Stability: Short-term
+"""
 	externalPermissions: Boolean!
+"""
+Stability: Short-term
+"""
 	externalGroupSynchronization: Boolean!
 """
-[PREVIEW: Cache policies are a limited feature and is subject to change] The default cache policy of this organization.
+The default cache policy of this organization.
+Stability: Preview
 """
 	defaultCachePolicy: CachePolicy
 }
@@ -13915,7 +17632,6 @@ enum OrganizationAction {
 	UseRemoteUpdates
 	UseFleetRemoteDebug
 	UseFleetEphemeralHosts
-	UseFleetStaticQueries
 	UseFleetLabels
 	ChangeTriggersToRunAsOtherUsers
 	ChangeEventForwarders
@@ -13925,7 +17641,6 @@ enum OrganizationAction {
 	ManageUsers
 	ViewIpFilters
 	DownloadMacOsInstaller
-	SecurityPoliciesEnabled
 	ChangeSecurityPolicies
 	QueryAssistant
 	OrganizationQueryOwnershipEnabled
@@ -13935,7 +17650,7 @@ enum OrganizationAction {
 	ViewFalconDataConnectorUrl
 	ManageSchemas
 """
-[PREVIEW: This is a temporary value that will be removed again] 
+Stability: Preview
 """
 	ExternalFunctionsEnabled
 	ViewOrganizationSettings
@@ -13948,6 +17663,12 @@ enum OrganizationAction {
 	ViewDeletedRepositoriesOrViews
 	ViewEventForwarders
 	ViewSchemas
+	UseFleetOverviewDashboards
+	UseFleetTablePageUI
+"""
+Stability: Preview
+"""
+	GranularPermissionsUI
 }
 
 """
@@ -13956,42 +17677,52 @@ Configurations for the organization
 type OrganizationConfigs {
 """
 Session settings
+Stability: Short-term
 """
 	session: OrganizationSession!
 """
 Social login settings
+Stability: Short-term
 """
 	socialLogin: [SocialLoginSettings!]!
 """
 Subdomain configuration for the organization
+Stability: Short-term
 """
 	subdomains: SubdomainConfig
 """
 Bucket storage configuration for the organization
+Stability: Short-term
 """
 	bucketStorage: BucketStorageConfig
 """
 Security policies for actions in the organization
+Stability: Short-term
 """
 	actions: ActionSecurityPolicies
 """
 Security policies for tokens in the organization
+Stability: Short-term
 """
 	tokens: TokenSecurityPolicies
 """
 Security policies for shared dashboard tokens in the organization
+Stability: Short-term
 """
 	sharedDashboards: SharedDashboardsSecurityPolicies
 """
 Login bridge
+Stability: Short-term
 """
 	loginBridge: LoginBridge
 """
 Whether the organization is currently blocking ingest
+Stability: Short-term
 """
 	blockingIngest: Boolean!
 """
 Default timezone to use for users without a default timezone set.
+Stability: Short-term
 """
 	defaultTimeZone: String
 }
@@ -14002,34 +17733,42 @@ Details about the organization
 type OrganizationDetails {
 """
 Notes of the organization (root only)
+Stability: Short-term
 """
 	notes: String!
 """
 Industry of the organization
+Stability: Short-term
 """
 	industry: String!
 """
 Industry of the organization
+Stability: Short-term
 """
 	useCases: [Organizations__UseCases!]!
 """
 Subscription of the organization
+Stability: Short-term
 """
 	subscription: Organizations__Subscription!
 """
 Trial end date of the organization if any
+Stability: Short-term
 """
 	trialEndDate: Long
 """
 Limits of the organization
+Stability: Short-term
 """
 	limits: OrganizationLimits!
 """
 The country of the organization
+Stability: Short-term
 """
 	country: String!
 """
 Determines whether an organization has access to IOCs (indicators of compromise)
+Stability: Short-term
 """
 	iocAccess: Boolean
 }
@@ -14040,34 +17779,42 @@ Limits of the organization
 type OrganizationLimits {
 """
 Daily ingest allowed
+Stability: Short-term
 """
 	dailyIngest: Long!
 """
 Days of retention allowed
+Stability: Short-term
 """
 	retention: Int!
 """
 Max amount of users allowed
+Stability: Short-term
 """
 	users: Int!
 """
 License expiration date
+Stability: Short-term
 """
 	licenseExpirationDate: Long
 """
 Whether self service is enabled for the Organization, allowing features like creating repositories and setting retention.
+Stability: Short-term
 """
 	allowSelfService: Boolean!
 """
 Last contract synchronization date
+Stability: Short-term
 """
 	lastSyncDate: Long
 """
 Whether the contract is missing for the organization. None for non accounts, true if account and has no contract and false if contract was found and used.
+Stability: Short-term
 """
 	missingContract: Boolean
 """
 Contract version
+Stability: Short-term
 """
 	contractVersion: Organizations__ContractVersion!
 }
@@ -14120,54 +17867,67 @@ An organization search result entry
 type OrganizationSearchResultEntry {
 """
 The unique id for the Organization
+Stability: Short-term
 """
 	organizationId: String!
 """
 The name of the Organization
+Stability: Short-term
 """
 	organizationName: String!
 """
 The string matching the search
+Stability: Short-term
 """
 	searchMatch: String!
 """
 The id of the entity matched
+Stability: Short-term
 """
 	entityId: String!
 """
 The subscription type of the organization
+Stability: Short-term
 """
 	subscription: Organizations__Subscription!
 """
 The type of the search result match
+Stability: Short-term
 """
 	type: Organizations__SearchEntryType!
 """
 The amount of users in the organization
+Stability: Short-term
 """
 	userCount: Int!
 """
 The amount of repositories and views in the organization
+Stability: Short-term
 """
 	viewCount: Int!
 """
 The total data volume in bytes that the organization is currently using
+Stability: Short-term
 """
 	byteVolume: Long!
 """
 The end date of the trial if applicable
+Stability: Short-term
 """
 	trialEndDate: Long
 """
 The time when the organization was created
+Stability: Short-term
 """
 	createdAt: Long!
 """
 If the organization has been marked for deletion, this indicates the time when the organization was marked.
+Stability: Short-term
 """
 	deletedAt: Long
 """
 The relevant organization for the result
+Stability: Short-term
 """
 	organization: Organization!
 }
@@ -14178,10 +17938,12 @@ An organization search result set
 type OrganizationSearchResultSet {
 """
 The total number of matching results
+Stability: Short-term
 """
 	totalResults: Int!
 """
 The paginated result set
+Stability: Short-term
 """
 	results: [OrganizationSearchResultEntry!]!
 }
@@ -14192,10 +17954,12 @@ Session configuration for the organization
 type OrganizationSession {
 """
 The maximum time in ms the user is allowed to be inactive
+Stability: Long-term
 """
 	maxInactivityPeriod: Long!
 """
 The time in ms after which the user is forced to reauthenticate
+Stability: Long-term
 """
 	forceReauthenticationAfter: Long!
 }
@@ -14206,18 +17970,22 @@ Stats of the organization
 type OrganizationStats {
 """
 Total compressed data volume used by the organization
+Stability: Short-term
 """
 	dataVolumeCompressed: Long!
 """
 Total data volume used by the organization
+Stability: Short-term
 """
 	dataVolume: Long!
 """
 The total daily ingest of the organization
+Stability: Short-term
 """
 	dailyIngest: Long!
 """
 The number of users in the organization
+Stability: Short-term
 """
 	userCount: Int!
 }
@@ -14285,30 +18053,97 @@ enum Organizations__UseCases {
 A Humio package
 """
 type Package2 {
+"""
+Stability: Long-term
+"""
 	id: VersionedPackageSpecifier!
+"""
+Stability: Long-term
+"""
 	scope: PackageScope!
+"""
+Stability: Long-term
+"""
 	name: PackageName!
+"""
+Stability: Long-term
+"""
 	version: PackageVersion!
+"""
+Stability: Long-term
+"""
 	description: String
+"""
+Stability: Long-term
+"""
 	iconUrl: UrlOrData
+"""
+Stability: Long-term
+"""
 	author: PackageAuthor!
+"""
+Stability: Long-term
+"""
 	contributors: [PackageAuthor!]!
+"""
+Stability: Long-term
+"""
 	licenseUrl: URL!
+"""
+Stability: Long-term
+"""
 	minHumioVersion: SemanticVersion!
+"""
+Stability: Long-term
+"""
 	readme: Markdown
+"""
+Stability: Long-term
+"""
 	dashboardTemplates: [DashboardTemplate!]!
+"""
+Stability: Long-term
+"""
 	savedQueryTemplates: [SavedQueryTemplate!]!
+"""
+Stability: Long-term
+"""
 	parserTemplates: [ParserTemplate!]!
+"""
+Stability: Long-term
+"""
 	alertTemplates: [AlertTemplate!]!
+"""
+Stability: Long-term
+"""
 	filterAlertTemplates: [FilterAlertTemplate!]!
+"""
+Stability: Long-term
+"""
 	aggregateAlertTemplates: [AggregateAlertTemplate!]!
+"""
+Stability: Long-term
+"""
 	lookupFileTemplates: [LookupFileTemplate!]!
+"""
+Stability: Long-term
+"""
 	actionTemplates: [ActionTemplate!]!
+"""
+Stability: Long-term
+"""
 	scheduledSearchTemplates: [ScheduledSearchTemplate!]!
+"""
+Stability: Long-term
+"""
 	viewInteractionTemplates: [ViewInteractionTemplate!]!
+"""
+Stability: Long-term
+"""
 	type: PackageType!
 """
 The available versions of the package on the marketplace.
+Stability: Long-term
 """
 	versionsOnMarketplace: [RegistryPackageVersionInfo!]!
 }
@@ -14317,7 +18152,13 @@ The available versions of the package on the marketplace.
 The author of a package.
 """
 type PackageAuthor {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	email: Email
 }
 
@@ -14325,19 +18166,41 @@ type PackageAuthor {
 A package installation.
 """
 type PackageInstallation {
+"""
+Stability: Long-term
+"""
 	id: VersionedPackageSpecifier!
+"""
+Stability: Long-term
+"""
 	installedBy: UserAndTimestamp!
+"""
+Stability: Long-term
+"""
 	updatedBy: UserAndTimestamp!
+"""
+Stability: Long-term
+"""
 	source: PackageInstallationSourceType!
 """
 Finds updates on a package. It also looks for updates on packages that were installed manually, in case e.g. test versions of a package have been distributed prior to the full release.
+Stability: Long-term
 """
 	availableUpdate: PackageVersion
+"""
+Stability: Long-term
+"""
 	package: Package2!
 }
 
 enum PackageInstallationSourceType {
+"""
+Stability: Long-term
+"""
 	HumioHub
+"""
+Stability: Long-term
+"""
 	ZipFile
 }
 
@@ -14347,17 +18210,34 @@ scalar PackageName
 Information about a package that matches a search in a package registry.
 """
 type PackageRegistrySearchResultItem {
+"""
+Stability: Long-term
+"""
 	id: VersionedPackageSpecifier!
+"""
+Stability: Long-term
+"""
 	description: String
+"""
+Stability: Long-term
+"""
 	iconUrl: UrlOrData
+"""
+Stability: Long-term
+"""
 	type: PackageType!
+"""
+Stability: Long-term
+"""
 	installedVersion: VersionedPackageSpecifier
 """
 True if the current version of LogScale supports the latest version of this package.
+Stability: Long-term
 """
 	isLatestVersionSupported: Boolean!
 """
 The version of LogScale required to run the latest version of this package.
+Stability: Long-term
 """
 	minHumioVersionOfLatest: SemanticVersion!
 }
@@ -14367,15 +18247,30 @@ scalar PackageScope
 scalar PackageTag
 
 enum PackageType {
+"""
+Stability: Long-term
+"""
 	application
+"""
+Stability: Long-term
+"""
 	library
 }
 
 scalar PackageVersion
 
 type PageType {
+"""
+Stability: Long-term
+"""
 	number: Int!
+"""
+Stability: Long-term
+"""
 	totalNumberOfRows: Int!
+"""
+Stability: Long-term
+"""
 	total: Int!
 }
 
@@ -14385,34 +18280,42 @@ The specification of a parameter
 type ParameterSpecificationOutput {
 """
 The name of the parameter
+Stability: Preview
 """
 	name: String!
 """
-The type of the parameter"
+The type of the parameter
+Stability: Preview
 """
 	parameterType: ParameterTypeEnum!
 """
 Restricts the smallest allowed value for parameters of type Long
+Stability: Preview
 """
 	minLong: Long
 """
 Restricts the largest allowed value for parameters of type Long
+Stability: Preview
 """
 	maxLong: Long
 """
  Restricts the smallest allowed value for parameters of type Double
+Stability: Preview
 """
 	minDouble: Float
 """
 Restricts the largest allowed value for parameters of type Double
+Stability: Preview
 """
 	maxDouble: Float
 """
 Restricts the minimum number of allowed elements for parameters of type Array
+Stability: Preview
 """
 	minLength: Int
 """
 Defines a default value of the parameter
+Stability: Preview
 """
 	defaultValue: [String!]
 }
@@ -14437,10 +18340,12 @@ Parameter value configuration.
 type ParameterValue {
 """
 Id of the parameter.
+Stability: Long-term
 """
 	id: String!
 """
 Value of the parameter.
+Stability: Long-term
 """
 	value: String!
 }
@@ -14451,36 +18356,46 @@ A configured parser for incoming data.
 type Parser {
 """
 The id of the parser.
+Stability: Long-term
 """
 	id: String!
 """
 Name of the parser.
+Stability: Long-term
 """
 	name: String!
 """
 The full name of the parser including package information if part of an application.
+Stability: Long-term
 """
 	displayName: String!
 """
 The description of the parser.
+Stability: Long-term
 """
 	description: String
 	assetType: AssetType!
 """
 True if the parser is one of LogScale's built-in parsers.
+Stability: Long-term
 """
 	isBuiltIn: Boolean!
 """
 The parser script that is executed for every incoming event.
+Stability: Long-term
 """
 	script: String!
 """
 The source code of the parser.
 """
 	sourceCode: String!
+"""
+Stability: Long-term
+"""
 	languageVersion: LanguageVersion!
 """
 Fields that are used as tags.
+Stability: Long-term
 """
 	fieldsToTag: [String!]!
 """
@@ -14489,10 +18404,12 @@ The fields to use as tags.
 	tagFields: [String!]!
 """
 A list of fields that will be removed from the event before it's parsed. These fields will not be included when calculating usage.
+Stability: Long-term
 """
 	fieldsToBeRemovedBeforeParsing: [String!]!
 """
 A template that can be used to recreate the parser.
+Stability: Long-term
 """
 	yamlTemplate: YAML!
 """
@@ -14501,15 +18418,31 @@ Saved test data (e.g. log lines) that you can use to test the parser.
 	testData: [String!]!
 """
 Test cases that can be used to help verify that the parser works as expected.
+Stability: Long-term
 """
 	testCases: [ParserTestCase!]!
+"""
+Stability: Long-term
+"""
 	packageId: VersionedPackageSpecifier
+"""
+Stability: Long-term
+"""
 	package: PackageInstallation
 }
 
 type ParserTemplate {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	displayName: String!
+"""
+Stability: Long-term
+"""
 	yamlTemplate: String!
 }
 
@@ -14519,10 +18452,12 @@ A test case for a parser.
 type ParserTestCase {
 """
 The event to parse and test on.
+Stability: Long-term
 """
 	event: ParserTestEvent!
 """
 Assertions on the shape of the test case output events. The list consists of key-value pairs to be treated as a map-construct, where the index of the output event is the key, and the assertions are the value.
+Stability: Long-term
 """
 	outputAssertions: [ParserTestCaseAssertionsForOutput!]!
 }
@@ -14533,10 +18468,12 @@ Assertions on the shape of the given output event. It is a key-value pair, where
 type ParserTestCaseAssertionsForOutput {
 """
 The index of the output event which the assertions should apply to.
+Stability: Long-term
 """
 	outputEventIndex: Int!
 """
 Assertions on the shape of a given test case output event.
+Stability: Long-term
 """
 	assertions: ParserTestCaseOutputAssertions!
 }
@@ -14547,10 +18484,12 @@ Assertions on the shape of a given test case output event.
 type ParserTestCaseOutputAssertions {
 """
 Names of fields which should not be present on the output event.
+Stability: Long-term
 """
 	fieldsNotPresent: [String!]!
 """
 Names of fields and their expected value on the output event. These are key-value pairs, and should be treated as a map-construct.
+Stability: Long-term
 """
 	fieldsHaveValues: [FieldHasValue!]!
 }
@@ -14561,25 +18500,9 @@ An event for a parser to parse during testing.
 type ParserTestEvent {
 """
 The contents of the `@rawstring` field when the event begins parsing.
+Stability: Long-term
 """
 	rawString: String!
-}
-
-"""
-A subset of a view
-"""
-type PartialSearchDomain {
-	id: String!
-	name: String!
-"""
-Check if the current user is allowed to perform the given action on the view.
-"""
-	isActionAllowed(
-"""
-The action to check if a user is allowed to perform on a view.
-"""
-		action: ViewAction!
-	): Boolean!
 }
 
 """
@@ -14588,34 +18511,42 @@ A pending user. I.e. a user that was invited to join an organization.
 type PendingUser {
 """
 The id or token for the pending user
+Stability: Long-term
 """
 	id: String!
 """
 Whether IDP is enabled for the organization
+Stability: Long-term
 """
 	idp: Boolean!
 """
 The time the pending user was created
+Stability: Long-term
 """
 	createdAt: Long!
 """
 The email of the user that invited the pending user
+Stability: Long-term
 """
 	invitedByEmail: String!
 """
 The name of the user that invited the pending user
+Stability: Long-term
 """
 	invitedByName: String!
 """
 The name of the organization the the pending user is about to join
+Stability: Long-term
 """
 	orgName: String!
 """
 The email of the pending user
+Stability: Long-term
 """
 	newUserEmail: String!
 """
 The current organization state for the user, if any.
+Stability: Long-term
 """
 	pendingUserState: PendingUserState!
 }
@@ -14645,16 +18576,31 @@ Permission to administer alerts, scheduled searches and actions
 Permission to administer alerts and scheduled searches
 """
 	ChangeTriggers
+	CreateTriggers
+	UpdateTriggers
+	DeleteTriggers
 """
 Permission to administer actions
 """
 	ChangeActions
+	CreateActions
+	UpdateActions
+	DeleteActions
 	ChangeDashboards
+	CreateDashboards
+	UpdateDashboards
+	DeleteDashboards
 	ChangeDashboardReadonlyToken
 	ChangeFiles
+	CreateFiles
+	UpdateFiles
+	DeleteFiles
 	ChangeInteractions
 	ChangeParsers
 	ChangeSavedQueries
+	CreateSavedQueries
+	UpdateSavedQueries
+	DeleteSavedQueries
 	ConnectView
 	ChangeDataDeletionPermissions
 	ChangeRetention
@@ -14679,6 +18625,9 @@ Permission to administer event forwarding rules
 	ReadExternalFunctions
 	ChangeIngestFeeds
 	ChangeScheduledReports
+	CreateScheduledReports
+	UpdateScheduledReports
+	DeleteScheduledReports
 }
 
 """
@@ -14698,33 +18647,40 @@ Personal token for a user. The token will inherit the same permissions as the us
 type PersonalUserToken implements Token{
 """
 The id of the token.
+Stability: Long-term
 """
 	id: String!
 """
 The name of the token.
+Stability: Long-term
 """
 	name: String!
 """
 The time at which the token expires.
+Stability: Long-term
 """
 	expireAt: Long
 """
 The ip filter on the token.
+Stability: Long-term
 """
 	ipFilter: String
 """
 The ip filter on the token.
+Stability: Long-term
 """
 	ipFilterV2: IPFilter
 """
 The date the token was created.
+Stability: Long-term
 """
 	createdAt: Long!
 }
 
 type Query {
 """
-[PREVIEW: Experimental feature, not ready for production.] All actions, labels and packages used in alerts.
+All actions, labels and packages used in alerts.
+Stability: Preview
 """
 	alertFieldValues(
 """
@@ -14733,49 +18689,41 @@ Arguments for alert field values query.
 		input: AlertFieldValuesInput!
 	): AlertFieldValues!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Get allowed asset actions for the logged in user on a specific asset
-"""
-	allowedAssetActions(
-"""
-Id of the asset
-"""
-		assetId: String!
-"""
-Asset type
-"""
-		assetType: AssetPermissionsAssetType!
-"""
-The name of the search domain that the asset belongs to
-"""
-		searchDomainName: String
-	): [AssetAction!]!
-"""
-Analyze a query for certain properties
+Analyze a query for certain properties.
+Stability: Short-term
 """
 	analyzeQuery(
 		input: AnalyzeQueryArguments!
 	): AnalyzeQueryInfo!
 """
 Returns information about the IP ASN database used by the LogScale instance.
+Stability: Long-term
 """
 	asnDatabaseInfo: IpDatabaseInfo!
 """
 This fetches the list of blocked query patterns.
+Stability: Long-term
 """
 	blockedQueries(
 """
 Whether to return all blocked queries within the cluster. Requires the ManageCluster permission.
 """
 		clusterWide: Boolean
+"""
+Whether to include blocked queries for organizations that have been deleted.
+"""
+		includeBlockedQueriesForDeletedOrganizations: Boolean
 	): [BlockedQuery!]!
 """
 This is used to check if a given domain is valid.
+Stability: Short-term
 """
 	checkDomain(
 		domain: String!
 	): Boolean!
 """
 Validate a local cluster connection.
+Stability: Short-term
 """
 	checkLocalClusterConnection(
 """
@@ -14785,6 +18733,7 @@ Data for checking a local cluster connection
 	): LocalClusterConnectionStatus!
 """
 Validate a remote cluster connection.
+Stability: Short-term
 """
 	checkRemoteClusterConnection(
 """
@@ -14793,7 +18742,8 @@ Data for checking a remote cluster connection
 		input: CheckRemoteClusterConnectionInput!
 	): RemoteClusterConnectionStatus!
 """
-[PREVIEW: Feature still in development] Get linked child organizations
+Get linked child organizations
+Stability: Preview
 """
 	childOrganizations(
 		search: String
@@ -14807,24 +18757,29 @@ Choose the order in which the results are returned.
 	): ChildOrganizationsResultSet!
 """
 This is used to retrieve information about a cluster.
+Stability: Long-term
 """
 	cluster: Cluster!
 """
 Return the cluster management settings for this LogScale cluster.
+Stability: Short-term
 """
 	clusterManagementSettings: ClusterManagementSettings
 """
 Concatenate multiple valid queries into a combined query.
+Stability: Short-term
 """
 	concatenateQueries(
 		input: ConcatenateQueriesArguments!
 	): QueryConcatenationInfo!
 """
 This returns the current authenticated user.
+Stability: Long-term
 """
 	currentUser: User!
 """
 This is used to retrieve a dashboard.
+Stability: Long-term
 """
 	dashboardsPage(
 		search: String
@@ -14832,23 +18787,27 @@ This is used to retrieve a dashboard.
 		pageSize: Int!
 	): DashboardPage!
 """
-[PREVIEW: Internal debugging] For internal debugging
+For internal debugging
+Stability: Preview
 """
 	debugCache(
 		searchKeys: [String!]!
 	): String!
 """
 This returns the current value for the dynamic configuration.
+Stability: Short-term
 """
 	dynamicConfig(
 		dynamicConfig: DynamicConfig!
 	): String!
 """
 Returns all dynamic configurations. Requires root access.
+Stability: Short-term
 """
 	dynamicConfigs: [DynamicConfigKeyValueType!]!
 """
-[PREVIEW: Under development] Get next and previous pages when querying assets across LogScale views and repositories. Requires the cursor from the entitiesSearch or entitiesPage response as well as a direction
+Get next and previous pages when querying assets across LogScale views and repositories. Requires the cursor from the entitiesSearch or entitiesPage response as well as a direction
+Stability: Preview
 """
 	entitiesPage(
 """
@@ -14857,7 +18816,8 @@ input parameters for the page
 		input: EntitiesPageInputType!
 	): SearchResult!
 """
-[PREVIEW: Under development] Query assets across LogScale views and repositories. Will only return the first page. The response includes a cursor that can be sent to entitiesPage to get next pages with the same parameters
+Query assets across LogScale views and repositories. Will only return the first page. The response includes a cursor that can be sent to entitiesPage to get next pages with the same parameters
+Stability: Preview
 """
 	entitiesSearch(
 """
@@ -14867,14 +18827,17 @@ input parameters for the search
 	): SearchResult!
 """
 Get usage information around non-secret environment variables
+Stability: Short-term
 """
 	environmentVariableUsage: [EnvironmentVariableUsage!]!
 """
 This will list all of the event forwarders associated with an organization.
+Stability: Long-term
 """
 	eventForwarders: [EventForwarder!]!
 """
 This is used to determine if a given user has exceeded their query quota.
+Stability: Short-term
 """
 	exceededQueryQuotas(
 """
@@ -14883,7 +18846,8 @@ Username of the user for which to retrieve exceeded Query Quotas
 		username: String!
 	): [QueryQuotaExceeded!]!
 """
-[PREVIEW: All flags should be considered as beta features. Enabling features that are marked as experimental is strongly discouraged and can lead to LogScale ending up in a bad state beyond repair.] List feature flags depending on filters and context
+List feature flags depending on filters and context
+Stability: Preview
 """
 	featureFlags(
 """
@@ -14897,6 +18861,7 @@ Filter defining for which scope feature flags should be returned
 	): [FeatureFlagV2!]!
 """
 This can fetch the OIDC metadata from the discovery (.well-known/openid-configuration) endpoint provided.
+Stability: Long-term
 """
 	fetchOIDCMetadataFromDiscoveryEndpoint(
 """
@@ -14906,6 +18871,7 @@ The .well-known OIDC endpoint.
 	): WellKnownEndpointDetails!
 """
 This will fetch the SAML metadata from the discovery endpoint provided.
+Stability: Long-term
 """
 	fetchSamlMetadataFromDiscoveryEndpoint(
 """
@@ -14914,33 +18880,37 @@ The SAML metadata endpoint.
 		discoveryEndpoint: String!
 	): SamlMetadata!
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Retrieve the active schema and its field aliases on the given view.
+Retrieve the active schema and its field aliases on the given view.
+Stability: Long-term
 """
 	fieldAliasSchemaOnView(
 		repoOrViewName: String!
 	): FieldAliasSchema
 """
-[PREVIEW: This functionality is still under development and can change without warning.] Retrieve all schemas for field aliases
+Retrieve all schemas for field aliases.
+Stability: Long-term
 """
 	fieldAliasSchemas: FieldAliasSchemasInfo!
 """
 This will find information on the identity provider.
+Stability: Long-term
 """
 	findIdentityProvider(
 		email: String!
 	): IdentityProviderAuth!
 """
-[PREVIEW: Under development.] 
+Stability: Long-term
 """
 	fleetInstallationToken(
 		id: String!
 	): FleetInstallationToken
 """
-[PREVIEW: Under development.] 
+Stability: Short-term
 """
 	fleetInstallationTokens: [FleetInstallationToken!]!
 """
 Return the Java Flight Recorder settings for the specified vhost.
+Stability: Preview
 """
 	flightRecorderSettings(
 """
@@ -14950,6 +18920,7 @@ The vhost to fetch settings for.
 	): FlightRecorderSettings
 """
 Generate an unsaved aggregate alert from a package alert template.
+Stability: Long-term
 """
 	generateAggregateAlertFromPackageTemplate(
 """
@@ -14959,6 +18930,7 @@ Data for generating an unsaved aggregate alert object from a library package tem
 	): UnsavedAggregateAlert!
 """
 Generate an unsaved aggregate alert from a yaml template.
+Stability: Long-term
 """
 	generateAggregateAlertFromTemplate(
 """
@@ -14968,6 +18940,7 @@ Data for generating an unsaved aggregate alert object from a yaml template
 	): UnsavedAggregateAlert!
 """
 Generate an unsaved alert from a package alert template.
+Stability: Long-term
 """
 	generateAlertFromPackageTemplate(
 """
@@ -14977,6 +18950,7 @@ Data for generating an unsaved alert object from a library package template
 	): UnsavedAlert!
 """
 Generate an unsaved alert from a yaml template.
+Stability: Long-term
 """
 	generateAlertFromTemplate(
 """
@@ -14986,6 +18960,7 @@ Data for generating an unsaved alert object from a yaml template
 	): UnsavedAlert!
 """
 Generate an unsaved filter alert from a package alert template.
+Stability: Long-term
 """
 	generateFilterAlertFromPackageTemplate(
 """
@@ -14995,6 +18970,7 @@ Data for generating an unsaved filter alert object from a library package templa
 	): UnsavedFilterAlert!
 """
 Generate an unsaved filter alert from a yaml template.
+Stability: Long-term
 """
 	generateFilterAlertFromTemplate(
 """
@@ -15004,6 +18980,7 @@ Data for generating an unsaved filter alert object from a yaml template
 	): UnsavedFilterAlert!
 """
 Generate an unsaved parser from a YAML template.
+Stability: Long-term
 """
 	generateParserFromTemplate(
 """
@@ -15013,6 +18990,7 @@ Data for generating an unsaved parser object from a YAML template
 	): UnsavedParser!
 """
 Generate an unsaved scheduled search from a package scheduled search template.
+Stability: Long-term
 """
 	generateScheduledSearchFromPackageTemplate(
 """
@@ -15022,6 +19000,7 @@ Data for generating an unsaved scheduled search object from a library package te
 	): UnsavedScheduledSearch!
 """
 Generate an unsaved scheduled search from a yaml template.
+Stability: Long-term
 """
 	generateScheduledSearchFromTemplate(
 """
@@ -15030,13 +19009,15 @@ Data for generating an unsaved scheduled search object from a yaml templat.
 		input: GenerateScheduledSearchFromTemplateInput!
 	): UnsavedScheduledSearch!
 """
-[PREVIEW: Experimental prototype not ready for production use] Look up an external function specification.
+Look up an external function specification.
+Stability: Preview
 """
 	getExternalFunction(
 		input: GetExternalFunctionInput!
 	): ExternalFunctionSpecificationOutput
 """
 This is used to get content of a file.
+Stability: Long-term
 """
 	getFileContent(
 		name: String!
@@ -15046,39 +19027,89 @@ This is used to get content of a file.
 		filterString: String
 	): UploadedFileSnapshot!
 """
-[PREVIEW: Under development.] 
+Get url endpoint for fleet management
+Stability: Short-term
+"""
+	getFleetManagementUrl: String!
+"""
+Stability: Short-term
 """
 	getLogCollectorDebugLogging: LogCollectorDebugLogging
 """
-[PREVIEW: Under development.] 
+Stability: Short-term
 """
 	getLogCollectorDetails(
 		machineId: String!
-	): LogCollectorDetails!
+	): LogCollectorDetails
 """
-[PREVIEW: Under development.] 
+Stability: Short-term
 """
 	getLogCollectorInstanceDebugLogging(
 		id: String!
 	): LogCollectorDebugLogging
 """
-[PREVIEW: Under development.] 
+Stability: Short-term
 """
 	getLostCollectorDays: Int!
 """
 Used to get information on a specified group.
+Stability: Long-term
 """
 	group(
 		groupId: String!
 	): Group!
 """
 Used to get information on groups by a given display name.
+Stability: Long-term
 """
 	groupByDisplayName(
 		displayName: String!
 	): Group!
 """
+Search groups and users with permissions on the asset.
+Stability: Preview
+"""
+	groupsAndUsersWithPermissionsOnAsset(
+"""
+The name of the search domain where the asset belongs.
+"""
+		searchDomainName: String!
+"""
+The type of the asset.
+"""
+		assetType: AssetPermissionsAssetType!
+"""
+The ID of the asset. For files, use the name of the file.
+"""
+		assetId: String!
+"""
+Filter results based on this string
+"""
+		searchFilter: String
+"""
+Indicates whether to include only users, only groups, or both.
+"""
+		groupsOrUsersFilters: [GroupsOrUsersFilter!]
+"""
+The amount of results to return.
+"""
+		limit: Int
+"""
+The number of results to skip or the offset to use. For instance if implementing pagination, set skip = limit * (page - 1)
+"""
+		skip: Int
+"""
+Choose the order in which the results are returned.
+"""
+		orderBy: OrderBy
+"""
+If true the result will also include users and groups that currently doesn't have access to the asset
+"""
+		includeEmptyPermissionSet: Boolean!
+	): UserOrGroupAssetPermissionSearchResultSet!
+"""
 All defined groups in an organization.
+Stability: Long-term
 """
 	groupsPage(
 		search: String
@@ -15088,23 +19119,30 @@ All defined groups in an organization.
 	): GroupPage!
 """
 This will check whether an organization has an organization root.
+Stability: Short-term
 """
 	hasOrgRoot(
 		orgId: String!
 	): Boolean!
 """
 This is used to get information on a specific identity provider.
+Stability: Long-term
 """
 	identityProvider(
 		id: String!
 	): IdentityProviderAuthentication!
+"""
+Stability: Long-term
+"""
 	identityProviders: [IdentityProviderAuthentication!]!
 """
 This returns information about the license for the LogScale instance, if any license installed.
+Stability: Long-term
 """
 	installedLicense: License
 """
 Provides details for a specific package installed on a specific view.
+Stability: Long-term
 """
 	installedPackage(
 """
@@ -15118,85 +19156,112 @@ The name of the view the package is installed in.
 	): PackageInstallation
 """
 Used to get information on the IOC database used by the LogScale instance.
+Stability: Long-term
 """
 	iocDatabaseInfo: CrowdStrikeIocStatus!
 """
 This returns information about the IP location database used by the LogScale instance.
+Stability: Long-term
 """
 	ipDatabaseInfo: IpDatabaseInfo!
 """
 Returns a list of IP filters.
+Stability: Long-term
 """
 	ipFilters: [IPFilter!]!
 """
 This will return information about the Kafka cluster.
+Stability: Short-term
 """
 	kafkaCluster: KafkaClusterDescription!
 """
-[PREVIEW: Internal testing.] Used to get language restrictions for language version.
+Used to get language restrictions for language version.
+Stability: Preview
 """
 	languageRestrictions(
 		version: LanguageVersionEnum!
 	): QueryLanguageRestriction!
 """
 Used to list all notifications currently set in the system. This requires root access.
+Stability: Long-term
 """
 	listNotifications: [Notification!]!
 """
-[PREVIEW: Under development.] 
+Stability: Short-term
 """
 	logCollectorConfiguration(
 		id: String!
 	): LogCollectorConfiguration!
 """
 List available Log Collector installers.
+Stability: Long-term
 """
 	logCollectorInstallers: [LogCollectorInstaller!]
 """
-[PREVIEW: Under development.] 
+Stability: Short-term
 """
 	logCollectorMergedConfiguration(
 		configIds: [String!]!
 	): LogCollectorMergedConfiguration!
 """
 List versions available through Remote Update for the LogScale Collector
+Stability: Long-term
 """
 	logCollectorVersionsAvailable: [String!]!
+"""
+Stability: Long-term
+"""
 	loginBridgeRequest: LoginBridgeRequest!
+"""
+Stability: Long-term
+"""
 	marketplace: Marketplace!
 """
 This will return information about the LogScale instance
+Stability: Short-term
 """
 	meta(
 		url: String
 	): HumioMetadata!
+"""
+Returns a list of organizations that has non-default bucket-storage configuration
+Stability: Short-term
+"""
+	nonDefaultBucketConfigs: [OrgConfig!]!
+"""
+Stability: Long-term
+"""
 	oidcIdentityProvider(
 		id: String!
 	): OidcIdentityProvider!
 """
 Get the current organization
+Stability: Long-term
 """
 	organization: Organization!
 """
 Get a pending user.
+Stability: Long-term
 """
 	pendingUser(
 		token: String!
 	): PendingUser!
 """
 Get a pending user.
+Stability: Long-term
 """
 	pendingUsers(
 		search: String
 	): [PendingUser!]!
 """
 Proxy query through a specific organization. Root operation.
+Stability: Long-term
 """
 	proxyOrganization(
 		organizationId: String!
 	): Query!
 """
-[PREVIEW: Internal testing.] 
+Stability: Preview
 """
 	queryAnalysis(
 		queryString: String!
@@ -15205,7 +19270,8 @@ Proxy query through a specific organization. Root operation.
 		viewName: String
 	): queryAnalysis!
 """
-[PREVIEW: in development.] Return the query assistance for the given search, as well as the assistant version.
+Return the query assistance for the given search, as well as the assistant version.
+Stability: Preview
 """
 	queryAssistance(
 """
@@ -15217,13 +19283,22 @@ Enable to remap often used fields to their LogScale equivalents
 """
 		remapFields: Boolean!
 	): QueryAssistantResult!
+"""
+Stability: Short-term
+"""
 	queryQuotaDefaultSettings: [QueryQuotaIntervalSetting!]!
+"""
+Stability: Short-term
+"""
 	queryQuotaUsage(
 """
 Username of the user for which to retrieve status of Query Quotas
 """
 		username: String!
 	): [QueryQuotaUsage!]!
+"""
+Stability: Short-term
+"""
 	queryQuotaUserSettings(
 """
 If omitted, returns the Query Quota Settings for all users. If provided, returns the Query Quota Settings for that particular user.
@@ -15232,6 +19307,7 @@ If omitted, returns the Query Quota Settings for all users. If provided, returns
 	): [QueryQuotaUserSettings!]!
 """
 Query search domains with organization filter
+Stability: Long-term
 """
 	querySearchDomains(
 """
@@ -15267,6 +19343,7 @@ Filter results by name of connected limit. Search domains without a limit will b
 	): SearchDomainSearchResultSet!
 """
 Fetch the list of active event redaction jobs.
+Stability: Long-term
 """
 	redactEvents(
 """
@@ -15274,6 +19351,9 @@ The name of the repository to fetch pending event redactions for.
 """
 		repositoryName: String!
 	): [DeleteEvents!]!
+"""
+Stability: Long-term
+"""
 	repositories(
 """
 Include sandboxes for other users in the results set
@@ -15283,6 +19363,7 @@ Include sandboxes for other users in the results set
 	): [Repository!]!
 """
 Lookup a given repository by name.
+Stability: Long-term
 """
 	repository(
 """
@@ -15293,22 +19374,26 @@ The name of the repository
 	): Repository!
 """
 A given role.
+Stability: Long-term
 """
 	role(
 		roleId: String!
 	): Role!
 """
 All defined roles.
+Stability: Long-term
 """
 	roles: [Role!]!
 """
 All defined roles in org.
+Stability: Long-term
 """
 	rolesInOrgForChangingUserAccess(
 		searchDomainId: String!
 	): [Role!]!
 """
 Searchable paginated roles
+Stability: Long-term
 """
 	rolesPage(
 		search: String
@@ -15319,6 +19404,7 @@ Searchable paginated roles
 	): RolePage!
 """
 Returns running queries.
+Stability: Long-term
 """
 	runningQueries(
 """
@@ -15335,61 +19421,73 @@ Whether to return global results. Default=false. True requires system level acce
 """
 		global: Boolean
 	): RunningQueries!
+"""
+Returns whether AWS Role is required when configuring S3 Archiving.
+Stability: Short-term
+"""
+	s3ArchivingRequiresRole: Boolean!
+"""
+Stability: Long-term
+"""
 	samlIdentityProvider(
 		id: String!
 	): SamlIdentityProvider!
+"""
+Stability: Long-term
+"""
 	savedQuery(
 		id: String!
 	): SavedQuery!
 """
 Get scheduled report information using a scheduled report access token.
+Stability: Long-term
 """
 	scheduledReport: LimitedScheduledReport!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Search asset permissions assigned to groups and/or users
+Stability: Long-term
 """
-	searchAssetPermissions(
+	searchDomain(
+		name: String!
+	): SearchDomain!
 """
-Id of the asset
+Lists assets in the provided search domains.
+Stability: Preview
 """
-		assetId: String!
+	searchDomainAssets(
 """
-Asset type
+The names of the search domains to search for assets in. If empty, includes assets from all search domains the requester has access to.
 """
-		assetType: AssetPermissionsAssetType!
+		searchDomainNames: [String!]!
 """
-The name of the search domain to search within
+The types of assets to include. If empty, all asset types are included.
 """
-		searchDomainName: String
+		assetTypes: [AssetPermissionsAssetType!]
 """
 Filter results based on this string
 """
 		searchFilter: String
 """
-The number of results to skip or the offset to use. For instance if implementing pagination, set skip = limit * (page - 1)
-"""
-		skip: Int
-"""
 The amount of results to return.
 """
 		limit: Int
 """
-List of user ids to limit the search to
+The number of results to skip or the offset to use. For instance if implementing pagination, set skip = limit * (page - 1)
 """
-		userIds: [String!]
+		skip: Int
 """
-List of group ids to limit the search to
+Choose the order in which the results are returned.
 """
-		groupIds: [String!]
-	): AssetPermissionSearchResultSet!
-	searchDomain(
-		name: String!
-	): SearchDomain!
+		orderBy: OrderBy
+	): SearchDomainAssetsResultSet!
+"""
+Stability: Long-term
+"""
 	searchDomains(
 		includeHidden: Boolean
 	): [SearchDomain!]!
 """
 Paged searchDomains.
+Stability: Long-term
 """
 	searchDomainsPage(
 		search: String
@@ -15398,10 +19496,13 @@ Paged searchDomains.
 		pageSize: Int!
 	): SearchDomainPage!
 """
-[PREVIEW: Under development.] Get paginated search results.
+Get paginated search results.
+Stability: Short-term
 """
 	searchFleet(
 		isLiveFilter: Boolean
+		versionFilter: SearchFleetVersionFilter
+		osFilter: SearchFleetOsFilter
 		groupIdsFilter: [String!]
 		changeFilter: Changes
 		groupFilter: GroupFilter
@@ -15429,7 +19530,7 @@ The amount of results to return.
 		limit: Int
 	): SearchFleetUnion!
 """
-[PREVIEW: Under development.] 
+Stability: Short-term
 """
 	searchFleetInstallationTokens(
 """
@@ -15447,7 +19548,8 @@ Choose the order in which the results are returned.
 		orderBy: OrderBy
 	): SearchFleetInstallationTokenResultSet!
 """
-[PREVIEW: Under development.] Search log collector configurations.
+Search log collector configurations.
+Stability: Short-term
 """
 	searchLogCollectorConfigurations(
 """
@@ -15469,7 +19571,8 @@ Choose the order in which the results are returned.
 		orderBy: OrderBy
 	): SearchLogCollectorConfigurationResultSet!
 """
-[PREVIEW: Under development.] Search log collector configurations.
+Search log collector configurations.
+Stability: Short-term
 """
 	searchLogCollectorGroups(
 """
@@ -15492,6 +19595,7 @@ Choose the order in which the results are returned.
 	): SearchLogCollectorGroupsResultSet!
 """
 Get paginated search results. (Root operation)
+Stability: Short-term
 """
 	searchOrganizations(
 """
@@ -15516,7 +19620,8 @@ The amount of results to return.
 		limit: Int
 	): OrganizationSearchResultSet!
 """
-[PREVIEW: Part of the ScheduledReports feature under development] Check the status for a specific typed service.
+Check the status for a specific typed service.
+Stability: Preview
 """
 	serviceStatus(
 """
@@ -15525,11 +19630,13 @@ The service type name of the service to get status for.
 		serviceType: String!
 	): HealthStatus!
 """
-[PREVIEW: Part of the ScheduledReports feature under development] Metadata from all registered services
+Metadata from all registered services
+Stability: Preview
 """
 	servicesMetadata: [ServiceMetadata!]!
 """
 Paginated search results for tokens
+Stability: Long-term
 """
 	sessions(
 """
@@ -15554,17 +19661,30 @@ The amount of results to return.
 	): SessionQueryResultSet!
 """
 Gets a shared dashboard by it's shared link token.
+Stability: Long-term
 """
 	sharedDashboards(
 		token: String!
 	): SharedDashboard!
+"""
+Stability: Long-term
+"""
 	starredDashboards: [Dashboard!]!
 """
-[PREVIEW: Under development.] Token for fleet management.
+Get a specific token by ID
+Stability: Long-term
+"""
+	token(
+		tokenId: String!
+	): Token!
+"""
+Token for fleet management.
+Stability: Short-term
 """
 	tokenForFleetManagement: String!
 """
 Paginated search results for tokens
+Stability: Long-term
 """
 	tokens(
 """
@@ -15588,22 +19708,28 @@ The amount of results to return.
 		limit: Int
 	): TokenQueryResultSet!
 """
-[PREVIEW: BETA feature.] 
+Stability: Preview
 """
 	usage: UsageStats!
 """
 A user in the system.
+Stability: Long-term
 """
 	user(
 		id: String!
 	): User
 """
 Requires manage cluster permission; Returns all users in the system.
+Stability: Long-term
 """
 	users(
 		orderBy: OrderByUserFieldInput
 		search: String
 	): [User!]!
+"""
+
+Stability: Long-term
+"""
 	usersAndGroupsForChangingUserAccess(
 		search: String
 		searchDomainId: String!
@@ -15618,6 +19744,7 @@ The amount of results to return.
 	): UsersAndGroupsSearchResultSet!
 """
 Requires either root access, org owner access or permission to manage users in at least one repository or view. Returns a page of all users in an organization.
+Stability: Long-term
 """
 	usersPage(
 		orderBy: OrderByUserFieldInput
@@ -15627,22 +19754,26 @@ Requires either root access, org owner access or permission to manage users in a
 	): UsersPage!
 """
 Return users without organizations
+Stability: Short-term
 """
 	usersWithoutOrganizations: [User!]!
 """
 Validate the Access Token
+Stability: Short-term
 """
 	validateAccessToken(
 		accessToken: String!
 	): String!
 """
 Validate the Access Token
+Stability: Long-term
 """
 	validateAccessTokenV2(
 		accessToken: String!
 	): AccessTokenValidatorResultType!
 """
-[PREVIEW: Internal testing.] Check that a query compiles.
+Check that a query compiles.
+Stability: Preview
 """
 	validateQuery(
 		queryString: String!
@@ -15652,20 +19783,24 @@ Validate the Access Token
 	): QueryValidationResult!
 """
 Validate the JWT Token
+Stability: Long-term
 """
 	validateToken(
 		jwtToken: String!
 	): Boolean!
 """
 The currently authenticated user's account.
+Stability: Long-term
 """
 	viewer: Account!
 """
 The currently authenticated user's account if any.
+Stability: Long-term
 """
 	viewerOpt: Account
 """
-[PREVIEW: Internal debugging tool, do not use without explicit instruction from support] Get the list of keys being used to select queries for tracing on workers.
+Get the list of keys being used to select queries for tracing on workers.
+Stability: Preview
 """
 	workerQueryTracingState: WorkerQueryTracingState!
 }
@@ -15704,22 +19839,55 @@ Either a successful assistance result, or an error
 union QueryAssistantAssistance =QueryAssistantSuccess | QueryAssistantError
 
 type QueryAssistantDiagnostic {
+"""
+Stability: Preview
+"""
 	message: QueryAssistantDiagnosticMessage!
+"""
+Stability: Preview
+"""
 	position: QueryAssistantDiagnosticPosition
+"""
+Stability: Preview
+"""
 	severity: QueryAssistantDiagnosticSeverity!
 }
 
 type QueryAssistantDiagnosticMessage {
+"""
+Stability: Preview
+"""
 	what: String!
+"""
+Stability: Preview
+"""
 	terse: String!
+"""
+Stability: Preview
+"""
 	code: String!
 }
 
 type QueryAssistantDiagnosticPosition {
+"""
+Stability: Preview
+"""
 	column: Int!
+"""
+Stability: Preview
+"""
 	line: Int!
+"""
+Stability: Preview
+"""
 	beginOffset: Int!
+"""
+Stability: Preview
+"""
 	endOffset: Int!
+"""
+Stability: Preview
+"""
 	longString: String!
 }
 
@@ -15731,6 +19899,9 @@ enum QueryAssistantDiagnosticSeverity {
 }
 
 type QueryAssistantError {
+"""
+Stability: Preview
+"""
 	error: String!
 }
 
@@ -15740,16 +19911,24 @@ An assistance result and a version of the query assistant
 type QueryAssistantResult {
 """
 The assistant version.
+Stability: Preview
 """
 	version: String!
 """
 The query assistance for the given search.
+Stability: Preview
 """
 	assistance: QueryAssistantAssistance!
 }
 
 type QueryAssistantSuccess {
+"""
+Stability: Preview
+"""
 	result: String!
+"""
+Stability: Preview
+"""
 	diagnostics: [QueryAssistantDiagnostic!]!
 }
 
@@ -15757,9 +19936,21 @@ type QueryAssistantSuccess {
 An interaction for a query based widget
 """
 type QueryBasedWidgetInteraction {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	titleTemplate: String
+"""
+Stability: Long-term
+"""
 	conditions: [WidgetInteractionCondition!]!
+"""
+Stability: Long-term
+"""
 	typeInfo: QueryBasedWidgetInteractionTypeInfo!
 }
 
@@ -15769,7 +19960,13 @@ union QueryBasedWidgetInteractionTypeInfo =DashboardLinkInteraction | CustomLink
 Result of concatenating queries.
 """
 type QueryConcatenationInfo {
+"""
+Stability: Short-term
+"""
 	concatenatedQuery: String!
+"""
+Stability: Short-term
+"""
 	validationResult: QueryValidationInfo!
 }
 
@@ -15778,15 +19975,15 @@ A diagnostic message from query validation.
 """
 type QueryDiagnostic {
 """
-[PREVIEW: Internal testing.] 
+Stability: Preview
 """
 	message: String!
 """
-[PREVIEW: Internal testing.] 
+Stability: Preview
 """
 	code: String!
 """
-[PREVIEW: Internal testing.] 
+Stability: Preview
 """
 	severity: Severity!
 }
@@ -15797,19 +19994,25 @@ Diagnostic information for a query.
 type QueryDiagnosticInfoOutputType {
 """
 The diagnostic message.
+Stability: Short-term
 """
 	message: String!
 """
 The code for the diagnostic.
+Stability: Short-term
 """
 	code: String!
 """
 The severity of the diagnostic.
+Stability: Short-term
 """
 	severity: String!
 }
 
 type QueryInProgress {
+"""
+Stability: Long-term
+"""
 	queryId: String!
 }
 
@@ -15817,8 +20020,17 @@ type QueryInProgress {
 Language restrictions for language version.
 """
 type QueryLanguageRestriction {
+"""
+Stability: Preview
+"""
 	version: LanguageVersion!
+"""
+Stability: Preview
+"""
 	allowedFunctions: [String!]!
+"""
+Stability: Preview
+"""
 	enabled: Boolean!
 }
 
@@ -15833,12 +20045,24 @@ Query ownership
 }
 
 type QueryPrefixes {
+"""
+Stability: Long-term
+"""
 	viewId: String!
+"""
+Stability: Long-term
+"""
 	queryPrefix: String!
 }
 
 type QueryQuotaExceeded {
+"""
+Stability: Short-term
+"""
 	kind: QueryQuotaMeasurementKind!
+"""
+Stability: Short-term
+"""
 	resetsAt: Long!
 }
 
@@ -15850,10 +20074,25 @@ enum QueryQuotaInterval {
 }
 
 type QueryQuotaIntervalSetting {
+"""
+Stability: Short-term
+"""
 	interval: QueryQuotaInterval!
+"""
+Stability: Short-term
+"""
 	measurementKind: QueryQuotaMeasurementKind!
+"""
+Stability: Short-term
+"""
 	value: Long
+"""
+Stability: Short-term
+"""
 	valueKind: QueryQuotaIntervalSettingKind!
+"""
+Stability: Short-term
+"""
 	source: QueryQuotaIntervalSettingSource!
 }
 
@@ -15874,9 +20113,21 @@ enum QueryQuotaMeasurementKind {
 }
 
 type QueryQuotaUsage {
+"""
+Stability: Short-term
+"""
 	interval: QueryQuotaInterval!
+"""
+Stability: Short-term
+"""
 	queryCount: Int!
+"""
+Stability: Short-term
+"""
 	staticCost: Long!
+"""
+Stability: Short-term
+"""
 	liveCost: Long!
 }
 
@@ -15886,10 +20137,12 @@ Query Quota Settings for a particular user
 type QueryQuotaUserSettings {
 """
 Username of the user for which these Query Quota Settings apply
+Stability: Short-term
 """
 	username: String!
 """
 List of the settings that apply
+Stability: Short-term
 """
 	settings: [QueryQuotaIntervalSetting!]!
 }
@@ -15912,7 +20165,13 @@ Use @ingesttimestamp for the query.
 Result of query validation.
 """
 type QueryValidationInfo {
+"""
+Stability: Short-term
+"""
 	isValid: Boolean!
+"""
+Stability: Short-term
+"""
 	diagnostics: [QueryDiagnosticInfoOutputType!]!
 }
 
@@ -15921,16 +20180,26 @@ Result of validating a query.
 """
 type QueryValidationResult {
 """
-[PREVIEW: Internal testing.] 
+Stability: Preview
 """
 	isValid: Boolean!
 """
-[PREVIEW: Internal testing.] 
+Stability: Preview
 """
 	diagnostics: [QueryDiagnostic!]!
 }
 
+"""
+Readonly default role
+"""
+enum ReadonlyDefaultRole {
+	Reader
+}
+
 type RealTimeDashboardUpdateFrequency {
+"""
+Stability: Long-term
+"""
 	name: String!
 }
 
@@ -15938,17 +20207,44 @@ type RealTimeDashboardUpdateFrequency {
 A map from reasons why a node might not be able to be unregistered safely, to the boolean value indicating whether a given reason applies to this node. For a node to be unregistered without any undue disruption, none of the reasons must apply.
 """
 type ReasonsNodeCannotBeSafelyUnregistered {
+"""
+Stability: Long-term
+"""
 	isAlive: Boolean!
+"""
+Stability: Long-term
+"""
 	leadsDigest: Boolean!
+"""
+Stability: Long-term
+"""
 	hasUnderReplicatedData: Boolean!
+"""
+Stability: Long-term
+"""
 	hasDataThatExistsOnlyOnThisNode: Boolean!
 }
 
 type RecentQuery {
+"""
+Stability: Long-term
+"""
 	languageVersion: LanguageVersion!
+"""
+Stability: Long-term
+"""
 	query: HumioQuery!
+"""
+Stability: Long-term
+"""
 	runAt: DateTime!
+"""
+Stability: Long-term
+"""
 	widgetType: String
+"""
+Stability: Long-term
+"""
 	widgetOptions: JSON
 }
 
@@ -15956,8 +20252,17 @@ type RecentQuery {
 Information about regions
 """
 type RegionSelectData {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	url: String!
+"""
+Stability: Long-term
+"""
 	iconUrl: String!
 }
 
@@ -15967,10 +20272,12 @@ Info about a version of a LogScale Package.
 type RegistryPackageVersionInfo {
 """
 The package version
+Stability: Long-term
 """
 	version: SemanticVersion!
 """
 The minimum version of LogScale required to run the package.
+Stability: Long-term
 """
 	minHumioVersion: SemanticVersion!
 }
@@ -15981,26 +20288,32 @@ The status of a remote cluster connection.
 type RemoteClusterConnectionStatus implements ClusterConnectionStatus{
 """
 Name of the remote view
+Stability: Short-term
 """
 	remoteViewName: String
 """
 Software version of the remote view
+Stability: Short-term
 """
 	remoteServerVersion: String
 """
 Oldest server version that is protocol compatible with the remote server
+Stability: Short-term
 """
 	remoteServerCompatVersion: String
 """
 Id of the connection
+Stability: Short-term
 """
 	id: String
 """
 Whether the connection is valid
+Stability: Short-term
 """
 	isValid: Boolean!
 """
 Errors if the connection is invalid
+Stability: Short-term
 """
 	errorMessages: [ConnectionAspectErrorType!]!
 }
@@ -16010,10 +20323,12 @@ scalar RepoOrViewName
 type RepositoriesUsageQueryResult {
 """
 The total number of matching results
+Stability: Long-term
 """
 	totalResults: Int!
 """
 The paginated result set
+Stability: Long-term
 """
 	results: [RepositoryUsageValue!]!
 }
@@ -16034,83 +20349,120 @@ A repository stores ingested data, configures parsers and data retention policie
 type Repository implements SearchDomain{
 """
 Repo Types are used for tracking trial status in LogScale Cloud setups.
+Stability: Long-term
 """
 	type: RepositoryType!
 """
 Repo data types are used for controlling the types of data are allowed in the repository.
+Stability: Long-term
 """
 	dataType: RepositoryDataType!
 """
 The limit attached to the repository.
+Stability: Long-term
 """
 	limit: LimitV2
 """
 The date and time in the future after which ingest for this repository will be re-enabled.
+Stability: Long-term
 """
 	ingestBlock: DateTime
 """
 Usage tag, used to group usage summary on repositories
+Stability: Long-term
 """
 	usageTag: String
 """
 Data sources where data is ingested from. E.g. This can be specific log files or services sending data to LogScale.
+Stability: Long-term
 """
 	datasources: [Datasource!]!
 """
 Total size the data. Size is measured as the size stored before compression and is thus the size of the internal format, not the data that was ingested.
+Stability: Long-term
 """
 	uncompressedByteSize: Long!
 """
 Total size of data. Size is measured as the size after compression.
+Stability: Long-term
 """
 	compressedByteSize: Long!
 """
 Total size the data, merged parts. Size is measured as the size stored before compression and is thus the size of the internal format, not the data that was ingested.
+Stability: Long-term
 """
 	uncompressedByteSizeOfMerged: Long!
 """
 Total size of data, merged parts. Size is measured as the size after compression.
+Stability: Long-term
 """
 	compressedByteSizeOfMerged: Long!
 """
 The timestamp of the latest ingested data, or null if the repository is empty.
+Stability: Long-term
 """
 	timeOfLatestIngest: DateTime
 """
 The maximum time (in days) to keep data. Data old than this will be deleted.
+Stability: Long-term
 """
 	timeBasedRetention: Float
 """
 Retention (in Gigabytes) based on the size of data when it arrives to LogScale, that is before parsing and compression. LogScale will keep `at most` this amount of data.
+Stability: Long-term
 """
 	ingestSizeBasedRetention: Float
+"""
+Stability: Long-term
+"""
 	ingestTokens: [IngestToken!]!
 """
 Retention (in Gigabytes) based on the size of data when in storage, that is, after parsing and compression. LogScale will keep `at least` this amount of data, but as close to this number as possible.
+Stability: Long-term
 """
 	storageSizeBasedRetention: Float
 """
 Sets time (in days) to keep backups before they are deleted.
+Stability: Long-term
 """
 	timeBasedBackupRetention: Float
 """
 The ingest listeners configured for this repository.
+Stability: Long-term
 """
 	ingestListeners: [IngestListener!]!
 """
 Maximum number of auto shards created.
+Stability: Long-term
 """
 	maxAutoShardCount: Int
 """
 Configuration for S3 archiving. E.g. bucket name and region.
+Stability: Long-term
 """
 	s3ArchivingConfiguration: S3Configuration
 """
-[PREVIEW: Cache policies are a limited feature and is subject to change] The cache policy set on this repo.
+Configuration for GCS archiving. E.g. bucket name.
+Stability: Preview
+"""
+	gcsArchivingConfiguration: GCSArchivingConfiguration
+"""
+Configuration for archiving. E.g. bucket name and region.
+Stability: Preview
+"""
+	archivingConfiguration: ArchivingConfiguration
+"""
+Provider for archiving, i.e. S3 or GCS
+Stability: Preview
+"""
+	archivingProvider: String
+"""
+The cache policy set on this repo.
+Stability: Preview
 """
 	cachePolicy: CachePolicy
 """
-[PREVIEW: Cache policies are a limited feature and is subject to change] The cache policy of this repo that as will be applied.
+The cache policy of this repo that as will be applied.
 
 This will apply the cache policy of the repo, org-wide default, or global
 default. This will be (in order of precedence):
@@ -16119,26 +20471,37 @@ default. This will be (in order of precedence):
  3. The global cache policy, if set.
  4. The default cache policy in which no segments are prioritized.
 
+Stability: Preview
 """
 	effectiveCachePolicy: CachePolicy!
 """
 Tag grouping rules applied on the repository currently. Rules only apply to the tags they denote, and tags without rules do not have any grouping.
+Stability: Long-term
 """
 	currentTagGroupings: [TagGroupingRule!]!
 """
 The AWS External ID used when assuming roles in AWS on behalf of this repository.
+Stability: Long-term
 """
 	awsExternalId: String!
 """
+The ARN of the AWS IAM identity that will write to S3 for S3 Archiving.
+Stability: Short-term
+"""
+	s3ArchivingArn: String
+"""
 The event forwarding rules configured for the repository
+Stability: Long-term
 """
 	eventForwardingRules: [EventForwardingRule!]!
 """
 List event forwarders in the organization with only basic information
+Stability: Long-term
 """
 	eventForwardersForSelection: [EventForwarderForSelection!]!
 """
 A saved FDR feed.
+Stability: Long-term
 """
 	fdrFeed(
 """
@@ -16148,10 +20511,12 @@ The id of the FDR feed to get.
 	): FdrFeed!
 """
 Saved FDR Feeds
+Stability: Long-term
 """
 	fdrFeeds: [FdrFeed!]!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Administrator control for an FDR feed.
+Administrator control for an FDR feed.
+Stability: Long-term
 """
 	fdrFeedControl(
 """
@@ -16160,11 +20525,13 @@ The id of the FDR feed to get administrator control for.
 		id: String!
 	): FdrFeedControl!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Administrator controls for FDR feeds
+Administrator controls for FDR feeds
+Stability: Long-term
 """
 	fdrFeedControls: [FdrFeedControl!]!
 """
-[PREVIEW: Experimental feature, not ready for production.] A saved Ingest feed.
+A saved Ingest feed.
+Stability: Long-term
 """
 	ingestFeed(
 """
@@ -16173,7 +20540,8 @@ The id of the IngestFeed to get.
 		id: String!
 	): IngestFeed!
 """
-[PREVIEW: Experimental feature, not ready for production.] Saved ingest feeds
+Saved ingest feeds
+Stability: Long-term
 """
 	ingestFeeds(
 """
@@ -16203,40 +20571,59 @@ The amount of results to return.
 	): IngestFeedQueryResultSet!
 """
 A parser on the repository.
+Stability: Long-term
 """
 	parser(
 		id: String
 """
-[DEPRECATED: Please use `id` instead. Will be removed in version 1.136]
+[DEPRECATED: Please use `id` instead. Will be removed in version 1.178]
 """
 		name: String
 	): Parser
 """
 Saved parsers.
+Stability: Long-term
 """
 	parsers: [Parser!]!
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	name: RepoOrViewName!
+"""
+Stability: Long-term
+"""
 	description: String
 """
 The point in time the search domain was marked for deletion.
+Stability: Long-term
 """
 	deletedDate: Long
 """
 The point in time the search domain will not be restorable anymore.
+Stability: Long-term
 """
 	permanentlyDeletedAt: Long
+"""
+Stability: Long-term
+"""
 	isStarred: Boolean!
 """
 Search limit in milliseconds, which searches should are limited to.
+Stability: Long-term
 """
 	searchLimitedMs: Long
 """
 Repositories not part of the search limitation.
+Stability: Long-term
 """
 	reposExcludedInSearchLimit: [String!]!
 """
 Returns a specific version of a package given a package version.
+Stability: Long-term
 """
 	packageV2(
 """
@@ -16245,13 +20632,15 @@ The package id of the package to get.
 		packageId: VersionedPackageSpecifier!
 	): Package2!
 """
-[PREVIEW: This may be moved to the Package2 object.] The available versions of a package.
+The available versions of a package.
+Stability: Long-term
 """
 	packageVersions(
 		packageId: UnversionedPackageSpecifier!
 	): [RegistryPackageVersionInfo!]!
 """
 Returns a list of available packages that can be installed.
+Stability: Long-term
 """
 	availablePackages(
 """
@@ -16269,17 +20658,23 @@ Packages with any of these categories will be included.
 	): [PackageRegistrySearchResultItem!]!
 """
 List packages installed on a specific view or repo.
+Stability: Long-term
 """
 	installedPackages: [PackageInstallation!]!
+"""
+Stability: Long-term
+"""
 	hasPackageInstalled(
 		packageId: VersionedPackageSpecifier!
 	): Boolean!
 """
-Users who has access.
+Users who have access.
+Stability: Long-term
 """
 	users: [User!]!
 """
 Users or groups who has access.
+Stability: Long-term
 """
 	usersAndGroups(
 		search: String
@@ -16293,7 +20688,8 @@ The amount of results to return.
 		limit: Int
 	): UsersAndGroupsSearchResultSet!
 """
-[PREVIEW] Search users with a given permission
+Search users with a given permission
+Stability: Preview
 """
 	usersV2(
 """
@@ -16315,13 +20711,24 @@ The amount of results to return.
 	): Users!
 """
 Groups with assigned roles.
+Stability: Long-term
 """
 	groups: [Group!]!
+"""
+Stability: Long-term
+"""
 	starredFields: [String!]!
+"""
+Stability: Long-term
+"""
 	recentQueriesV2: [RecentQuery!]!
+"""
+Stability: Long-term
+"""
 	automaticSearch: Boolean!
 """
 Check if the current user is allowed to perform the given action on the view.
+Stability: Long-term
 """
 	isActionAllowed(
 """
@@ -16331,62 +20738,80 @@ The action to check if a user is allowed to perform on a view.
 	): Boolean!
 """
 Returns the all actions the user is allowed to perform on the view.
+Stability: Long-term
 """
 	allowedViewActions: [ViewAction!]!
 """
 The query prefix prepended to each search in this domain.
+Stability: Long-term
 """
 	viewerQueryPrefix: String!
 """
 All tags from all datasources.
+Stability: Long-term
 """
 	tags: [String!]!
 """
+The resource identifier for this search domain.
+Stability: Short-term
+"""
+	resource: String!
+"""
 All interactions defined on the view.
+Stability: Long-term
 """
 	interactions: [ViewInteraction!]!
 """
 A saved alert
+Stability: Long-term
 """
 	alert(
 		id: String!
 	): Alert!
 """
 Saved alerts.
+Stability: Long-term
 """
 	alerts: [Alert!]!
 """
 A saved dashboard.
+Stability: Long-term
 """
 	dashboard(
 		id: String!
 	): Dashboard!
 """
 All dashboards available on the view.
+Stability: Long-term
 """
 	dashboards: [Dashboard!]!
 """
 A saved filter alert
+Stability: Long-term
 """
 	filterAlert(
 		id: String!
 	): FilterAlert!
 """
 Saved filter alerts.
+Stability: Long-term
 """
 	filterAlerts: [FilterAlert!]!
 """
 A saved aggregate alert
+Stability: Long-term
 """
 	aggregateAlert(
 		id: String!
 	): AggregateAlert!
 """
 Saved aggregate alerts.
+Stability: Long-term
 """
 	aggregateAlerts: [AggregateAlert!]!
 """
 A saved scheduled search.
+Stability: Long-term
 """
 	scheduledSearch(
 """
@@ -16396,10 +20821,12 @@ The id of the scheduled search to get.
 	): ScheduledSearch!
 """
 Saved scheduled searches.
+Stability: Long-term
 """
 	scheduledSearches: [ScheduledSearch!]!
 """
 A saved action.
+Stability: Long-term
 """
 	action(
 """
@@ -16409,20 +20836,37 @@ The id of the action to get.
 	): Action!
 """
 A list of saved actions.
+Stability: Long-term
 """
-	actions: [Action!]!
+	actions(
+"""
+The result will only include actions with the specified ids. Omit to find all actions.
+"""
+		actionIds: [String!]
+	): [Action!]!
 """
 A saved query.
+Stability: Long-term
 """
 	savedQuery(
 		id: String!
 	): SavedQuery!
 """
 Saved queries.
+Stability: Long-term
 """
 	savedQueries: [SavedQuery!]!
+"""
+Stability: Long-term
+"""
 	defaultQuery: SavedQuery
+"""
+Stability: Long-term
+"""
 	files: [File!]!
+"""
+Stability: Long-term
+"""
 	fileFieldSearch(
 """
 Name of the csv or json file to retrieve the field entries from.
@@ -16451,10 +20895,12 @@ Maximum number of values to retrieve from the file.
 	): [[DictionaryEntryType!]!]!
 """
 Saved scheduled reports.
+Stability: Long-term
 """
 	scheduledReports: [ScheduledReport!]!
 """
 Saved scheduled report.
+Stability: Long-term
 """
 	scheduledReport(
 """
@@ -16484,24 +20930,69 @@ enum RepositoryType {
 }
 
 type RepositoryUsageValue {
+"""
+Stability: Long-term
+"""
 	name: String
+"""
+Stability: Long-term
+"""
 	valueBytes: Long!
+"""
+Stability: Long-term
+"""
 	percentage: Float!
+"""
+Stability: Long-term
+"""
 	id: String!
 }
 
 type Role {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	displayName: String!
 	color: String
+"""
+Stability: Long-term
+"""
 	description: String
+"""
+Stability: Long-term
+"""
 	viewPermissions: [Permission!]!
+"""
+Stability: Long-term
+"""
 	systemPermissions: [SystemPermission!]!
+"""
+Stability: Long-term
+"""
 	organizationPermissions: [OrganizationPermission!]!
+"""
+Stability: Long-term
+"""
 	organizationManagementPermissions: [OrganizationManagementPermission!]!
+"""
+Stability: Long-term
+"""
 	groupsCount: Int!
+"""
+Stability: Long-term
+"""
 	usersCount: Int!
+"""
+Stability: Long-term
+"""
 	users: [User!]!
+"""
+Stability: Long-term
+"""
 	groupsV2(
 		search: String
 		userId: String
@@ -16516,14 +21007,27 @@ The number of results to skip or the offset to use. For instance if implementing
 """
 		skip: Int
 	): GroupResultSetType!
+"""
+Stability: Long-term
+"""
 	groups: [Group!]!
+"""
+Stability: Preview
+"""
+	readonlyDefaultRole: ReadonlyDefaultRole
 }
 
 """
 A page of roles.
 """
 type RolePage {
+"""
+Stability: Long-term
+"""
 	pageInfo: PageType!
+"""
+Stability: Long-term
+"""
 	page: [Role!]!
 }
 
@@ -16533,10 +21037,12 @@ The roles query result set.
 type RolesResultSetType {
 """
 The total number of matching results
+Stability: Long-term
 """
 	totalResults: Int!
 """
 The paginated result set
+Stability: Long-term
 """
 	results: [Role!]!
 }
@@ -16547,34 +21053,42 @@ Queries that are currently being executed
 type RunningQueries {
 """
 Number of milliseconds until next update is available
+Stability: Long-term
 """
 	updateAvailableIn: Long!
 """
 Total number of queries being executed
+Stability: Long-term
 """
 	totalNumberOfQueries: Int!
 """
 Total number of live queries being executed
+Stability: Long-term
 """
 	totalNumberOfLiveQueries: Int!
 """
 Total number of clients querying
+Stability: Long-term
 """
 	totalNumberOfClients: Int!
 """
 Total size of skipped bytes for all queries being executed
+Stability: Long-term
 """
 	totalSkippedBytes: Long!
 """
 Total size of included bytes for all queries being executed
+Stability: Long-term
 """
 	totalIncludedBytes: Long!
 """
 Total size of remaining bytes to be processed for all queries being executed
+Stability: Long-term
 """
 	totalQueuedBytes: Long!
 """
 Queries being executed, at most 1000 queries are returned.
+Stability: Long-term
 """
 	queries: [RunningQuery!]!
 }
@@ -16583,81 +21097,173 @@ Queries being executed, at most 1000 queries are returned.
 A query that is currently being executed.
 """
 type RunningQuery {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	clients: [Client!]!
+"""
+Stability: Long-term
+"""
 	initiatedBy: String
+"""
+Stability: Long-term
+"""
 	isLive: Boolean!
+"""
+Stability: Long-term
+"""
 	isHistoricDone: Boolean!
+"""
+Stability: Long-term
+"""
 	queryInput: String!
+"""
+Stability: Long-term
+"""
 	queryPrefix: String!
+"""
+Stability: Long-term
+"""
 	coordinatorId: String!
+"""
+Stability: Long-term
+"""
 	totalWork: Int!
+"""
+Stability: Long-term
+"""
 	workDone: Int!
+"""
+Stability: Long-term
+"""
 	view: String!
 """
 The organization owning the query, if any.
+Stability: Long-term
 """
 	organization: Organization
+"""
+Stability: Long-term
+"""
 	timeInMillis: Long!
+"""
+Stability: Long-term
+"""
 	timeQueuedInMillis: Long!
+"""
+Stability: Long-term
+"""
 	isDashboard: Boolean!
+"""
+Stability: Long-term
+"""
 	estimatedTotalBytes: Long!
+"""
+Stability: Long-term
+"""
 	skippedBytes: Long!
+"""
+Stability: Long-term
+"""
 	includedBytes: Long!
+"""
+Stability: Long-term
+"""
 	processedEvents: Long!
 """
 Static CPU time spent since query started
+Stability: Long-term
 """
 	mapMillis: Float!
 """
 Static CPU time spent the last 30 seconds
+Stability: Long-term
 """
 	deltaMapMillis: Float!
 """
 Live CPU time spent since query started
+Stability: Long-term
 """
 	liveMillis: Float!
 """
 Live CPU time spent the last 30 seconds
+Stability: Long-term
 """
 	deltaLiveMillis: Float!
+"""
+Stability: Long-term
+"""
 	mapAllocations: Long!
+"""
+Stability: Long-term
+"""
 	liveAllocations: Long!
+"""
+Stability: Long-term
+"""
 	reduceAllocations: Long!
+"""
+Stability: Long-term
+"""
 	totalAllocations: Long!
+"""
+Stability: Long-term
+"""
 	deltaTotalAllocations: Long!
+"""
+Stability: Long-term
+"""
 	timeInterval: String!
+"""
+Stability: Long-term
+"""
 	timeZoneOffSetMinutes: Int!
+"""
+Stability: Long-term
+"""
 	queryArgs: String!
+"""
+Stability: Long-term
+"""
 	status: String!
 """
 Total cost calculation.
+Stability: Long-term
 """
 	totalCost: Float!
 """
 Live cost calculation
+Stability: Long-term
 """
 	liveCost: Float!
 """
 Static cost calculation
+Stability: Long-term
 """
 	staticCost: Float!
 """
 Total cost calculation last 30 seconds.
+Stability: Long-term
 """
 	deltaTotalCost: Float!
 """
 Live cost calculation last 30 seconds.
+Stability: Long-term
 """
 	deltaLiveCost: Float!
 """
 Static cost calculation last 30 seconds.
+Stability: Long-term
 """
 	deltaStaticCost: Float!
 }
 
 """
-The format to store archived segments in on AWS S3.
+The format to store archived segments in AWS S3.
 """
 enum S3ArchivingFormat {
 	RAW
@@ -16667,57 +21273,126 @@ enum S3ArchivingFormat {
 """
 Configuration for S3 archiving. E.g. bucket name and region.
 """
-type S3Configuration {
+type S3Configuration implements ArchivingConfiguration{
 """
 S3 bucket name for storing archived data. Example: acme-bucket.
+Stability: Short-term
 """
 	bucket: String!
 """
 The region the S3 bucket belongs to. Example: eu-central-1.
+Stability: Short-term
 """
 	region: String!
 """
 Do not archive logs older than this.
+Stability: Short-term
 """
 	startFrom: DateTime
 """
 Whether the archiving has been disabled.
+Stability: Short-term
 """
 	disabled: Boolean
 """
 The format to store the archived data in on S3.
+Stability: Short-term
 """
 	format: S3ArchivingFormat
 """
 Array of names of tag fields to use in that order in the output file names.
+Stability: Short-term
 """
 	tagOrderInName: [String!]!
+"""
+The ARN of the AWS Role that is assumed when writing to S3.
+Stability: Short-term
+"""
+	roleArn: String
 }
 
 """
 A SAML Identity Provider
 """
 type SamlIdentityProvider implements IdentityProviderAuthentication{
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	domains: [String!]!
+"""
+Stability: Long-term
+"""
 	groupMembershipAttribute: String
+"""
+Stability: Long-term
+"""
 	idpCertificateInBase64: String!
+"""
+Stability: Long-term
+"""
 	idpEntityId: String!
+"""
+Stability: Long-term
+"""
 	signOnUrl: String!
+"""
+Stability: Long-term
+"""
 	authenticationMethod: AuthenticationMethodAuth!
+"""
+Stability: Long-term
+"""
 	userAttribute: String
+"""
+Stability: Long-term
+"""
 	adminAttribute: String
+"""
+Stability: Long-term
+"""
 	adminAttributeMatch: String
+"""
+Stability: Long-term
+"""
+	alternativeIdpCertificateInBase64: String
+"""
+Stability: Long-term
+"""
 	defaultIdp: Boolean!
+"""
+Stability: Long-term
+"""
 	humioManaged: Boolean!
+"""
+Stability: Long-term
+"""
 	lazyCreateUsers: Boolean!
+"""
+Stability: Long-term
+"""
 	debug: Boolean!
 }
 
 type SamlMetadata {
+"""
+Stability: Long-term
+"""
 	entityID: String!
+"""
+Stability: Long-term
+"""
 	signOnUrl: String!
+"""
+Stability: Long-term
+"""
 	certificate: String!
 }
 
@@ -16729,35 +21404,91 @@ type SavedQuery {
 A YAML formatted string that describes the saved query.
 """
 	templateYaml: String!
+"""
+A YAML formatted string that describes the saved query.
+Stability: Long-term
+"""
+	yamlTemplate: YAML!
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	displayName: String!
+"""
+Stability: Long-term
+"""
 	description: String
 	assetType: AssetType!
+"""
+Stability: Long-term
+"""
 	query: HumioQuery!
+"""
+Stability: Long-term
+"""
 	isStarred: Boolean!
+"""
+Stability: Long-term
+"""
 	widgetType: String!
+"""
+Stability: Long-term
+"""
 	options: JSON!
+"""
+Stability: Long-term
+"""
 	packageId: VersionedPackageSpecifier
+"""
+Stability: Long-term
+"""
 	package: PackageInstallation
 """
-[PREVIEW: Saved query interactions feature is under preview] 
+Stability: Long-term
 """
 	interactions: [QueryBasedWidgetInteraction!]!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Allowed asset actions
+Allowed asset actions
+Stability: Preview
 """
 	allowedActions: [AssetAction!]!
+"""
+The resource identifier for this saved query.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 type SavedQueryTemplate {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	displayName: String!
+"""
+Stability: Long-term
+"""
 	yamlTemplate: String!
 }
 
 type ScannedData {
+"""
+Stability: Long-term
+"""
 	currentBytes: Long!
+"""
+Stability: Long-term
+"""
 	limit: UsageLimit!
 }
 
@@ -16767,18 +21498,22 @@ A scheduled report schedule properties
 type Schedule {
 """
 Cron pattern describing the schedule to execute the report on.
+Stability: Long-term
 """
 	cronExpression: String!
 """
 Timezone of the schedule. Examples include UTC, Europe/Copenhagen.
+Stability: Long-term
 """
 	timeZone: String!
 """
 Start date of the active period of the schedule.
+Stability: Long-term
 """
 	startDate: Long!
 """
 Optional end date of the active period of the schedule.
+Stability: Long-term
 """
 	endDate: Long
 }
@@ -16789,88 +21524,114 @@ Information about a scheduled report
 type ScheduledReport {
 """
 Id of the scheduled report.
+Stability: Long-term
 """
 	id: String!
 """
 Name of the scheduled report.
+Stability: Long-term
 """
 	name: String!
 """
 Flag indicating whether a password is defined for the report.
+Stability: Long-term
 """
 	isPasswordDefined: Boolean!
 """
 Flag indicating whether the scheduled report is enabled.
+Stability: Long-term
 """
 	enabled: Boolean!
 """
 Status of the latest report execution.
+Stability: Long-term
 """
 	status: String!
 """
 Description of the scheduled report.
+Stability: Long-term
 """
 	description: String!
 """
 The id of the dashboard the report was created for.
+Stability: Long-term
 """
 	dashboardId: String!
 """
 The dashboard the report was created for.
+Stability: Long-term
 """
 	dashboard: Dashboard!
 """
 Unix timestamp for the last report execution. The timestamp only indicates an attempt, not if it was successful.
+Stability: Long-term
 """
 	timeOfLastReportExecution: Long
 """
 Unix timestamp for the next planned report execution.
+Stability: Long-term
 """
 	timeOfNextPlannedReportExecution: Long
 """
 Last errors encountered while generating the scheduled report.
+Stability: Long-term
 """
 	lastExecutionErrors: [String!]!
 """
 Last warnings encountered while generating the scheduled report.
+Stability: Long-term
 """
 	lastExecutionWarnings: [String!]!
 """
 User who created the report.
+Stability: Long-term
 """
 	createdBy: User
 """
 Date when the report was created.
+Stability: Long-term
 """
 	creationDate: String!
 """
 Start of the relative time interval for the dashboard.
+Stability: Long-term
 """
 	timeIntervalStart: String
 """
 The schedule to run the report by.
+Stability: Long-term
 """
 	schedule: Schedule!
 """
 Labels attached to the scheduled report.
+Stability: Long-term
 """
 	labels: [String!]!
 """
 List of parameter value configurations.
+Stability: Long-term
 """
 	parameters: [ParameterValue!]!
 """
 List of recipients who should receive an email with the generated report.
+Stability: Long-term
 """
 	recipients: [String!]!
 """
 Layout of the scheduled report.
+Stability: Long-term
 """
 	layout: ScheduledReportLayout!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Allowed asset actions
+Allowed asset actions
+Stability: Preview
 """
 	allowedActions: [AssetAction!]!
+"""
+The resource identifier for this scheduled report.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 """
@@ -16879,42 +21640,52 @@ Information about a scheduled report layout
 type ScheduledReportLayout {
 """
 Paper size. Supported types are A4 and Letter.
+Stability: Long-term
 """
 	paperSize: String!
 """
 Paper orientation. Supported types are Landscape and Portrait.
+Stability: Long-term
 """
 	paperOrientation: String!
 """
 Paper layout. Supported types are List and Grid.
+Stability: Long-term
 """
 	paperLayout: String!
 """
 Flag indicating whether to show report description.
+Stability: Long-term
 """
 	showDescription: Boolean
 """
 Flag indicating whether to show title on frontpage.
+Stability: Long-term
 """
 	showTitleFrontpage: Boolean!
 """
 Flag indicating whether to show parameters.
+Stability: Long-term
 """
 	showParameters: Boolean!
 """
 Max number of rows to display in tables.
+Stability: Long-term
 """
 	maxNumberOfRows: Int!
 """
 Flag indicating whether to show title header.
+Stability: Long-term
 """
 	showTitleHeader: Boolean!
 """
 Flag indicating whether to show export date.
+Stability: Long-term
 """
 	showExportDate: Boolean!
 """
 Flag indicating whether to show footer page numbers.
+Stability: Long-term
 """
 	footerShowPageNumbers: Boolean!
 }
@@ -16925,18 +21696,22 @@ Information about a scheduled search
 type ScheduledSearch {
 """
 Id of the scheduled search.
+Stability: Long-term
 """
 	id: String!
 """
 Name of the scheduled search.
+Stability: Long-term
 """
 	name: String!
 """
 Description of the scheduled search.
+Stability: Long-term
 """
 	description: String
 """
 LogScale query to execute.
+Stability: Long-term
 """
 	queryString: String!
 """
@@ -16948,31 +21723,62 @@ End of the relative time interval for the query.
 """
 	end: String!
 """
+Search interval in seconds.
+Stability: Long-term
+"""
+	searchIntervalSeconds: Long!
+"""
+Offset of the search interval in seconds. Only present when 'queryTimestampType' is EventTimestamp.
+Stability: Long-term
+"""
+	searchIntervalOffsetSeconds: Long
+"""
+Maximum number of seconds to wait for ingest delay. Only present when 'queryTimestampType' is IngestTimestamp.
+Stability: Long-term
+"""
+	maxWaitTimeSeconds: Long
+"""
 Time zone of the schedule. Currently this field only supports UTC offsets like 'UTC', 'UTC-01' or 'UTC+12:45'.
+Stability: Long-term
 """
 	timeZone: String!
 """
 Cron pattern describing the schedule to execute the query on.
+Stability: Long-term
 """
 	schedule: String!
 """
-User-defined limit, which caps the number of missed searches to backfill, e.g. in the event of a shutdown.
+User-defined limit, which caps the number of missed searches to backfill, e.g. in the event of a shutdown. If the 'queryTimestampType' is IngestTimestamp this field is not used, but due to backwards compatibility a value of 0 is returned.
 """
 	backfillLimit: Int!
 """
+User-defined limit, which caps the number of missed searches to backfill, e.g. in the event of a shutdown. Only present when 'queryTimestampType' is EventTimestamp.
+Stability: Long-term
+"""
+	backfillLimitV2: Int
+"""
+Timestamp type to use for the query.
+Stability: Long-term
+"""
+	queryTimestampType: QueryTimestampType!
+"""
 Flag indicating whether the scheduled search is enabled.
+Stability: Long-term
 """
 	enabled: Boolean!
 """
 List of Ids for actions to fire on query result.
+Stability: Long-term
 """
 	actions: [String!]!
 """
 List of actions to fire on query result.
+Stability: Long-term
 """
 	actionsV2: [Action!]!
 """
 Id of user which the scheduled search is running as.
+Stability: Long-term
 """
 	runAsUser: User
 """
@@ -16981,26 +21787,32 @@ Unix timestamp for when last query execution finished.
 	lastScheduledSearch: Long
 """
 Unix timestamp for end of search interval for last query execution.
+Stability: Long-term
 """
 	lastExecuted: Long
 """
 Unix timestamp for end of search interval for last query execution that triggered.
+Stability: Long-term
 """
 	lastTriggered: Long
 """
 Unix timestamp for next planned search.
+Stability: Long-term
 """
 	timeOfNextPlannedExecution: Long
 """
 Last error encountered while running the search.
+Stability: Long-term
 """
 	lastError: String
 """
 Last warnings encountered while running the scheduled search.
+Stability: Long-term
 """
 	lastWarnings: [String!]!
 """
 Labels added to the scheduled search.
+Stability: Long-term
 """
 	labels: [String!]!
 """
@@ -17009,29 +21821,66 @@ Flag indicating whether the calling user has 'starred' the scheduled search.
 	isStarred: Boolean!
 """
 A template that can be used to recreate the scheduled search.
+Stability: Long-term
 """
 	yamlTemplate: YAML!
+"""
+Stability: Long-term
+"""
 	packageId: VersionedPackageSpecifier
+"""
+Stability: Long-term
+"""
 	package: PackageInstallation
 """
+User or token used to modify the asset.
+Stability: Preview
+"""
+	modifiedInfo: ModifiedInfo!
+"""
 Ownership of the query run by this scheduled search
+Stability: Long-term
 """
 	queryOwnership: QueryOwnership!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Allowed asset actions
+Allowed asset actions
+Stability: Preview
 """
 	allowedActions: [AssetAction!]!
+"""
+The resource identifier for this scheduled search.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 type ScheduledSearchTemplate {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	displayName: String!
+"""
+Stability: Long-term
+"""
 	yamlTemplate: String!
+"""
+Stability: Long-term
+"""
 	labels: [String!]!
 }
 
 type SchemaField {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	description: String
 }
 
@@ -17041,24 +21890,34 @@ An asset permissions search result entry
 type SearchAssetPermissionsResultEntry {
 """
 The unique id for the Asset
+Stability: Preview
 """
 	assetId: String!
 """
 The name of the Asset
+Stability: Preview
 """
 	assetName: String!
 """
 The type of the Asset
+Stability: Preview
 """
 	assetType: AssetPermissionsAssetType!
 """
 The search domain that the asset belongs to
+Stability: Preview
 """
 	searchDomain: SearchDomain
 """
-The asset permissions assigned to this asset
+The asset actions allowed for this asset
+Stability: Preview
 """
-	permissions: [AssetPermissionOutputEnum!]!
+	permissions: [AssetAction!]!
+"""
+The resource string representation of this asset. Can be used for assigning asset permissions for this asset
+Stability: Preview
+"""
+	resource: String!
 }
 
 """
@@ -17185,6 +22044,10 @@ Common interface for Repositories and Views.
 """
 Common interface for Repositories and Views.
 """
+	resource: String!
+"""
+Common interface for Repositories and Views.
+"""
 	interactions: [ViewInteraction!]!
 """
 Common interface for Repositories and Views.
@@ -17245,7 +22108,9 @@ Common interface for Repositories and Views.
 """
 Common interface for Repositories and Views.
 """
-	actions: [Action!]!
+	actions(
+		actionIds: [String!]
+	): [Action!]!
 """
 Common interface for Repositories and Views.
 """
@@ -17288,10 +22153,68 @@ Common interface for Repositories and Views.
 }
 
 """
+An asset in a search domain.
+"""
+type SearchDomainAsset {
+"""
+The id of the asset.
+Stability: Preview
+"""
+	id: String!
+"""
+The name of the asset.
+Stability: Preview
+"""
+	name: String!
+"""
+The type of the asset.
+Stability: Preview
+"""
+	assetType: AssetPermissionsAssetType!
+"""
+The id of the search domain.
+Stability: Preview
+"""
+	searchDomainId: String!
+"""
+The name of the search domain.
+Stability: Preview
+"""
+	searchDomainName: String!
+"""
+The resource string representation of this asset. Can be used for assigning asset permissions for this asset
+Stability: Preview
+"""
+	resource: String!
+}
+
+"""
+A result set containing information about search domain assets.
+"""
+type SearchDomainAssetsResultSet {
+"""
+The total number of matching results.
+Stability: Preview
+"""
+	totalResults: Int!
+"""
+The paginated result set.
+Stability: Preview
+"""
+	results: [SearchDomainAsset!]!
+}
+
+"""
 A page of searchDomains.
 """
 type SearchDomainPage {
+"""
+Stability: Long-term
+"""
 	pageInfo: PageType!
+"""
+Stability: Long-term
+"""
 	page: [SearchDomain!]!
 }
 
@@ -17299,7 +22222,13 @@ type SearchDomainPage {
 The role assigned in a searchDomain.
 """
 type SearchDomainRole {
+"""
+Stability: Long-term
+"""
 	searchDomain: SearchDomain!
+"""
+Stability: Long-term
+"""
 	role: Role!
 }
 
@@ -17309,10 +22238,12 @@ The search domain search result set
 type SearchDomainSearchResultSet {
 """
 The total number of matching results
+Stability: Long-term
 """
 	totalResults: Int!
 """
 The paginated result set
+Stability: Long-term
 """
 	results: [SearchDomain!]!
 }
@@ -17324,19 +22255,68 @@ enum SearchDomainTypes {
 }
 
 """
+Aggregations for search fleet result set
+"""
+type SearchFleetAggregations {
+"""
+Stability: Short-term
+"""
+	status: SearchFleetStatus!
+"""
+Stability: Short-term
+"""
+	versions: [SearchFleetVersions!]!
+"""
+Stability: Short-term
+"""
+	allVersions: [String!]!
+"""
+Stability: Short-term
+"""
+	os: SearchFleetSystems!
+"""
+Stability: Short-term
+"""
+	ingest: SearchFleetIngest!
+}
+
+"""
 The fleet search has not finished yet
 """
 type SearchFleetInProgress {
+"""
+Stability: Short-term
+"""
 	queryState: String!
+"""
+Stability: Short-term
+"""
 	totalResultsInfo: SearchFleetTotalResultInfo!
 """
 The total number of matching results
+Stability: Short-term
 """
 	totalResults: Int!
 """
+Aggregations of the result set
+Stability: Short-term
+"""
+	aggregations: SearchFleetAggregations
+"""
 The paginated result set
+Stability: Short-term
 """
 	results: [LogCollector!]!
+}
+
+"""
+Ingest aggregation for search fleet result set
+"""
+type SearchFleetIngest {
+"""
+Stability: Short-term
+"""
+	volume: Long!
 }
 
 """
@@ -17345,33 +22325,87 @@ A fleet installation token search result set
 type SearchFleetInstallationTokenResultSet {
 """
 The total number of matching results
+Stability: Short-term
 """
 	totalResults: Int!
 """
 The paginated result set
+Stability: Short-term
 """
 	results: [FleetInstallationToken!]!
+}
+
+enum SearchFleetOsFilter {
+	Unknown
+	MacOS
+	Linux
+	Windows
 }
 
 """
 A fleet search result set
 """
 type SearchFleetResultSet {
+"""
+Stability: Short-term
+"""
 	queryState: String!
+"""
+Stability: Short-term
+"""
 	totalResultsInfo: SearchFleetTotalResultInfo!
 """
 The total number of matching results
+Stability: Short-term
 """
 	totalResults: Int!
 """
+Aggregations of the result set
+Stability: Short-term
+"""
+	aggregations: SearchFleetAggregations
+"""
 The paginated result set
+Stability: Short-term
 """
 	results: [LogCollector!]!
+}
+
+"""
+Status aggregation for search fleet result set
+"""
+type SearchFleetStatus {
+"""
+Stability: Short-term
+"""
+	errored: Int!
+"""
+Stability: Short-term
+"""
+	ok: Int!
 }
 
 enum SearchFleetStatusFilter {
 	Error
 	OK
+}
+
+"""
+Systems aggregation for search fleet result set
+"""
+type SearchFleetSystems {
+"""
+Stability: Short-term
+"""
+	windows: Int!
+"""
+Stability: Short-term
+"""
+	macOs: Int!
+"""
+Stability: Short-term
+"""
+	linux: Int!
 }
 
 """
@@ -17384,11 +22418,45 @@ Query result for search fleet
 """
 union SearchFleetUnion =SearchFleetResultSet | SearchFleetInProgress
 
+input SearchFleetVersionFilter {
+	version: String
+	needsUpdate: Boolean
+}
+
+"""
+Version aggregation for search fleet result set
+"""
+type SearchFleetVersions {
+"""
+Stability: Short-term
+"""
+	version: String!
+"""
+Stability: Short-term
+"""
+	count: Int!
+}
+
 type SearchLinkInteraction {
+"""
+Stability: Long-term
+"""
 	repoOrViewName: RepoOrViewName
+"""
+Stability: Long-term
+"""
 	queryString: String!
+"""
+Stability: Long-term
+"""
 	arguments: [DictionaryEntryType!]!
+"""
+Stability: Long-term
+"""
 	openInNewTab: Boolean!
+"""
+Stability: Long-term
+"""
 	useWidgetTimeWindow: Boolean!
 }
 
@@ -17398,10 +22466,12 @@ A log collector configuration search result set
 type SearchLogCollectorConfigurationResultSet {
 """
 The total number of matching results
+Stability: Short-term
 """
 	totalResults: Int!
 """
 The paginated result set
+Stability: Short-term
 """
 	results: [LogCollectorConfiguration!]!
 }
@@ -17412,10 +22482,12 @@ A log collector group search result set
 type SearchLogCollectorGroupsResultSet {
 """
 The total number of matching results
+Stability: Short-term
 """
 	totalResults: Int!
 """
 The paginated result set
+Stability: Short-term
 """
 	results: [LogCollectorGroup!]!
 }
@@ -17423,11 +22495,24 @@ The paginated result set
 type SearchResult {
 """
 The total number of results that matched the search query. Only [pageSize] elements will be returned.
+Stability: Preview
 """
 	totalResults: Int!
+"""
+Stability: Preview
+"""
 	data: [EntitySearchResultEntity!]!
+"""
+Stability: Preview
+"""
 	cursor: String
+"""
+Stability: Preview
+"""
 	hasNextPage: Boolean!
+"""
+Stability: Preview
+"""
 	hasPreviousPage: Boolean!
 }
 
@@ -17442,16 +22527,52 @@ enum Searchdomain__SortBy {
 A dashboard section.
 """
 type Section {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	title: String
+"""
+Stability: Long-term
+"""
 	description: String
+"""
+Stability: Long-term
+"""
 	collapsed: Boolean!
+"""
+Stability: Long-term
+"""
 	timeSelector: TimeInterval
+"""
+Stability: Long-term
+"""
 	widgetIds: [String!]!
+"""
+Stability: Long-term
+"""
 	order: Int!
 }
 
 scalar SemanticVersion
+
+type SeriesConfig {
+"""
+Stability: Long-term
+"""
+	name: String!
+"""
+Stability: Long-term
+"""
+	title: String
+"""
+Stability: Long-term
+"""
+	color: String
+}
 
 """
 Metadata about a registered service
@@ -17459,22 +22580,27 @@ Metadata about a registered service
 type ServiceMetadata {
 """
 The name of the service
+Stability: Preview
 """
 	name: String!
 """
 The type of the service
+Stability: Preview
 """
 	serviceType: String!
 """
 The endpoint of the service
+Stability: Preview
 """
 	endpointUrl: String!
 """
 The version of the service
+Stability: Preview
 """
 	version: String!
 """
 The health status of the service
+Stability: Preview
 """
 	healthStatus: HealthStatus!
 }
@@ -17485,38 +22611,47 @@ An active session.
 type Session {
 """
 The id of the session
+Stability: Long-term
 """
 	id: String!
 """
 Client info.
+Stability: Long-term
 """
 	clientInfo: String!
 """
 Approximate city from IP
+Stability: Long-term
 """
 	city: String
 """
 Country from IP
+Stability: Long-term
 """
 	country: String
 """
 The IP of the client when the session was created.
+Stability: Long-term
 """
 	ip: String!
 """
 The user that created the session.
+Stability: Long-term
 """
 	user: User!
 """
 The time at which the session was created.
+Stability: Long-term
 """
 	createdAt: Long
 """
 The time at which the session was last active.
+Stability: Long-term
 """
 	lastActivityAt: Long
 """
 If the session is the current session for the user.
+Stability: Long-term
 """
 	isCurrentSession: Boolean!
 }
@@ -17527,10 +22662,12 @@ The session query result set
 type SessionQueryResultSet {
 """
 The total number of matching results
+Stability: Long-term
 """
 	totalResults: Int!
 """
 The paginated result set
+Stability: Long-term
 """
 	results: [Session!]!
 }
@@ -17563,28 +22700,66 @@ enum Severity {
 Represents information about a dashboard shared through a link.
 """
 type SharedDashboard {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	displayName: String!
 """
 The ip filter on the shared dashboard.
+Stability: Long-term
 """
 	ipFilter: IPFilter
+"""
+Stability: Long-term
+"""
 	sharedTimeInterval: SharedDashboardTimeInterval
 """
 The name of the repository or view queries are executed against.
+Stability: Long-term
 """
 	repoOrViewName: RepoOrViewName!
+"""
+Stability: Long-term
+"""
 	widgets: [Widget!]!
+"""
+Stability: Long-term
+"""
 	sections: [Section!]!
+"""
+Stability: Long-term
+"""
+	series: [SeriesConfig!]!
+"""
+The resource identifier for this dashboard.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 """
 Time Interval that is active on all dashboard widgets
 """
 type SharedDashboardTimeInterval {
+"""
+Stability: Long-term
+"""
 	isLive: Boolean!
+"""
+Stability: Long-term
+"""
 	start: String!
+"""
+Stability: Long-term
+"""
 	end: String!
 }
 
@@ -17594,10 +22769,12 @@ Security policies for shared dashboards in the organization
 type SharedDashboardsSecurityPolicies {
 """
 Whether shared dashboard tokens are enabled
+Stability: Short-term
 """
 	sharedDashboardsEnabled: Boolean!
 """
 The IP filter that is enforced on all shared dashboards
+Stability: Short-term
 """
 	enforceIpFilter: IPFilter
 }
@@ -17620,14 +22797,17 @@ Social login configuration for the organization
 type SocialLoginSettings {
 """
 Social provider
+Stability: Short-term
 """
 	provider: SocialProviderProfile!
 """
 Filter
+Stability: Short-term
 """
 	filter: SocialLoginField!
 """
 Allowed users
+Stability: Short-term
 """
 	allowList: [User!]!
 }
@@ -17639,12 +22819,11 @@ enum SocialProviderProfile {
 }
 
 """
-The sort by options for asset permissions.
+The sort by options for assets.
 """
 enum SortBy {
 	Name
 	SearchDomain
-	Permission
 }
 
 """
@@ -17682,38 +22861,42 @@ Returns a query that gives the underlying events for some specified fields. quer
 """
 type SourceEventsQueryResultType {
 """
-[PREVIEW: Internal testing.] 
+Stability: Preview
 """
 	query: String
 """
-[PREVIEW: Internal testing.] 
+Stability: Preview
 """
 	queryArguments: [String!]!
 """
-[PREVIEW: Internal testing.] 
+Stability: Preview
 """
 	diagnostics: [QueryDiagnostic!]!
 }
 
 type StorageOnDay {
+"""
+Stability: Long-term
+"""
 	date: DateTime!
+"""
+Stability: Long-term
+"""
 	storageBytes: Long!
+"""
+Stability: Long-term
+"""
 	limit: UsageLimit!
 }
 
-"""
-A cluster storage partition. It assigns cluster nodes with the responsibility of storing a segment data.
-"""
-type StoragePartition {
-	id: Int!
-"""
-A list of ids for the nodes responsible for the partition. The list is ordered so that the first node is the primary node and the rest are followers.
-"""
-	nodeIds: [Int!]!
-}
-
 type StoredData {
+"""
+Stability: Long-term
+"""
 	currentBytes: Long!
+"""
+Stability: Long-term
+"""
 	limit: UsageLimit!
 }
 
@@ -17723,14 +22906,17 @@ Subdomain configuration for the organization
 type SubdomainConfig {
 """
 The primary subdomain of the organization
+Stability: Short-term
 """
 	primarySubdomain: String!
 """
 The secondary subdomains of the organization
+Stability: Short-term
 """
 	secondarySubdomains: [String!]!
 """
 EnforceSubdomain, if set to true the organization can only be accessed by the subdomain, otherwise it can also be accessed directly at the cluster domain url.
+Stability: Short-term
 """
 	enforceSubdomains: Boolean!
 }
@@ -17738,6 +22924,7 @@ EnforceSubdomain, if set to true the organization can only be accessed by the su
 type SuggestedAlertTypeInfo {
 """
 The suggested alert type.
+Stability: Short-term
 """
 	alertType: AlertType!
 }
@@ -17784,7 +22971,13 @@ enum SystemPermission {
 A tag on a datasource.
 """
 type Tag {
+"""
+Stability: Short-term
+"""
 	key: String!
+"""
+Stability: Short-term
+"""
 	value: String!
 }
 
@@ -17792,12 +22985,24 @@ type Tag {
 Describes the number of groups that tag values get distributed into for a given tag.
 """
 type TagGroupingRule {
+"""
+Stability: Short-term
+"""
 	tagName: String!
+"""
+Stability: Short-term
+"""
 	groupCount: Int!
 }
 
 type TagInfo {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	value: String!
 }
 
@@ -17805,7 +23010,13 @@ type TagInfo {
 A time interval that represents either a fixed or relative time range.
 """
 type TimeInterval {
+"""
+Stability: Long-term
+"""
 	start: String!
+"""
+Stability: Long-term
+"""
 	end: String!
 }
 
@@ -17845,10 +23056,12 @@ The token query result set
 type TokenQueryResultSet {
 """
 The total number of matching results
+Stability: Long-term
 """
 	totalResults: Int!
 """
 The paginated result set
+Stability: Long-term
 """
 	results: [Token!]!
 }
@@ -17859,62 +23072,77 @@ Security policies for tokens in the organization
 type TokenSecurityPolicies {
 """
 Whether personal user tokens are enabled
+Stability: Short-term
 """
 	personalUserTokensEnabled: Boolean!
 """
 Maximum time in ms a personal user token can be used before expiring (TTL)
+Stability: Short-term
 """
 	personalUserTokensEnforceExpirationAfterMs: Long
 """
 The IP filter that is enforced on all personal user tokens
+Stability: Short-term
 """
 	personalUserTokensEnforceIpFilter: IPFilter
 """
 Whether view permission tokens are enabled
+Stability: Short-term
 """
 	viewPermissionTokensEnabled: Boolean!
 """
 Maximum time in ms a view permission token can be used before expiring (TTL)
+Stability: Short-term
 """
 	viewPermissionTokensEnforceExpirationAfterMs: Long
 """
 The IP filter that is enforced on all view permission tokens
+Stability: Short-term
 """
 	viewPermissionTokensEnforceIpFilter: IPFilter
 """
 Whether it is allowed to change permissions on existing view permission tokens
+Stability: Short-term
 """
 	viewPermissionTokensAllowPermissionUpdates: Boolean
 """
 Whether organization permission tokens are enabled
+Stability: Short-term
 """
 	organizationPermissionTokensEnabled: Boolean!
 """
 Maximum time in ms a organization permission token can be used before expiring (TTL)
+Stability: Short-term
 """
 	organizationPermissionTokensEnforceExpirationAfterMs: Long
 """
 The IP filter that is enforced on all organization permission tokens
+Stability: Short-term
 """
 	organizationPermissionTokensEnforceIpFilter: IPFilter
 """
 Whether it is allowed to change permissions on existing organization permission tokens
+Stability: Short-term
 """
 	organizationPermissionTokensAllowPermissionUpdates: Boolean
 """
 Whether system permission tokens are enabled
+Stability: Short-term
 """
 	systemPermissionTokensEnabled: Boolean!
 """
 Maximum time in ms a system permission token can be used before expiring (TTL)
+Stability: Short-term
 """
 	systemPermissionTokensEnforceExpirationAfterMs: Long
 """
 The IP filter that is enforced on all system permission tokens
+Stability: Short-term
 """
 	systemPermissionTokensEnforceIpFilter: IPFilter
 """
 Whether it is allowed to change permissions on existing system permission tokens
+Stability: Short-term
 """
 	systemPermissionTokensAllowPermissionUpdates: Boolean
 }
@@ -17954,6 +23182,9 @@ enum UiTheme {
 }
 
 type UnlimitedUsage {
+"""
+Stability: Long-term
+"""
 	unlimited: Boolean!
 }
 
@@ -17963,46 +23194,57 @@ An unsaved aggregate alert.
 type UnsavedAggregateAlert {
 """
 Name of the aggregate alert.
+Stability: Long-term
 """
 	name: String!
 """
 Description of the aggregate alert.
+Stability: Long-term
 """
 	description: String
 """
 LogScale query to execute.
+Stability: Long-term
 """
 	queryString: String!
 """
 List of actions to fire on query result.
+Stability: Long-term
 """
 	actions: [Action!]!
 """
 Labels attached to the aggregate alert.
+Stability: Long-term
 """
 	labels: [String!]!
 """
 Flag indicating whether the aggregate alert is enabled.
+Stability: Long-term
 """
 	enabled: Boolean!
 """
 Throttle time in seconds.
+Stability: Long-term
 """
 	throttleTimeSeconds: Long!
 """
 A field to throttle on. Can only be set if throttleTimeSeconds is set.
+Stability: Long-term
 """
 	throttleField: String
 """
 Timestamp type to use for a query.
+Stability: Long-term
 """
 	queryTimestampType: QueryTimestampType!
 """
 Trigger mode used for triggering the alert.
+Stability: Long-term
 """
 	triggerMode: TriggerMode!
 """
 Search interval in seconds.
+Stability: Long-term
 """
 	searchIntervalSeconds: Long!
 }
@@ -18013,38 +23255,47 @@ An unsaved alert.
 type UnsavedAlert {
 """
 Name of the alert.
+Stability: Long-term
 """
 	name: String!
 """
 Description of the alert.
+Stability: Long-term
 """
 	description: String
 """
 LogScale query to execute.
+Stability: Long-term
 """
 	queryString: String!
 """
 Start of the relative time interval for the query.
+Stability: Long-term
 """
 	queryStart: String!
 """
 Throttle time in milliseconds.
+Stability: Long-term
 """
 	throttleTimeMillis: Long!
 """
 Field to throttle on.
+Stability: Long-term
 """
 	throttleField: String
 """
 List of ids for actions to fire on query result.
+Stability: Long-term
 """
 	actions: [Action!]!
 """
 Labels attached to the alert.
+Stability: Long-term
 """
 	labels: [String!]!
 """
 Flag indicating whether the alert is enabled.
+Stability: Long-term
 """
 	enabled: Boolean!
 }
@@ -18055,34 +23306,42 @@ An unsaved filter alert.
 type UnsavedFilterAlert {
 """
 Name of the filter alert.
+Stability: Long-term
 """
 	name: String!
 """
 Description of the filter alert.
+Stability: Long-term
 """
 	description: String
 """
 LogScale query to execute.
+Stability: Long-term
 """
 	queryString: String!
 """
 List of ids for actions to fire on query result.
+Stability: Long-term
 """
 	actions: [Action!]!
 """
 Labels attached to the filter alert.
+Stability: Long-term
 """
 	labels: [String!]!
 """
 Flag indicating whether the filter alert is enabled.
+Stability: Long-term
 """
 	enabled: Boolean!
 """
 Throttle time in seconds.
+Stability: Long-term
 """
 	throttleTimeSeconds: Long
 """
 A field to throttle on. Can only be set if throttleTimeSeconds is set.
+Stability: Long-term
 """
 	throttleField: String
 }
@@ -18093,22 +23352,32 @@ The contents of a parser YAML template in structured form. The parser needs to b
 type UnsavedParser {
 """
 Name of the parser.
+Stability: Long-term
 """
 	name: String!
 """
+The description of the parser.
+Stability: Long-term
+"""
+	description: String
+"""
 The parser script that is executed for every incoming event.
+Stability: Long-term
 """
 	script: String!
 """
 Fields that are used as tags.
+Stability: Long-term
 """
 	fieldsToTag: [String!]!
 """
 A list of fields that will be removed from the event before it's parsed. These fields will not be included when calculating usage.
+Stability: Long-term
 """
 	fieldsToBeRemovedBeforeParsing: [String!]!
 """
 Test cases that can be used to help verify that the parser works as expected.
+Stability: Long-term
 """
 	testCases: [ParserTestCase!]!
 }
@@ -18119,14 +23388,17 @@ An unsaved scheduled search.
 type UnsavedScheduledSearch {
 """
 Name of the scheduled search.
+Stability: Long-term
 """
 	name: String!
 """
 Description of the scheduled search.
+Stability: Long-term
 """
 	description: String
 """
 LogScale query to execute.
+Stability: Long-term
 """
 	queryString: String!
 """
@@ -18139,26 +23411,56 @@ End of the relative time interval for the query.
 	end: String!
 """
 Cron pattern describing the schedule to execute the query on.
+Stability: Long-term
 """
 	schedule: String!
 """
 Time zone of the schedule. Currently this field only supports UTC offsets like 'UTC', 'UTC-01' or 'UTC+12:45'.
+Stability: Long-term
 """
 	timeZone: String!
 """
-User-defined limit, which caps the number of missed searches to backfill, e.g. in the event of a shutdown.
+User-defined limit, which caps the number of missed searches to backfill, e.g. in the event of a shutdown. If the 'queryTimestampType' is IngestTimestamp this field is not used, but due to backwards compatibility a value of 0 is returned.
 """
 	backfillLimit: Int!
 """
+User-defined limit, which caps the number of missed searches to backfill, e.g. in the event of a shutdown. Only present when 'queryTimestampType' is EventTimestamp.
+Stability: Long-term
+"""
+	backfillLimitV2: Int
+"""
+Search interval in seconds.
+Stability: Long-term
+"""
+	searchIntervalSeconds: Long!
+"""
+Offset of the search interval in seconds. Only present when 'queryTimestampType' is EventTimestamp.
+Stability: Long-term
+"""
+	searchIntervalOffsetSeconds: Long
+"""
+Maximum number of seconds to wait for ingest delay. Only present when 'queryTimestampType' is IngestTimestamp.
+Stability: Long-term
+"""
+	maxWaitTimeSeconds: Long
+"""
+Timestamp type to use for the query.
+Stability: Long-term
+"""
+	queryTimestampType: QueryTimestampType!
+"""
 List of Ids for actions to fire on query result.
+Stability: Long-term
 """
 	actions: [Action!]!
 """
 Labels attached to the scheduled search.
+Stability: Long-term
 """
 	labels: [String!]!
 """
 Flag indicating whether the scheduled search is enabled.
+Stability: Long-term
 """
 	enabled: Boolean!
 }
@@ -18166,7 +23468,13 @@ Flag indicating whether the scheduled search is enabled.
 scalar UnversionedPackageSpecifier
 
 type UpdateParametersInteraction {
+"""
+Stability: Long-term
+"""
 	arguments: [DictionaryEntryType!]!
+"""
+Stability: Long-term
+"""
 	useWidgetTimeWindow: Boolean!
 }
 
@@ -18174,13 +23482,39 @@ type UpdateParametersInteraction {
 An uploaded file snapshot.
 """
 type UploadedFileSnapshot {
+"""
+Stability: Long-term
+"""
 	nameAndPath: FileNameAndPath!
+"""
+Stability: Long-term
+"""
 	headers: [String!]!
+"""
+Stability: Long-term
+"""
 	lines: [[String!]!]!
+"""
+Stability: Long-term
+"""
 	totalLinesCount: Long!
+"""
+Stability: Long-term
+"""
 	limit: Int!
+"""
+Stability: Long-term
+"""
 	offset: Int!
+"""
+Stability: Long-term
+"""
 	filterString: String
+"""
+The resource identifier for this file.
+Stability: Short-term
+"""
+	resource: String!
 }
 
 scalar UrlOrData
@@ -18191,34 +23525,62 @@ Contractual usage limit. If you are above you should renegotiate your contract.
 union UsageLimit =UsageLimitDefined | UnlimitedUsage
 
 type UsageLimitDefined {
+"""
+Stability: Long-term
+"""
 	limit: Long!
 }
 
 type UsageOnDay {
+"""
+Stability: Long-term
+"""
 	date: DateTime!
+"""
+Stability: Long-term
+"""
 	ingestBytes: Long!
+"""
+Stability: Long-term
+"""
 	averageIngestBytes: Long
+"""
+Stability: Long-term
+"""
 	limit: UsageLimit!
 }
 
 type UsageStats {
 """
 Current usage measurements and limits for ingest, storage, scanned data and users
+Stability: Long-term
 """
 	currentStats(
 		queryId: String
 	): CurrentUsageQueryResult!
+"""
+Stability: Long-term
+"""
 	monthlyIngest(
 		month: Int!
 		year: Int!
 		queryId: String
 	): MonthlyIngestQueryResult!
+"""
+Stability: Long-term
+"""
 	monthlyStoredData(
 		month: Int!
 		year: Int!
 		queryId: String
 	): MonthlyStorageQueryResult!
+"""
+Stability: Long-term
+"""
 	firstUsageTimeStamp: Long!
+"""
+Stability: Long-term
+"""
 	repositoriesIngest(
 		month: Int!
 		year: Int!
@@ -18242,6 +23604,9 @@ Choose the order in which the results are returned.
 		sortBy: RepositoriesUsageQuerySortBy!
 		queryId: String
 	): RepositoriesUsageQueryResultTypes!
+"""
+Stability: Long-term
+"""
 	repositoriesStorage(
 		month: Int!
 		year: Int!
@@ -18271,24 +23636,70 @@ Choose the order in which the results are returned.
 A user profile.
 """
 type User {
+"""
+Stability: Long-term
+"""
 	id: String!
 """
 fullName if present, otherwise username.
+Stability: Long-term
 """
 	displayName: String!
+"""
+Stability: Long-term
+"""
 	username: String!
+"""
+Stability: Long-term
+"""
 	isRoot: Boolean!
+"""
+Stability: Long-term
+"""
 	isOrgRoot: Boolean!
+"""
+Stability: Long-term
+"""
 	fullName: String
+"""
+Stability: Long-term
+"""
 	firstName: String
+"""
+Stability: Long-term
+"""
 	lastName: String
+"""
+Stability: Long-term
+"""
 	phoneNumber: String
+"""
+Stability: Long-term
+"""
 	email: String
+"""
+Stability: Long-term
+"""
 	picture: String
+"""
+Stability: Long-term
+"""
 	createdAt: DateTime!
+"""
+Stability: Long-term
+"""
 	countryCode: String
+"""
+Stability: Long-term
+"""
 	stateCode: String
+"""
+Stability: Long-term
+"""
 	company: String
+"""
+Stability: Long-term
+"""
 	userOrGroupSearchDomainRoles(
 		search: String
 """
@@ -18300,35 +23711,46 @@ The amount of results to return.
 """
 		limit: Int
 	): UserOrGroupSearchDomainRoleResultSet!
+"""
+Stability: Long-term
+"""
 	groupSearchDomainRoles: [GroupSearchDomainRole!]!
+"""
+Stability: Long-term
+"""
 	searchDomainRoles(
 		searchDomainId: String
 	): [SearchDomainRole!]!
 	searchDomainRolesByName(
 		searchDomainName: String!
 	): SearchDomainRole
+"""
+Stability: Long-term
+"""
 	searchDomainRolesBySearchDomainName(
 		searchDomainName: String!
 	): [SearchDomainRole!]!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Get asset permissions assigned to the user for the specific asset
+Get allowed asset actions for the user on a specific asset and explain how these actions have been granted
+Stability: Preview
 """
-	assetPermissions(
+	allowedAssetActionsBySource(
 """
 Id of the asset
 """
 		assetId: String!
 """
-Asset type
+The type of the asset.
 """
 		assetType: AssetPermissionsAssetType!
 """
 Search domain id
 """
 		searchDomainId: String
-	): AssetPermissionsForUser!
+	): [AssetActionsBySource!]!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] Search for asset permissions for the user
+Search for asset permissions for the user. Only search for asset name is supported with regards to the ${SearchFilterArg.name} argument.
+Stability: Preview
 """
 	searchAssetPermissions(
 """
@@ -18348,28 +23770,25 @@ Choose the order in which the results are returned.
 """
 		orderBy: OrderBy
 """
-The sort by options for asset permissions.
+The sort by options for assets. Asset name is default
 """
 		sortBy: SortBy
 """
-Asset type
+List of asset types
 """
-		assetType: AssetPermissionsAssetType!
+		assetTypes: [AssetPermissionsAssetType!]
 """
-List of search domain id's to search within
+List of search domain id's to search within. Null or empty list is interpreted as all search domains
 """
 		searchDomainIds: [String!]
 """
-Include UpdateAsset and/or DeleteAsset permission assignments
+Include Read, Update and/or Delete permission assignments. The filter will accept all assets if the argument Null or the empty list.
 """
-		permissions: AssetPermissionInputEnum
-"""
-If this is set to true, the search will also return all assets, that the user has not been assigned any permissions for
-"""
-		includeUnassignedAssets: Boolean
+		permissions: [AssetAction!]
 	): AssetPermissionSearchResultSet!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] The roles assigned to the user through a group.
+The roles assigned to the user through a group.
+Stability: Preview
 """
 	rolesV2(
 		search: String
@@ -18385,7 +23804,8 @@ The number of results to skip or the offset to use. For instance if implementing
 		searchInGroups: Boolean
 	): RolesResultSetType!
 """
-[PREVIEW: Feature currently being iterated on. Changes may occur.] The groups the user is a member of.
+The groups the user is a member of.
+Stability: Preview
 """
 	groupsV2(
 		search: String
@@ -18402,10 +23822,12 @@ The number of results to skip or the offset to use. For instance if implementing
 	): GroupResultSetType!
 """
 The groups the user is a member of.
+Stability: Long-term
 """
 	groups: [Group!]!
 """
 Permissions of the user.
+Stability: Long-term
 """
 	permissions(
 """
@@ -18423,17 +23845,28 @@ A page of user permissions.
 	): UserPermissionsPage!
 """
 Returns the actions the user is allowed to perform in the system.
+Stability: Long-term
 """
 	allowedSystemActions: [SystemAction!]!
 """
 Returns the actions the user is allowed to perform in the organization.
+Stability: Long-term
 """
 	allowedOrganizationActions: [OrganizationAction!]!
 }
 
 type UserAndTimestamp {
+"""
+Stability: Long-term
+"""
 	username: String!
+"""
+Stability: Long-term
+"""
 	user: User
+"""
+Stability: Long-term
+"""
 	timestamp: DateTime!
 }
 
@@ -18441,6 +23874,22 @@ type UserAndTimestamp {
 A user or a group
 """
 union UserOrGroup =Group | User
+
+"""
+An asset permission search result set
+"""
+type UserOrGroupAssetPermissionSearchResultSet {
+"""
+The total number of matching results
+Stability: Preview
+"""
+	totalResults: Int!
+"""
+The paginated result set
+Stability: Preview
+"""
+	results: [UserOrGroupTypeAndPermissions!]!
+}
 
 """
 A user or a group role
@@ -18453,17 +23902,53 @@ A page of users or group roles.
 type UserOrGroupSearchDomainRoleResultSet {
 """
 The total number of matching results
+Stability: Long-term
 """
 	totalResults: Int!
+"""
+Stability: Long-term
+"""
 	results: [UserOrGroupSearchDomainRole!]!
+"""
+Stability: Long-term
+"""
+	totalSearchDomains: Int!
+}
+
+"""
+User or groups and its asset permissions
+"""
+type UserOrGroupTypeAndPermissions {
+"""
+Stability: Preview
+"""
+	userOrGroup: UserOrGroup!
+"""
+Stability: Preview
+"""
+	assetPermissions: [AssetAction!]!
+"""
+The type of the Asset
+Stability: Preview
+"""
+	assetType: AssetPermissionsAssetType!
 }
 
 """
 Permissions of the user.
 """
 type UserPermissions {
+"""
+Stability: Short-term
+"""
 	searchDomain: SearchDomain!
+"""
+Stability: Short-term
+"""
 	queryPrefix: String!
+"""
+Stability: Short-term
+"""
 	viewPermissions: [Permission!]!
 }
 
@@ -18471,7 +23956,13 @@ type UserPermissions {
 A page of user permissions.
 """
 type UserPermissionsPage {
+"""
+Stability: Short-term
+"""
 	pageInfo: PageType!
+"""
+Stability: Short-term
+"""
 	page: [UserPermissions!]!
 }
 
@@ -18481,41 +23972,79 @@ The users query result set.
 type UserResultSetType {
 """
 The total number of matching results
+Stability: Long-term
 """
 	totalResults: Int!
 """
 The paginated result set
+Stability: Long-term
 """
 	results: [User!]!
 }
 
 type UserSettings {
-	isCommunityMessageDismissed: Boolean!
-	isGettingStartedMessageDismissed: Boolean!
-	isWelcomeMessageDismissed: Boolean!
-	isEventListOrderedWithNewestAtBottom: Boolean!
-	isPackageDocsMessageDismissed: Boolean!
-	isFieldPanelOpenByDefault: Boolean!
-	isAutomaticSearchEnabled: Boolean!
-	isDarkModeMessageDismissed: Boolean!
+"""
+Stability: Long-term
+"""
 	uiTheme: UiTheme!
+"""
+Stability: Long-term
+"""
 	starredDashboards: [String!]!
+"""
+Stability: Long-term
+"""
 	starredSearchDomains: [String!]!
 	starredAlerts: [String!]!
 """
-[PREVIEW: We are iterating on our feature announcements, and may change this again] 
+Stability: Preview
 """
 	featureAnnouncementsToShow: [FeatureAnnouncement!]!
+"""
+Stability: Long-term
+"""
 	isQuickStartCompleted: Boolean!
 """
 Default timezone preference
+Stability: Long-term
 """
 	defaultTimeZone: String
 """
-[PREVIEW: Experimental user setting value for a feature which allow for automatic highlighting on the search page] 
+Stability: Preview
 """
 	isAutomaticHighlightingEnabled: Boolean!
-	isResizableQueryFieldMessageDismissed: Boolean!
+"""
+Stability: Short-term
+"""
+	isCommunityMessageDismissed: Boolean!
+"""
+Stability: Short-term
+"""
+	isGettingStartedMessageDismissed: Boolean!
+"""
+Stability: Short-term
+"""
+	isWelcomeMessageDismissed: Boolean!
+"""
+Stability: Short-term
+"""
+	isEventListOrderedWithNewestAtBottom: Boolean!
+"""
+Stability: Short-term
+"""
+	isPackageDocsMessageDismissed: Boolean!
+"""
+Stability: Short-term
+"""
+	isFieldPanelOpenByDefault: Boolean!
+"""
+Stability: Short-term
+"""
+	isAutomaticSearchEnabled: Boolean!
+"""
+Stability: Short-term
+"""
+	isDarkModeMessageDismissed: Boolean!
 }
 
 """
@@ -18524,10 +24053,12 @@ A paginated set of users
 type Users {
 """
 The total number of users
+Stability: Long-term
 """
 	totalUsers: Int!
 """
 The paginated set of users
+Stability: Long-term
 """
 	users: [User!]!
 }
@@ -18538,13 +24069,23 @@ A page of users and groups.
 type UsersAndGroupsSearchResultSet {
 """
 The total number of matching results
+Stability: Long-term
 """
 	totalResults: Int!
+"""
+Stability: Long-term
+"""
 	results: [UserOrGroup!]!
 }
 
 type UsersLimit {
+"""
+Stability: Long-term
+"""
 	currentBytes: Int!
+"""
+Stability: Long-term
+"""
 	limit: UsageLimit!
 }
 
@@ -18552,7 +24093,13 @@ type UsersLimit {
 A page of users.
 """
 type UsersPage {
+"""
+Stability: Long-term
+"""
 	pageInfo: PageType!
+"""
+Stability: Long-term
+"""
 	page: [User!]!
 }
 
@@ -18562,14 +24109,22 @@ scalar VersionedPackageSpecifier
 Represents information about a view, pulling data from one or several repositories.
 """
 type View implements SearchDomain{
+"""
+Stability: Long-term
+"""
 	connections: [ViewConnection!]!
+"""
+Stability: Short-term
+"""
 	crossOrgConnections: [CrossOrgViewConnection!]!
 """
-[PREVIEW: Experimental feature, not ready for production.] Cluster connections.
+Cluster connections.
+Stability: Short-term
 """
 	clusterConnections: [ClusterConnection!]!
 """
 A specific connection.
+Stability: Short-term
 """
 	clusterConnection(
 """
@@ -18578,35 +24133,54 @@ The id of the connection to get.
 		id: String!
 	): ClusterConnection!
 """
-[PREVIEW: Experimental feature, not ready for production.] Check all this search domain's cluster connections.
+Check all this search domain's cluster connections.
+Stability: Short-term
 """
 	checkClusterConnections: [ClusterConnectionStatus!]!
 """
-[PREVIEW: Experimental feature, not ready for production.] True if the view is federated, false otherwise.
+True if the view is federated, false otherwise.
+Stability: Preview
 """
 	isFederated: Boolean!
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	name: RepoOrViewName!
+"""
+Stability: Long-term
+"""
 	description: String
 """
 The point in time the search domain was marked for deletion.
+Stability: Long-term
 """
 	deletedDate: Long
 """
 The point in time the search domain will not be restorable anymore.
+Stability: Long-term
 """
 	permanentlyDeletedAt: Long
+"""
+Stability: Long-term
+"""
 	isStarred: Boolean!
 """
 Search limit in milliseconds, which searches should are limited to.
+Stability: Long-term
 """
 	searchLimitedMs: Long
 """
 Repositories not part of the search limitation.
+Stability: Long-term
 """
 	reposExcludedInSearchLimit: [String!]!
 """
 Returns a specific version of a package given a package version.
+Stability: Long-term
 """
 	packageV2(
 """
@@ -18615,13 +24189,15 @@ The package id of the package to get.
 		packageId: VersionedPackageSpecifier!
 	): Package2!
 """
-[PREVIEW: This may be moved to the Package2 object.] The available versions of a package.
+The available versions of a package.
+Stability: Long-term
 """
 	packageVersions(
 		packageId: UnversionedPackageSpecifier!
 	): [RegistryPackageVersionInfo!]!
 """
 Returns a list of available packages that can be installed.
+Stability: Long-term
 """
 	availablePackages(
 """
@@ -18639,17 +24215,23 @@ Packages with any of these categories will be included.
 	): [PackageRegistrySearchResultItem!]!
 """
 List packages installed on a specific view or repo.
+Stability: Long-term
 """
 	installedPackages: [PackageInstallation!]!
+"""
+Stability: Long-term
+"""
 	hasPackageInstalled(
 		packageId: VersionedPackageSpecifier!
 	): Boolean!
 """
-Users who has access.
+Users who have access.
+Stability: Long-term
 """
 	users: [User!]!
 """
 Users or groups who has access.
+Stability: Long-term
 """
 	usersAndGroups(
 		search: String
@@ -18663,7 +24245,8 @@ The amount of results to return.
 		limit: Int
 	): UsersAndGroupsSearchResultSet!
 """
-[PREVIEW] Search users with a given permission
+Search users with a given permission
+Stability: Preview
 """
 	usersV2(
 """
@@ -18685,13 +24268,24 @@ The amount of results to return.
 	): Users!
 """
 Groups with assigned roles.
+Stability: Long-term
 """
 	groups: [Group!]!
+"""
+Stability: Long-term
+"""
 	starredFields: [String!]!
+"""
+Stability: Long-term
+"""
 	recentQueriesV2: [RecentQuery!]!
+"""
+Stability: Long-term
+"""
 	automaticSearch: Boolean!
 """
 Check if the current user is allowed to perform the given action on the view.
+Stability: Long-term
 """
 	isActionAllowed(
 """
@@ -18701,62 +24295,80 @@ The action to check if a user is allowed to perform on a view.
 	): Boolean!
 """
 Returns the all actions the user is allowed to perform on the view.
+Stability: Long-term
 """
 	allowedViewActions: [ViewAction!]!
 """
 The query prefix prepended to each search in this domain.
+Stability: Long-term
 """
 	viewerQueryPrefix: String!
 """
 All tags from all datasources.
+Stability: Long-term
 """
 	tags: [String!]!
 """
+The resource identifier for this search domain.
+Stability: Short-term
+"""
+	resource: String!
+"""
 All interactions defined on the view.
+Stability: Long-term
 """
 	interactions: [ViewInteraction!]!
 """
 A saved alert
+Stability: Long-term
 """
 	alert(
 		id: String!
 	): Alert!
 """
 Saved alerts.
+Stability: Long-term
 """
 	alerts: [Alert!]!
 """
 A saved dashboard.
+Stability: Long-term
 """
 	dashboard(
 		id: String!
 	): Dashboard!
 """
 All dashboards available on the view.
+Stability: Long-term
 """
 	dashboards: [Dashboard!]!
 """
 A saved filter alert
+Stability: Long-term
 """
 	filterAlert(
 		id: String!
 	): FilterAlert!
 """
 Saved filter alerts.
+Stability: Long-term
 """
 	filterAlerts: [FilterAlert!]!
 """
 A saved aggregate alert
+Stability: Long-term
 """
 	aggregateAlert(
 		id: String!
 	): AggregateAlert!
 """
 Saved aggregate alerts.
+Stability: Long-term
 """
 	aggregateAlerts: [AggregateAlert!]!
 """
 A saved scheduled search.
+Stability: Long-term
 """
 	scheduledSearch(
 """
@@ -18766,10 +24378,12 @@ The id of the scheduled search to get.
 	): ScheduledSearch!
 """
 Saved scheduled searches.
+Stability: Long-term
 """
 	scheduledSearches: [ScheduledSearch!]!
 """
 A saved action.
+Stability: Long-term
 """
 	action(
 """
@@ -18779,20 +24393,37 @@ The id of the action to get.
 	): Action!
 """
 A list of saved actions.
+Stability: Long-term
 """
-	actions: [Action!]!
+	actions(
+"""
+The result will only include actions with the specified ids. Omit to find all actions.
+"""
+		actionIds: [String!]
+	): [Action!]!
 """
 A saved query.
+Stability: Long-term
 """
 	savedQuery(
 		id: String!
 	): SavedQuery!
 """
 Saved queries.
+Stability: Long-term
 """
 	savedQueries: [SavedQuery!]!
+"""
+Stability: Long-term
+"""
 	defaultQuery: SavedQuery
+"""
+Stability: Long-term
+"""
 	files: [File!]!
+"""
+Stability: Long-term
+"""
 	fileFieldSearch(
 """
 Name of the csv or json file to retrieve the field entries from.
@@ -18821,10 +24452,12 @@ Maximum number of values to retrieve from the file.
 	): [[DictionaryEntryType!]!]!
 """
 Saved scheduled reports.
+Stability: Long-term
 """
 	scheduledReports: [ScheduledReport!]!
 """
 Saved scheduled report.
+Stability: Long-term
 """
 	scheduledReport(
 """
@@ -18848,13 +24481,16 @@ Denotes if you can administer alerts, scheduled searches and actions
 Denotes if you can administer alerts and scheduled searches
 """
 	ChangeTriggers
+	CreateTriggers
 """
 Denotes if you can administer actions
 """
 	ChangeActions
+	CreateActions
 	ChangeInteractions
 	ChangeViewOrRepositoryDescription
 	ChangeDashboards
+	CreateDashboards
 	ChangeDashboardReadonlyToken
 	ChangeFdrFeeds
 	ChangeDataspaceKind
@@ -18862,9 +24498,11 @@ Denotes if you can administer actions
 	ReadFdrFeeds
 	ChangeIngestFeeds
 	ChangeFiles
+	CreateFiles
 	ChangeParsers
 	DeleteParsers
 	ChangeSavedQueries
+	CreateSavedQueries
 	ConnectView
 	ConnectMultiClusterView
 	ChangeDataDeletionPermissions
@@ -18894,6 +24532,10 @@ Denotes if you can administer event forwarding rules
 	ChangeOrganizationOwnedQueries
 	ReadExternalFunctions
 	ChangeScheduledReports
+	CreateScheduledReports
+	GenerateParsers
+	SaveSearchResultAsWidget
+	TestActions
 }
 
 """
@@ -18902,12 +24544,17 @@ Represents the connection between a view and an underlying repository.
 type ViewConnection {
 """
 The underlying repository
+Stability: Long-term
 """
 	repository: Repository!
 """
 The filter applied to all results from the repository.
+Stability: Long-term
 """
 	filter: String!
+"""
+Stability: Long-term
+"""
 	languageVersion: LanguageVersion!
 }
 
@@ -18915,12 +24562,30 @@ The filter applied to all results from the repository.
 An interaction available across search and dashboards
 """
 type ViewInteraction {
+"""
+Stability: Long-term
+"""
 	id: String!
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	displayName: String!
+"""
+Stability: Long-term
+"""
 	description: String
 	assetType: AssetType!
+"""
+Stability: Long-term
+"""
 	packageId: VersionedPackageSpecifier
+"""
+Stability: Long-term
+"""
 	package: PackageInstallation
 }
 
@@ -18928,26 +24593,71 @@ type ViewInteraction {
 A defined view interaction
 """
 type ViewInteractionEntry {
+"""
+Stability: Preview
+"""
 	id: String!
+"""
+Stability: Preview
+"""
 	view: SearchDomain!
+"""
+Stability: Preview
+"""
 	interaction: QueryBasedWidgetInteraction!
+"""
+Stability: Preview
+"""
 	packageId: VersionedPackageSpecifier
+"""
+Stability: Preview
+"""
 	package: PackageInstallation
 }
 
 type ViewInteractionTemplate {
+"""
+Stability: Long-term
+"""
 	name: String!
+"""
+Stability: Long-term
+"""
 	displayName: String!
+"""
+Stability: Long-term
+"""
 	yamlTemplate: String!
 }
 
 type WellKnownEndpointDetails {
+"""
+Stability: Long-term
+"""
 	issuer: String!
+"""
+Stability: Long-term
+"""
 	authorizationEndpoint: String
+"""
+Stability: Long-term
+"""
 	jwksEndpoint: String
+"""
+Stability: Long-term
+"""
 	registrationEndpoint: String
+"""
+Stability: Long-term
+"""
 	tokenEndpoint: String
+"""
+Stability: Long-term
+"""
 	tokenEndpointAuthMethod: String!
+"""
+Stability: Long-term
+"""
 	userInfoEndpoint: String
 }
 
@@ -18986,8 +24696,17 @@ A dashboard widget.
 }
 
 type WidgetInteractionCondition {
+"""
+Stability: Long-term
+"""
 	fieldName: String!
+"""
+Stability: Long-term
+"""
 	operator: FieldConditionOperatorType!
+"""
+Stability: Long-term
+"""
 	argument: String!
 }
 
@@ -18995,7 +24714,13 @@ type WidgetInteractionCondition {
 A key being traced by worker query tracing.
 """
 type WorkerQueryTracingItem {
+"""
+Stability: Preview
+"""
 	key: String!
+"""
+Stability: Preview
+"""
 	expiry: Long!
 }
 
@@ -19003,6 +24728,9 @@ type WorkerQueryTracingItem {
 The state of worker query tracing.
 """
 type WorkerQueryTracingState {
+"""
+Stability: Preview
+"""
 	items: [WorkerQueryTracingItem!]!
 }
 
@@ -19020,7 +24748,8 @@ Common interface for contractual parts of the limit
 
 type drilldowns {
 """
-[PREVIEW: Internal testing.] Get the query that returns the underlying events for the given fields.
+Get the query that returns the underlying events for the given fields.
+Stability: Preview
 """
 	sourceEventsForFieldsQuery(
 		fields: [String!]!
@@ -19031,6 +24760,9 @@ type drilldowns {
 A namespace for various query analyses and transformations.
 """
 type queryAnalysis {
+"""
+Stability: Preview
+"""
 	drilldowns: drilldowns!
 """
 Checks if a query is fit for use for a filter alert
@@ -19040,14 +24772,17 @@ Checks if a query is fit for use for a filter alert
 	): Boolean!
 """
 The query contains an aggregator
+Stability: Preview
 """
 	isAggregate: Boolean!
 """
-The query does not contain a join-like function
+The query does not contain a join-like function or defineTable()
+Stability: Preview
 """
 	isSinglePhase: Boolean!
 """
 The query string up to the first aggregator
+Stability: Preview
 """
 	filterPart: String!
 }
@@ -19088,4 +24823,4 @@ The `String` scalar type represents textual data, represented as UTF-8 character
 scalar String
 
 
-# Fetched from version 1.154.0--build-1810--sha-eebd9d5d384aeb5d20f7a012d51fa7c64a07417e
+# Fetched from version 1.180.0--build-2981--sha-eba6ae23b00e69c90317d596a09527ab206e8bfc

--- a/internal/api/scheduled-search-v2.go
+++ b/internal/api/scheduled-search-v2.go
@@ -1,0 +1,159 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/humio/cli/internal/api/humiographql"
+)
+
+type ScheduledSearchV2 struct {
+	ID                          string   `yaml:"-"`
+	Name                        string   `yaml:"name"`
+	Description                 *string  `yaml:"description,omitempty"`
+	QueryString                 string   `yaml:"queryString"`
+	SearchIntervalSeconds       int64    `yaml:"searchIntervalSeconds"`
+	SearchIntervalOffsetSeconds *int64   `yaml:"searchIntervalOffsetSeconds,omitempty"`
+	QueryTimestampType          string   `yaml:"queryTimestampType"`
+	MaxWaitTimeSeconds          *int64   `yaml:"maxWaitTimeSeconds,omitempty"`
+	BackfillLimitV2             *int     `yaml:"backfillLimitV2,omitempty"`
+	TimeZone                    string   `yaml:"timeZone"`
+	Schedule                    string   `yaml:"schedule"`
+	Enabled                     bool     `yaml:"enabled"`
+	ActionNames                 []string `yaml:"actionNames"`
+	Labels                      []string `yaml:"labels"`
+	QueryOwnershipType          string   `yaml:"queryOwnershipType"`
+	OwnershipRunAsID            string   `yaml:"ownershipRunAsID"`
+}
+
+type ScheduledSearchesV2 struct {
+	client *Client
+}
+
+func (c *Client) ScheduledSearchesV2() *ScheduledSearchesV2 { return &ScheduledSearchesV2{client: c} }
+
+func (a *ScheduledSearchesV2) List(searchDomainName string) ([]ScheduledSearchV2, error) {
+	if searchDomainName == "" {
+		return nil, fmt.Errorf("searchDomainName must not be empty")
+	}
+
+	resp, err := humiographql.ListScheduledSearchesV2(context.Background(), a.client, searchDomainName)
+	if err != nil {
+		return nil, err
+	}
+	respSearchDomain := resp.GetSearchDomain()
+	respScheduledSearches := respSearchDomain.GetScheduledSearches()
+	scheduledSearches := make([]ScheduledSearchV2, len(respScheduledSearches))
+	for idx, scheduledSearch := range respScheduledSearches {
+		actionNames := make([]string, len(scheduledSearch.GetActionsV2()))
+		for kdx, action := range scheduledSearch.GetActionsV2() {
+			actionNames[kdx] = action.GetName()
+		}
+		respQueryOwnership := scheduledSearch.GetQueryOwnership()
+		runAsUserID := ""
+		if respQueryOwnership != nil {
+			runAsUserID = respQueryOwnership.GetId()
+		}
+		scheduledSearches[idx] = ScheduledSearchV2{
+			ID:                          scheduledSearch.GetId(),
+			Name:                        scheduledSearch.GetName(),
+			Description:                 scheduledSearch.GetDescription(),
+			QueryString:                 scheduledSearch.GetQueryString(),
+			SearchIntervalSeconds:       scheduledSearch.GetSearchIntervalSeconds(),
+			SearchIntervalOffsetSeconds: scheduledSearch.GetSearchIntervalOffsetSeconds(),
+			MaxWaitTimeSeconds:          scheduledSearch.GetMaxWaitTimeSeconds(),
+			Schedule:                    scheduledSearch.GetSchedule(),
+			TimeZone:                    scheduledSearch.GetTimeZone(),
+			BackfillLimitV2:             scheduledSearch.GetBackfillLimitV2(),
+			Enabled:                     scheduledSearch.GetEnabled(),
+			ActionNames:                 actionNames,
+			Labels:                      scheduledSearch.GetLabels(),
+			OwnershipRunAsID:            runAsUserID,
+			QueryTimestampType:          string(scheduledSearch.QueryTimestampType),
+			QueryOwnershipType:          string(queryOwnershipToQueryOwnershipType(scheduledSearch.GetQueryOwnership())),
+		}
+	}
+	return scheduledSearches, nil
+}
+
+func (a *ScheduledSearchesV2) Create(searchDomainName string, newScheduledSearch *ScheduledSearchV2) (*ScheduledSearchV2, error) {
+	if searchDomainName == "" {
+		return nil, fmt.Errorf("searchDomainName must not be empty")
+	}
+	if newScheduledSearch == nil {
+		return nil, fmt.Errorf("newScheduledSearch must not be nil")
+	}
+
+	var ownershipRunAsID *string
+	if humiographql.QueryOwnershipType(newScheduledSearch.QueryOwnershipType) == humiographql.QueryOwnershipTypeUser {
+		ownershipRunAsID = &newScheduledSearch.OwnershipRunAsID
+	}
+
+	queryOwnershipType := humiographql.QueryOwnershipType(newScheduledSearch.QueryOwnershipType)
+	queryTimestampType := humiographql.QueryTimestampType(newScheduledSearch.QueryTimestampType)
+
+	resp, err := humiographql.CreateScheduledSearchV2(
+		context.Background(),
+		a.client,
+		searchDomainName,
+		newScheduledSearch.Name,
+		newScheduledSearch.Description,
+		newScheduledSearch.QueryString,
+		newScheduledSearch.SearchIntervalSeconds,
+		newScheduledSearch.SearchIntervalOffsetSeconds,
+		newScheduledSearch.MaxWaitTimeSeconds,
+		newScheduledSearch.Schedule,
+		newScheduledSearch.TimeZone,
+		newScheduledSearch.BackfillLimitV2,
+		newScheduledSearch.Enabled,
+		newScheduledSearch.ActionNames,
+		ownershipRunAsID,
+		newScheduledSearch.Labels,
+		queryTimestampType,
+		queryOwnershipType,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	respScheduledSearch := resp.GetCreateScheduledSearchV2()
+	actionNames := make([]string, len(respScheduledSearch.GetActionsV2()))
+	for kdx, action := range respScheduledSearch.GetActionsV2() {
+		actionNames[kdx] = action.GetName()
+	}
+	respQueryOwnership := respScheduledSearch.GetQueryOwnership()
+	runAsUserID := ""
+	if respQueryOwnership != nil {
+		runAsUserID = respQueryOwnership.GetId()
+	}
+	return &ScheduledSearchV2{
+		ID:                          respScheduledSearch.GetId(),
+		Name:                        respScheduledSearch.GetName(),
+		Description:                 respScheduledSearch.GetDescription(),
+		QueryString:                 respScheduledSearch.GetQueryString(),
+		SearchIntervalSeconds:       respScheduledSearch.GetSearchIntervalSeconds(),
+		SearchIntervalOffsetSeconds: respScheduledSearch.GetSearchIntervalOffsetSeconds(),
+		MaxWaitTimeSeconds:          respScheduledSearch.GetMaxWaitTimeSeconds(),
+		TimeZone:                    respScheduledSearch.GetTimeZone(),
+		Schedule:                    respScheduledSearch.GetSchedule(),
+		BackfillLimitV2:             respScheduledSearch.GetBackfillLimitV2(),
+		Enabled:                     respScheduledSearch.GetEnabled(),
+		ActionNames:                 actionNames,
+		OwnershipRunAsID:            runAsUserID,
+		Labels:                      respScheduledSearch.GetLabels(),
+		QueryTimestampType:          string(respScheduledSearch.QueryTimestampType),
+		QueryOwnershipType:          string(queryOwnershipToQueryOwnershipType(respScheduledSearch.GetQueryOwnership())),
+	}, nil
+}
+
+func (a *ScheduledSearchesV2) Delete(searchDomainName, scheduledSearchID string) error {
+	if searchDomainName == "" {
+		return fmt.Errorf("searchdomainName is empty")
+	}
+	if scheduledSearchID == "" {
+		return fmt.Errorf("scheduledSearchID is empty")
+	}
+
+	_, err := humiographql.DeleteScheduledSearchV2ByID(context.Background(), a.client, searchDomainName, scheduledSearchID)
+	return err
+}

--- a/internal/api/searchdomains.go
+++ b/internal/api/searchdomains.go
@@ -16,7 +16,7 @@ type SearchDomain struct {
 	AutomaticSearch bool
 }
 
-func (s *Client) SearchDomains() *SearchDomains { return &SearchDomains{client: s} }
+func (c *Client) SearchDomains() *SearchDomains { return &SearchDomains{client: c} }
 
 func (s *SearchDomains) Get(name string) (*SearchDomain, error) {
 	resp, err := humiographql.GetSearchDomain(context.Background(), s.client, name)

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -75,18 +75,18 @@ func StringPtr(s *string) Value {
 	return String(*s)
 }
 
-func IntPtr(i *int64) Value {
+func Int64Ptr(i *int64) Value {
 	if i == nil {
 		return Int(0)
 	}
 	return Int(*i)
 }
 
-func Float64Ptr(f *float64) Value {
-	if f == nil {
-		return Float(0)
+func IntPtr(i *int) Value {
+	if i == nil {
+		return Int(0)
 	}
-	return Float(*f)
+	return Int(*i)
 }
 
 func (m MultiValue) String() string {


### PR DESCRIPTION
New `./bin/humioctl scheduled-searches-v2` command to use the new scheduled searches endpoints and types.

.`/bin/humioctl scheduled-searches` still works as intended but will not support creating scheduled searches running on ingesttimestamp.

If trying to install an old scheduled search yaml file, `scheduled-searches-v2` will try and install it using the deprecated mutation.

Release notes for 1.180:
Scheduled searches can now also run on the [@ingesttimestamp](https://library.humio.com/data-analysis/searching-data-event-fields.html#searching-data-event-fields-metadata-ingesttimestamp). A configurable [Max wait time](https://library.humio.com/data-analysis/automated-alerts-editing-new-properties.html#automated-scheduled-searches-create-maxwaittime) property on scheduled searches that runs on [@ingesttimestamp](https://library.humio.com/data-analysis/searching-data-event-fields.html#searching-data-event-fields-metadata-ingesttimestamp) is used to catch events that are delayed in the ingestion pipeline, or to wait for query warnings about missing data and errors. The [@ingesttimestamp](https://library.humio.com/data-analysis/searching-data-event-fields.html#searching-data-event-fields-metadata-ingesttimestamp) is the default timestamp set on all new scheduled searches.

With this change, the GraphQL mutations [createScheduledSearch](https://library.humio.com/logscale-graphql-reference-mutations/graphql-mutation-field-createscheduledsearch.html) and [updateScheduledSearch](https://library.humio.com/logscale-graphql-reference-mutations/graphql-mutation-field-updatescheduledsearch.html) have been deprecated for removal in 1.231 and [createScheduledSearchV2](https://library.humio.com/logscale-graphql-reference-mutations/graphql-mutation-field-createscheduledsearchv2.html) and [updateScheduledSearchV2](https://library.humio.com/logscale-graphql-reference-mutations/graphql-mutation-field-updatescheduledsearchv2.html) will replace them.

For more information about scheduled searches and their timestamps, see [Ingest delay for scheduled searches](https://library.humio.com/data-analysis/automated-alerts.html#trigger_types-automated-scheduled-searches-ingest-delay). For information about the [Max wait time](https://library.humio.com/data-analysis/automated-alerts-editing-new-properties.html#automated-scheduled-searches-create-maxwaittime) property, see [Max wait time](https://library.humio.com/data-analysis/automated-alerts-editing-new-properties.html#automated-scheduled-searches-create-maxwaittime).