### PR TITLE
add update-username feature

### DIFF
--- a/cmd/humioctl/users.go
+++ b/cmd/humioctl/users.go
@@ -31,6 +31,7 @@ func newUsersCmd() *cobra.Command {
 	cmd.AddCommand(newUsersUpdateCmd())
 	cmd.AddCommand(newUsersListCmd())
 	cmd.AddCommand(newUsersShowCmd())
+	cmd.AddCommand(newUsersUpdateUsernameCmd())
 
 	return cmd
 }

--- a/cmd/humioctl/users_update_username.go
+++ b/cmd/humioctl/users_update_username.go
@@ -1,0 +1,118 @@
+// Copyright © 2018 Humio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/humio/cli/internal/api"
+	"github.com/spf13/cobra"
+)
+
+func newUsersUpdateUsernameCmd() *cobra.Command {
+	var csvFile string
+	var dryRun bool
+
+	cmd := cobra.Command{
+		Use:   "update-username [flags] <current-username> <new-username>",
+		Short: "Updates a user's username. Requires the system permission 'ChangeUsername'. [Root Only]",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if csvFile != "" {
+				return nil
+			}
+			return cobra.ExactArgs(2)(cmd, args)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			client := NewApiClient(cmd)
+
+			if csvFile != "" {
+				rows, err := ReadCSV(csvFile)
+				if err != nil {
+					exitOnError(cmd, err, "Error reading CSV file")
+				}
+
+				for _, row := range rows {
+					updateUsername(client, row["username"], row["new_username"], dryRun)
+				}
+			} else {
+				updateUsername(client, args[0], args[1], dryRun)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&csvFile, "csv", "", "Bulk update usernames via CSV file (use headers: username, new_username)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview changes without updating usernames")
+
+	return &cmd
+}
+
+func updateUsername(client *api.Client, username, newUsername string, dryRun bool) {
+	if dryRun {
+		fmt.Printf("[DRYRUN] User %s would be renamed to %s\n", username, newUsername)
+		return
+	}
+
+	_, err := client.Users().UpdateUsername(
+		username,
+		newUsername,
+	)
+	if err != nil {
+		fmt.Printf("Error updating user: %s\n", err)
+		return
+	}
+
+	fmt.Printf("Successfully updated user: %s renamed to %s\n", username, newUsername)
+}
+
+// Simple function to read a CSV file and return an array of maps, assumes the first row is always headers.
+func ReadCSV(filePath string) ([]map[string]string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %s: %w", filePath, err)
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	reader.TrimLeadingSpace = true
+
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CSV: %w", err)
+	}
+
+	if len(records) == 0 {
+		return []map[string]string{}, nil
+	}
+
+	headers := records[0]
+	results := make([]map[string]string, 0, len(records)-1)
+
+	for _, row := range records[1:] {
+		if len(row) != len(headers) {
+			continue // Skip rows with missing columns
+		}
+
+		rowMap := make(map[string]string)
+		for i, value := range row {
+			rowMap[strings.TrimSpace(headers[i])] = strings.TrimSpace(value)
+		}
+		results = append(results, rowMap)
+	}
+
+	return results, nil
+}

--- a/internal/api/humiographql/graphql/users.graphql
+++ b/internal/api/humiographql/graphql/users.graphql
@@ -18,6 +18,14 @@ query GetUsersByUsername(
     }
 }
 
+query GetUserById(
+    $UserId: String!
+) {
+    user(id: $UserId) {
+        ...UserDetails
+    }
+}
+
 query ListUsers {
     users {
         ...UserDetails
@@ -65,6 +73,18 @@ mutation UpdateUser(
         picture: $Picture
         email: $Email
         countryCode: $CountryCode
+    }) {
+        __typename
+    }
+}
+
+mutation UpdateUserUsername(
+    $UserId: String!
+    $Username: String!
+) {
+    updateUserById(input: {
+        userId: $UserId
+        username: $Username
     }) {
         __typename
     }

--- a/internal/api/humiographql/humiographql.go
+++ b/internal/api/humiographql/humiographql.go
@@ -7737,6 +7737,119 @@ func (v *GetSupportedFeatureFlagsResponse) GetFeatureFlags() []GetSupportedFeatu
 	return v.FeatureFlags
 }
 
+// GetUserByIdResponse is returned by GetUserById on success.
+type GetUserByIdResponse struct {
+	// A user in the system.
+	// Stability: Long-term
+	User *GetUserByIdUser `json:"user"`
+}
+
+// GetUser returns GetUserByIdResponse.User, and is useful for accessing the field via an interface.
+func (v *GetUserByIdResponse) GetUser() *GetUserByIdUser { return v.User }
+
+// GetUserByIdUser includes the requested fields of the GraphQL type User.
+// The GraphQL type's documentation follows.
+//
+// A user profile.
+type GetUserByIdUser struct {
+	UserDetails `json:"-"`
+}
+
+// GetId returns GetUserByIdUser.Id, and is useful for accessing the field via an interface.
+func (v *GetUserByIdUser) GetId() string { return v.UserDetails.Id }
+
+// GetUsername returns GetUserByIdUser.Username, and is useful for accessing the field via an interface.
+func (v *GetUserByIdUser) GetUsername() string { return v.UserDetails.Username }
+
+// GetFullName returns GetUserByIdUser.FullName, and is useful for accessing the field via an interface.
+func (v *GetUserByIdUser) GetFullName() *string { return v.UserDetails.FullName }
+
+// GetEmail returns GetUserByIdUser.Email, and is useful for accessing the field via an interface.
+func (v *GetUserByIdUser) GetEmail() *string { return v.UserDetails.Email }
+
+// GetCompany returns GetUserByIdUser.Company, and is useful for accessing the field via an interface.
+func (v *GetUserByIdUser) GetCompany() *string { return v.UserDetails.Company }
+
+// GetCountryCode returns GetUserByIdUser.CountryCode, and is useful for accessing the field via an interface.
+func (v *GetUserByIdUser) GetCountryCode() *string { return v.UserDetails.CountryCode }
+
+// GetPicture returns GetUserByIdUser.Picture, and is useful for accessing the field via an interface.
+func (v *GetUserByIdUser) GetPicture() *string { return v.UserDetails.Picture }
+
+// GetIsRoot returns GetUserByIdUser.IsRoot, and is useful for accessing the field via an interface.
+func (v *GetUserByIdUser) GetIsRoot() bool { return v.UserDetails.IsRoot }
+
+// GetCreatedAt returns GetUserByIdUser.CreatedAt, and is useful for accessing the field via an interface.
+func (v *GetUserByIdUser) GetCreatedAt() time.Time { return v.UserDetails.CreatedAt }
+
+func (v *GetUserByIdUser) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*GetUserByIdUser
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.GetUserByIdUser = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.UserDetails)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalGetUserByIdUser struct {
+	Id string `json:"id"`
+
+	Username string `json:"username"`
+
+	FullName *string `json:"fullName"`
+
+	Email *string `json:"email"`
+
+	Company *string `json:"company"`
+
+	CountryCode *string `json:"countryCode"`
+
+	Picture *string `json:"picture"`
+
+	IsRoot bool `json:"isRoot"`
+
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+func (v *GetUserByIdUser) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *GetUserByIdUser) __premarshalJSON() (*__premarshalGetUserByIdUser, error) {
+	var retval __premarshalGetUserByIdUser
+
+	retval.Id = v.UserDetails.Id
+	retval.Username = v.UserDetails.Username
+	retval.FullName = v.UserDetails.FullName
+	retval.Email = v.UserDetails.Email
+	retval.Company = v.UserDetails.Company
+	retval.CountryCode = v.UserDetails.CountryCode
+	retval.Picture = v.UserDetails.Picture
+	retval.IsRoot = v.UserDetails.IsRoot
+	retval.CreatedAt = v.UserDetails.CreatedAt
+	return &retval, nil
+}
+
 // GetUsernameResponse is returned by GetUsername on success.
 type GetUsernameResponse struct {
 	// The currently authenticated user's account.
@@ -15160,6 +15273,28 @@ type UpdateUserUpdateUserUpdateUserMutation struct {
 // GetTypename returns UpdateUserUpdateUserUpdateUserMutation.Typename, and is useful for accessing the field via an interface.
 func (v *UpdateUserUpdateUserUpdateUserMutation) GetTypename() *string { return v.Typename }
 
+// UpdateUserUsernameResponse is returned by UpdateUserUsername on success.
+type UpdateUserUsernameResponse struct {
+	// Updates a user.
+	// Stability: Long-term
+	UpdateUserById UpdateUserUsernameUpdateUserByIdUpdateUserByIdMutation `json:"updateUserById"`
+}
+
+// GetUpdateUserById returns UpdateUserUsernameResponse.UpdateUserById, and is useful for accessing the field via an interface.
+func (v *UpdateUserUsernameResponse) GetUpdateUserById() UpdateUserUsernameUpdateUserByIdUpdateUserByIdMutation {
+	return v.UpdateUserById
+}
+
+// UpdateUserUsernameUpdateUserByIdUpdateUserByIdMutation includes the requested fields of the GraphQL type UpdateUserByIdMutation.
+type UpdateUserUsernameUpdateUserByIdUpdateUserByIdMutation struct {
+	Typename *string `json:"__typename"`
+}
+
+// GetTypename returns UpdateUserUsernameUpdateUserByIdUpdateUserByIdMutation.Typename, and is useful for accessing the field via an interface.
+func (v *UpdateUserUsernameUpdateUserByIdUpdateUserByIdMutation) GetTypename() *string {
+	return v.Typename
+}
+
 // UpdateViewConnectionsResponse is returned by UpdateViewConnections on success.
 type UpdateViewConnectionsResponse struct {
 	// Update a view.
@@ -16181,6 +16316,14 @@ type __GetSearchDomainInput struct {
 // GetSearchDomainName returns __GetSearchDomainInput.SearchDomainName, and is useful for accessing the field via an interface.
 func (v *__GetSearchDomainInput) GetSearchDomainName() string { return v.SearchDomainName }
 
+// __GetUserByIdInput is used internally by genqlient
+type __GetUserByIdInput struct {
+	UserId string `json:"UserId"`
+}
+
+// GetUserId returns __GetUserByIdInput.UserId, and is useful for accessing the field via an interface.
+func (v *__GetUserByIdInput) GetUserId() string { return v.UserId }
+
 // __GetUsersByUsernameInput is used internally by genqlient
 type __GetUsersByUsernameInput struct {
 	Username string `json:"Username"`
@@ -16530,6 +16673,18 @@ func (v *__UpdateUserInput) GetEmail() *string { return v.Email }
 
 // GetCountryCode returns __UpdateUserInput.CountryCode, and is useful for accessing the field via an interface.
 func (v *__UpdateUserInput) GetCountryCode() *string { return v.CountryCode }
+
+// __UpdateUserUsernameInput is used internally by genqlient
+type __UpdateUserUsernameInput struct {
+	UserId   string `json:"UserId"`
+	Username string `json:"Username"`
+}
+
+// GetUserId returns __UpdateUserUsernameInput.UserId, and is useful for accessing the field via an interface.
+func (v *__UpdateUserUsernameInput) GetUserId() string { return v.UserId }
+
+// GetUsername returns __UpdateUserUsernameInput.Username, and is useful for accessing the field via an interface.
+func (v *__UpdateUserUsernameInput) GetUsername() string { return v.Username }
 
 // __UpdateViewConnectionsInput is used internally by genqlient
 type __UpdateViewConnectionsInput struct {
@@ -18910,6 +19065,52 @@ func GetSupportedFeatureFlags(
 	return &data_, err_
 }
 
+// The query or mutation executed by GetUserById.
+const GetUserById_Operation = `
+query GetUserById ($UserId: String!) {
+	user(id: $UserId) {
+		... UserDetails
+	}
+}
+fragment UserDetails on User {
+	id
+	username
+	fullName
+	email
+	company
+	countryCode
+	picture
+	isRoot
+	createdAt
+}
+`
+
+func GetUserById(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	UserId string,
+) (*GetUserByIdResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "GetUserById",
+		Query:  GetUserById_Operation,
+		Variables: &__GetUserByIdInput{
+			UserId: UserId,
+		},
+	}
+	var err_ error
+
+	var data_ GetUserByIdResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
 // The query or mutation executed by GetUsername.
 const GetUsername_Operation = `
 query GetUsername {
@@ -20552,6 +20753,43 @@ func UpdateUser(
 	var err_ error
 
 	var data_ UpdateUserResponse
+	resp_ := &graphql.Response{Data: &data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return &data_, err_
+}
+
+// The query or mutation executed by UpdateUserUsername.
+const UpdateUserUsername_Operation = `
+mutation UpdateUserUsername ($UserId: String!, $Username: String!) {
+	updateUserById(input: {userId:$UserId,username:$Username}) {
+		__typename
+	}
+}
+`
+
+func UpdateUserUsername(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	UserId string,
+	Username string,
+) (*UpdateUserUsernameResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "UpdateUserUsername",
+		Query:  UpdateUserUsername_Operation,
+		Variables: &__UpdateUserUsernameInput{
+			UserId:   UserId,
+			Username: Username,
+		},
+	}
+	var err_ error
+
+	var data_ UpdateUserUsernameResponse
 	resp_ := &graphql.Response{Data: &data_}
 
 	err_ = client_.MakeRequest(

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -85,6 +85,20 @@ func (u *Users) Update(username string, isRoot *bool, fullName, company, country
 
 }
 
+func (u *Users) UpdateUsername(username, newUsername string) (User, error) {
+	user, err := u.Get(username)
+	if err != nil {
+		return User{}, err
+	}
+
+	_, err = humiographql.UpdateUserUsername(context.Background(), u.client, user.ID, newUsername)
+	if err != nil {
+		return User{}, err
+	}
+
+	return u.Get(newUsername)
+}
+
 func (u *Users) Add(username string, isRoot *bool, fullName, company, countryCode, email, picture *string) (User, error) {
 	resp, err := humiographql.AddUser(context.Background(), u.client, username, company, isRoot, fullName, picture, email, countryCode)
 	if err != nil {


### PR DESCRIPTION
I had the need a while back to change all usernames in the cluster due to an IdP migration. Quickly added the feature to do this in bulk from a CSV file. Might be useful for others.

Usage:

1. Create a CSV with headers: username, new_username
2. Run command: ./bin/humioctl users update-username --csv ./users.csv

Or update a single user,
./bin/humioctl users update-username [flags] \<current-username> \<new-username>
