### PR TITLE
Trimming token file after reading it

### DIFF
--- a/cmd/humioctl/root.go
+++ b/cmd/humioctl/root.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/humio/cli/internal/api"
 	"github.com/humio/cli/internal/viperkey"
@@ -186,8 +187,9 @@ func initConfig() {
 	if tokenFile != "" {
 		// #nosec G304
 		tokenFileContent, err := os.ReadFile(tokenFile)
+		tokenFileContentStr := strings.TrimSpace(string(tokenFileContent))
 		exitOnError(rootCmd, err, "Error loading token file")
-		viper.Set(viperkey.Token, string(tokenFileContent))
+		viper.Set(viperkey.Token, tokenFileContentStr)
 	}
 
 	if caCertificateFile != "" {


### PR DESCRIPTION
Fixes #72 

Example input:
```

eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
    
```
Output:
```
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
```
