### PR TITLE
Include "humioctl" in the default user agent

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -13,7 +13,7 @@ import (
 	graphql "github.com/cli/shurcooL-graphql"
 )
 
-const defaultUserAgent = "Humio-go-client/unknown"
+const defaultUserAgent = "Deprecated-Humio-go-client/unknown"
 
 // Deprecated: Should no longer be used. https://github.com/CrowdStrike/logscale-go-api-client-example
 type Client struct {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -18,7 +18,7 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
-const defaultUserAgent = "Humio-go-client/unknown"
+const defaultUserAgent = "humioctl/unknown"
 
 type Client struct {
 	config        Config


### PR DESCRIPTION
Release builds will continue to populate the user agent with full timestamps, git sha etc. 